### PR TITLE
Added link to "GSA Internal Tools" in tools section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -278,7 +278,7 @@ navigation:
       url: google-hangouts/
       internal: true
     - text: GSA Internal Tools
-      url: https://handbook.18f.gov/gsa-tools-equipment-and-transit/#gsa-tools
+      url: gsa-tools-equipment-and-transit/#gsa-tools
       internal: true
     - text: Managed Software Center
       url: managed-software-center/

--- a/_config.yml
+++ b/_config.yml
@@ -278,7 +278,7 @@ navigation:
       url: google-hangouts/
       internal: true
     - text: GSA Internal Tools
-      url: gsa-tools-equipment-and-transit/#gsa-tools/
+      url: /#gsa-tools/
       internal: true
     - text: Managed Software Center
       url: managed-software-center/

--- a/_config.yml
+++ b/_config.yml
@@ -235,7 +235,7 @@ navigation:
     internal: true
   - text: Purchase requests
     url: purchase-requests/
-    internal: true    
+    internal: true
   - text: Sensitive information
     url: sensitive-information/
     internal: true
@@ -276,6 +276,9 @@ navigation:
       internal: true
     - text: Google Hangouts
       url: google-hangouts/
+      internal: true
+    - text: GSA Internal Tools
+      url: gsa-tools-equipment-and-transit/#gsa-tools/
       internal: true
     - text: Managed Software Center
       url: managed-software-center/
@@ -331,7 +334,7 @@ navigation:
     url: business-and-ops-policies/
     internal: true
     generated: true
-    children:  
+    children:
     - text: Account management policy
       url: client-accounts/
       internal: true
@@ -340,13 +343,13 @@ navigation:
       internal: false
     - text: Performance management requirements and timeline
       url: performance-management/
-      internal: true  
- 
+      internal: true
+
   - text: Tech
     url: tech-policies/
     internal: true
     generated: true
-    children: 
+    children:
     - text: Authority To Operate (ATO)
       url: authority-to-operate/
       internal: true
@@ -355,43 +358,43 @@ navigation:
       internal: true
     - text: Open source policy
       url: open-source/
-      internal: true   
+      internal: true
     - text: Requirements for Passwords
       url: password-requirements/
-      internal: true   
+      internal: true
     - text: Security incidents
       url: security-incidents/
-      internal: true  
+      internal: true
 
   - text: Travel and Leave
     url: travel-and-leave-policies/
     internal: true
     generated: true
-    children:       
+    children:
     - text: ALOHA/ETAMS reconciliation feature
       url: aloha-etams-reconciliation-feature/
       internal: true
     - text: Leave, telework, and virtual worker policy
       url: leave-telework-and-virtual-worker/
-      internal: true    
+      internal: true
     - text: Moving
       url: moving/
-      internal: true    
+      internal: true
     - text: Travel guide
       url: travel-guide-start-here/
-      internal: true   
+      internal: true
 
   - text: Employee Resources
     url: employee-resources-policies/
     internal: true
     generated: true
-    children: 
+    children:
     - text: Employee assistance program
       url: employee-assistance-program/
       internal: true
     - text: Emergency procedures
       url: https://docs.google.com/document/d/11tUnOegbHajqXPwSFxGtmGakupYrLgyItz4sgxAysi8/edit
-      internal: false    
+      internal: false
     - text: Overtime and comp-time policy
       url: overtime-and-comp-time/
       internal: true
@@ -403,7 +406,7 @@ navigation:
     url: detailing-and-offboarding-policies/
     internal: true
     generated: true
-    children:   
+    children:
     - text: Detailing to and from 18F
       url: detail/
       internal: true
@@ -413,4 +416,3 @@ navigation:
     - text: Term extensions
       url: term-extensions/
       internal: true
-

--- a/_config.yml
+++ b/_config.yml
@@ -278,7 +278,7 @@ navigation:
       url: google-hangouts/
       internal: true
     - text: GSA Internal Tools
-      url: /#gsa-tools/
+      url: https://handbook.18f.gov/gsa-tools-equipment-and-transit/#gsa-tools
       internal: true
     - text: Managed Software Center
       url: managed-software-center/


### PR DESCRIPTION
This link jumps to section with Aloha, Concur, OLU, etc.