### PR TITLE
Adding a GitHub repo to list of Private Eye sites

### DIFF
--- a/javascripts/application.js
+++ b/javascripts/application.js
@@ -131,6 +131,7 @@ document.addEventListener('DOMContentLoaded', function() {
       'github.com/18F/Infrastructure',
       'github.com/18F/staffing-and-resources',
       'github.com/18F/team-api.18f.gov',
+      'github.com/18F/security-incidents',
       'github.com/18F/writing-lab',
       'gkey.gsa.gov',
       'gsa.my.salesforce.com',


### PR DESCRIPTION
Just making this repo get a little lock icon when we link to it from the handbook.
