### PR TITLE
Adds "self-directed study for designers" subsection

### DIFF
--- a/_pages/welcome-to-18f/classes/professional-development-and-training.md
+++ b/_pages/welcome-to-18f/classes/professional-development-and-training.md
@@ -256,6 +256,23 @@ We have been slowly working on support for mentorship at 18F, including running 
 
 Engineering Chapter members: Would you like to pursue a self-directed training option? Would you like to teach yourself a new programming language, read the latest book on software development ideology, or take an online course? You totally can! Please include the request as part of your Individual Development Plan (IDP). If there is any type of cost associated with your training, you will need to also submit a supervisor-approved (i.e., signed) Standard Form 182. Once you’ve submitted your IDP your Supervisor will usually approve the request within 72 hours, and you will be good to go! Please coordinate with your project to carve out the time, and with your Supervisor to determine the duration, goals, and success markers of self-directed study. Please talk with your Facilitator or Supervisor with any questions, comments, or concerns.
 
+## Self-directed study for designers
+
+Experience Design Chapter members: You can use some or all of your yearly training time for independent study. To do this, you should:
+
+- Work with your lead to define an independent study in your Individual Development Plan (IDP) that includes your desired measurable outcomes for your studies.
+- Tock your time to `71 - Training / Prof Dev - Non Billable` with a note in the description field. Example note: "I used 4 hours of my yearly training time towards my independent study in JavaScript."
+
+If you've Tock'd 32 hours to your assigned project, you can use the remaining 8 hours for whatever else needs to get done at 18F, including training, without using your yearly assigned training hours. To use some of this 8 hours for training, you should:
+
+- Work with your lead to define an independent study in your Individual Development Plan (IDP) that includes your desired measurable outcomes for your studies.
+- Tock your time to `71 - Training / Prof Dev - Non Billable` with a note in the description field. Example note: "After completing my project work, I used 2 hours of my remaining time this week towards my independent study in JavaScript."
+- Consider putting co-work time on the calendar at a few hours a week with a colleague or group of colleagues, even if you're not working on exactly the same skill.
+
+Remember, this all only holds true if you've Tock'd at least 32 hours to your assigned project. If you'd like to use some of that '32 hours' time for training (for example, to go to an all-day conference, or go heads-down for a few days working on your independent study), you have up to 4 days of time per fiscal year towards this.
+
+And finally, there are a a few weekly tasks that should come before training: design huddle, your discipline's huddle, critique group, and required GSA trainings. After those, you have flexibility in how you spend your time. Options include: guild work, independent study as per this guidance, and other internal projects.
+
 ## Other training resources
 
 As an 18F team member, you have access to additional online training resources.

--- a/_pages/welcome-to-18f/classes/professional-development-and-training.md
+++ b/_pages/welcome-to-18f/classes/professional-development-and-training.md
@@ -266,12 +266,12 @@ Experience Design Chapter members: You can use some or all of your yearly traini
 If you've Tock'd 32 hours to your assigned project, you can use the remaining 8 hours for whatever else needs to get done at 18F, including training, without using your yearly assigned training hours. To use some of this 8 hours for training, you should:
 
 - Work with your lead to define an independent study in your Individual Development Plan (IDP) that includes your desired measurable outcomes for your studies.
-- Tock your time to `71 - Training / Prof Dev - Non Billable` with a note in the description field. Example note: "After completing my project work, I used 2 hours of my remaining time this week towards my independent study in JavaScript."
+- Tock your time to `71 - Training / Prof Dev - Non Billable` with a note in the description field. Example note: "After completing my project work, I used 2 hours of my remaining time this week toward my independent study in JavaScript."
 - Consider putting co-work time on the calendar at a few hours a week with a colleague or group of colleagues, even if you're not working on exactly the same skill.
 
-Remember, this all only holds true if you've Tock'd at least 32 hours to your assigned project. If you'd like to use some of that '32 hours' time for training (for example, to go to an all-day conference, or go heads-down for a few days working on your independent study), you have up to 4 days of time per fiscal year towards this.
+Remember, this all only holds true if you've Tock'd at least 32 hours to your assigned project. If you'd like to use some of that '32 hours' time for training (for example, to go to an all-day conference, or go heads-down for a few days working on your independent study), you have up to 4 days of time per fiscal year toward this.
 
-And finally, there are a a few weekly tasks that should come before training: design huddle, your discipline's huddle, critique group, and required GSA trainings. After those, you have flexibility in how you spend your time. Options include: guild work, independent study as per this guidance, and other internal projects.
+And finally, there are a a few weekly tasks that should come before training: design huddle, your discipline's huddle, critique group, and required [GSA trainings (OLU)](https://gsaolu.gsa.gov/). After those, you have flexibility in how you spend your time. Options include: guild work, independent study as per this guidance, and other internal projects.
 
 ## Other training resources
 


### PR DESCRIPTION
The experience design team would like to add guidance for self-directed study to the professional development page. This guidance has been through several revisions within the chapter, and folks feel it is time to let a first version fly 🚀 

Please let me know if there are any concerns @keithrwilson . Thank you!