### PR TITLE
Stray parenthesis rendering broken Markdown

### DIFF
--- a/_pages/how-we-work/purchase-requests.md
+++ b/_pages/how-we-work/purchase-requests.md
@@ -15,7 +15,7 @@ You'll then be able to proceed to make either an event request (for trainings an
 
 * [Trainings and conferences](/purchase-requests/#trainings-and-conferences)
 * [Business cards](/purchase-requests/#business-cards)
-* [Office supplies]((/purchase-requests/#office-supplies)
+* [Office supplies](/purchase-requests/#office-supplies)
 * [Mice, keyboards, and trackpads](/equipment/#mice-keyboards-and-trackpads)
 * [Software](/purchase-requests/#software) [(not currently in the 18F library)](https://docs.google.com/spreadsheets/d/14hEWuhlhKi-EbAFUcy1tuoEejl-7DNiBTI57ZbIQF9w/edit?ts=5727c8ba#gid=0)
 * [Equipment repair (laptop or phone)](/equipment/#repairs)


### PR DESCRIPTION
Fixes this display bug:

<img width="566" alt="screen shot 2016-11-29 at 8 37 43 pm" src="https://cloud.githubusercontent.com/assets/4592/20736304/b070a036-b673-11e6-9e84-4da563df1c67.png">
