### PR TITLE
Moved ClamXav info to Google Doc

### DIFF
--- a/_pages/how-we-work/tools/clamxav.md
+++ b/_pages/how-we-work/tools/clamxav.md
@@ -4,30 +4,6 @@ title: ClamXav
 
 ClamXav is an anti-virus and malware scanner for Mac OS X with the ability to detect both Mac and Windows threats.
 
+[ClamXav Installation, Update, and Usage Guide](https://docs.google.com/a/gsa.gov/document/d/10CiCkCx1fb5r1x4BN-XL-9bEyHkegraQGfkNweO6DCo/edit?usp=sharing)
 
-## Installation
-
-1. Download ClamXav through 18F&rsquo;s [Managed Software Center](/managed-software-center).
-2. Accept the software licensing agreement.
-3. Register ClamXav by clicking [this link](https://www.clamxav.com/installRegistration/CLA151230-5218-44105). You may receive an `External Protocol Request` warning. Please **do not** select **Remember my choice for all links of this type**.
-4. Click **Launch Application** in the External Protocol Request window.
-5. In the pop up that reads "Before using ClamXav, you must first install the scanning engine," click **Install**.
-6. Click **Continue** in the next two windows and then click **Install** to run the installer.
-7. Enter your administrator name and password to continue. If you're not an administrator on your Mac, ping [Kimber Dowsett](https://gsa-tts.slack.com/team/kimber) for assistance.
-8. Click **Install Software.**
-9. In the **Check for updates automatically?** window, deselect the **Include anonymous system profile** checkbox.
-10. Click **Check Automatically**. You may need to update ClamXav again, which requires your administrator username and password.
-
-## Update the virus definitions
-
-Once you have the latest version:
-
-1. Open **ClamXav Preferences > General**, select the **Update virus definitions on launch** checkbox.
-2. Click **OK**.
-3. Click **Update Definitions**. ClamXav will alert you when all virus definitions are updated (this takes about two minutes).
-
-## Usage
-
-- ClamXav will run in the background unless you choose to scan something manually.
-
-- You can use ClamXav to scan your entire drive, email attachments, and downloads. For more information, read the [ClamXav FAQ](https://www.clamxav.com/faq.php).
+For more information, read the [ClamXav FAQ](https://www.clamxav.com/faq.php).


### PR DESCRIPTION
Per Erik Burgess, moving ClamXav instructions to GSA google doc for infosec reasons