### PR TITLE
Find your timekeeper update

### DIFF
--- a/_pages/policies/travel-and-leave-policies/aloha-etams-reconciliation-feature.md
+++ b/_pages/policies/travel-and-leave-policies/aloha-etams-reconciliation-feature.md
@@ -24,9 +24,4 @@ Also, your timekeeper will be pulling leave reports on a monthly basis and notif
 
 ### Find your timekeeper
 
-* Shawnique Muller: Last names A-G  
-* Matt Spencer: Last names H-R  
-* Leah Gitter: Last names S-Z  
-* Andres Lazo: Design Team A-G
-* Jamie Albrecht: Design Team H-P
-* Manny Pressley: Design Team Q-Z
+* [Timekeeper and certifier directory](https://docs.google.com/a/gsa.gov/spreadsheets/d/1HQYkVPvKOdzG0lvtcIwR3iEfryPaBktaDYGERqGymoc/edit?usp=sharing)


### PR DESCRIPTION
Deleted list of names and replaced with link to the "Timekeeper and certifier directory" google sheet per https://github.com/18F/handbook/issues/181