### PR TITLE
Updating Fugacious info and copyediting

### DIFF
--- a/_pages/how-we-work/sensitive-information.md
+++ b/_pages/how-we-work/sensitive-information.md
@@ -16,7 +16,7 @@ There are several options for sharing sensitive information at 18F. As taught in
 
 <!-- Note this information needs to remain *somewhere* for cloud.gov FedRAMP compliance, since the cloud.gov team uses Fugacious. It's linked from https://cloud.gov/docs/ops/secrets/#sharing-secret-keys - if you make (or want to make) major changes here, please ping #cloud-gov-highbar. -->
 
-You can use [Fugacious](https://fugacious.18f.gov/) for short-term secure messaging. Fugacious is most useful for sending small bits of text once, such as passwords or API keys. Set the lowest acceptable "self-destruct" settings for number of views and hours available that you need. Do not set the hour limit for more than 120 hours (it's currently configured with a maximum of 48 hours). You can share Fugacious links over TTS Slack, but don't put sensitive information in Slack directly.
+You can use [Fugacious](https://fugacious.18f.gov/) for short-term secure messaging. Fugacious is most useful for sending small bits of text once, such as passwords or API keys. Set the lowest acceptable "self-destruct" settings for number of views and hours available that you need (maximum 48 hours). You can share Fugacious links over TTS Slack, but don't put sensitive information in Slack directly.
 
 If you're on the cloud.gov team, see [this additional cloud.gov policy for sharing sensitive information](https://cloud.gov/docs/ops/secrets/).
 

--- a/_pages/how-we-work/sensitive-information.md
+++ b/_pages/how-we-work/sensitive-information.md
@@ -6,22 +6,24 @@ Here's what you need to know about sensitive information at 18F.
 
 ## What is considered sensitive
 
-To learn more about what information is considered sensitive, see [our Open Source Policy practices guide](https://github.com/18F/open-source-policy/blob/master/practice.md#protecting-sensitive-information).
+To learn what information we consider sensitive, see [our Open Source Policy practices guide](https://github.com/18F/open-source-policy/blob/master/practice.md#protecting-sensitive-information).
 
 ## Tools
 
-There are several options for sharing sensitive information at 18F. As you'll remember from your Security Awareness and Privacy training in [GSA Online University (OLU)](https://gsaolu.gsa.gov), please make sure to share sensitive information with only the people that absolutely need it, and who are authorized to see it.
+There are several options for sharing sensitive information at 18F. As taught in your Security Awareness and Privacy training in [GSA Online University (OLU)](https://gsaolu.gsa.gov), only share sensitive information with the people who absolutely need it and are authorized to see it.
 
 ### Fugacious
 
-<!-- Note this information needs to remain *somewhere* for cloud.gov FedRAMP compliance. -->
+<!-- Note this information needs to remain *somewhere* for cloud.gov FedRAMP compliance, since the cloud.gov team uses Fugacious. It's linked from https://cloud.gov/docs/ops/secrets/#sharing-secret-keys - if you make (or want to make) major changes here, please ping #cloud-gov-highbar. -->
 
-[Fugacious](https://fugacious.18f.gov/) is a tool for short-term secure messaging. Fugacious is most useful for sending small bits of text once, such as passwords or API keys. We recommend setting the lowest acceptable "self-destruct" settings for number of views and hours available that you need. Do not set the hour limit for more than 120 hours. Fugacious links can be shared over Slack, but please don't put sensitive information in Slack directly.
+You can use [Fugacious](https://fugacious.18f.gov/) for short-term secure messaging. Fugacious is most useful for sending small bits of text once, such as passwords or API keys. Set the lowest acceptable "self-destruct" settings for number of views and hours available that you need. Do not set the hour limit for more than 120 hours (it's currently configured with a maximum of 48 hours). You can share Fugacious links over TTS Slack, but don't put sensitive information in Slack directly.
+
+If you're on the cloud.gov team, see [this additional cloud.gov policy for sharing sensitive information](https://cloud.gov/docs/ops/secrets/).
 
 ### Google Drive
 
-[GSA Google Drive](../google-drive/) can be used for sharing sensitive files, spreadsheets, and documents. This includes personally identifiable information (PII) of either Federal staff, or the public, but *does not* include classified information of any kind. If handling PII, be absolutely sure you are only sharing Drive files with GSA staff, and that they have a direct need of the information for their job.
+You can use [GSA Google Drive](../google-drive/) to share sensitive files, spreadsheets, and documents. This includes personally identifiable information (PII) of either Federal staff or the public, but it *does not* include classified information of any kind. If handling PII, be absolutely sure you are only sharing Drive files with GSA staff, and that they have a direct need for the information for their job.
 
 ### OMB MAX
 
-[OMB MAX](https://max.omb.gov/) is a tool that's provided by/for the federal government, which can be used for sharing files. MAX is most likely to be used with partners who don't have access to (or who don't feel comfortable putting the information in) Google Drive. Some workspaces in MAX are available to private organizations (for example, cloud service providers in the FedRAMP workspaces) or many other government agencies. Be sure you know who you're sharing with before posting.
+You can use [OMB MAX](https://max.omb.gov/) for sharing sensitive files (in appropriate "workspaces" within MAX). We typically use MAX for working with partners who don't have access to (or who don't feel comfortable putting the information in) Google Drive. Some workspaces in MAX are available to private organizations (for example, cloud service providers in the FedRAMP workspaces) or many other government agencies. Be sure you know who you're sharing with before posting.


### PR DESCRIPTION
Noting that Fugacious is limited to 48 hours right now, to reduce confusion (https://gsa-tts.slack.com/archives/fugacious/p1478626736000004).

Also copyediting to fit the guidance at https://pages.18f.gov/content-guide/address-the-user/