### PR TITLE
Remove outdated UIE info

### DIFF
--- a/_pages/welcome-to-18f/classes/professional-development-and-training.md
+++ b/_pages/welcome-to-18f/classes/professional-development-and-training.md
@@ -235,8 +235,6 @@ As an 18F team member, you have access to additional online training resources.
 
 - **DigitalGov University** holds webinars and in-person events about all things digital government. See the DigitalGov [calendar of events](http://www.digitalgov.gov/events/) and [video library](http://www.digitalgov.gov/digitalgov-university/video-library/) for more information.
 
-- 18F has a number of licenses to **User Interface Engineering (UIE)&rsquo;s video library.** To access it, add your name to [this spreadsheet](https://docs.google.com/a/gsa.gov/spreadsheets/d/1CGl5gBdFhKQ3aFdvv67KGLa21xj-WFp6whRF9XGU-B0/edit#gid=0). Then log in [here](http://aycl.uie.com/).
-
 - [Safari Books Online](https://www.safaribooksonline.com) provides online access to 30,000 books and videos about programming, UX design, leadership, project management, content strategy, agile development, and more. To request access, email [18fsoftware@gsa.gov](mailto:18fsoftware@gsa.gov).
 
 -  GSA offers free, individual coaching for employees. Any of us can tap them any time, at no cost. The coaches are all certified by the International Federation of Coaches. They aim to help with more or less any workplace challenges you face--managing your manager; dealing with a colleague whose communication style is very different from yours; positioning yourself for a different kind of work within the agency; balancing urgent vs important requests; etc. Some of the coaches also specialize in leadership and executive issues. For more details, please contact Nicole O'Brien in GSA Office of Human Resources Management.


### PR DESCRIPTION
We no longer have a license for UIE's All You can Learn library per Slack convo: 
https://gsa-tts.slack.com/archives/design/p1476196555001569
