### PR TITLE
Add information about funeral leave

### DIFF
--- a/_pages/policies/travel-and-leave-policies/leave-telework-and-virtual-worker.md
+++ b/_pages/policies/travel-and-leave-policies/leave-telework-and-virtual-worker.md
@@ -37,9 +37,9 @@ Sick leave accrues at four hours per pay period for all federal employees, regar
 
 ### Funeral leave
 
-Employees can take 3 days of funeral leave to plan or attend services of an immediate relative who has suffered a combat-related death. Additionally, veterans can take funeral leave to participate in a funeral ceremony for a member of the Armed Forces.
+Employees can take 3 days (24 hours) of funeral leave to plan or attend services of an immediate relative who has suffered a combat-related death. Additionally, veterans can take funeral leave to participate in a funeral ceremony for a member of the Armed Forces.
 
-Employees can take up to 104 hours (13 days) per year of sick leave for bereavement and funeral planning and attendance for family members.
+Employees can take up to 13 days (104 hours) per year of sick leave for bereavement, funeral planning, and/or attending the funeral of a family member.
 
 Further funeral leave information can be found in OPM's Fact Sheets: 
 

--- a/_pages/policies/travel-and-leave-policies/leave-telework-and-virtual-worker.md
+++ b/_pages/policies/travel-and-leave-policies/leave-telework-and-virtual-worker.md
@@ -5,6 +5,8 @@ tags:
 - aloha
 - aloha
 - vacation
+- funeral
+- bereavement
 ---
 
 In this policy, your _supervisor_ is your administrative or official supervisor (or their designee).
@@ -35,11 +37,15 @@ Sick leave accrues at four hours per pay period for all federal employees, regar
 
 ### Funeral leave
 
-Employees can take funeral leave to plan or attend services of an immediate relative who has suffered a combat-related death. Additionally, veterans can take funeral leave to participate in a funeral ceremony for a member of the Armed Forces.
+Employees can take 3 days of funeral leave to plan or attend services of an immediate relative who has suffered a combat-related death. Additionally, veterans can take funeral leave to participate in a funeral ceremony for a member of the Armed Forces.
 
-Employees can take up to 104 hours per year of sick leave for bereavement and funeral planning and attendance for family members.
+Employees can take up to 104 hours (13 days) per year of sick leave for bereavement and funeral planning and attendance for family members.
 
-Further information can be found in OPM's Fact Sheets for [Leave for Funerals and Bereavement](https://www.opm.gov/policy-data-oversight/pay-leave/leave-administration/fact-sheets/leave-for-funerals-and-bereavement/) and [Definitions Related to Family Member...](https://www.opm.gov/policy-data-oversight/pay-leave/leave-administration/fact-sheets/definitions-related-to-family-member-and-immediate-relative-for-purposes-of-sick-leave/).
+Further funeral leave information can be found in OPM's Fact Sheets: 
+
+* [Leave for funerals and bereavement](https://www.opm.gov/policy-data-oversight/pay-leave/leave-administration/fact-sheets/leave-for-funerals-and-bereavement/)
+* [Sick leave for family care or bereavement purposes](https://www.opm.gov/policy-data-oversight/pay-leave/leave-administration/fact-sheets/sick-leave-for-family-care-or-bereavement-purposes/)
+* [Definitions related to family member and immediate relative for purposes of sick leave](https://www.opm.gov/policy-data-oversight/pay-leave/leave-administration/fact-sheets/definitions-related-to-family-member-and-immediate-relative-for-purposes-of-sick-leave/)
 
 ### Unpaid leave
 

--- a/_pages/policies/travel-and-leave-policies/leave-telework-and-virtual-worker.md
+++ b/_pages/policies/travel-and-leave-policies/leave-telework-and-virtual-worker.md
@@ -6,6 +6,8 @@ tags:
 - aloha
 - vacation
 - funeral
+- funeral
+- death
 - bereavement
 ---
 

--- a/_pages/policies/travel-and-leave-policies/leave-telework-and-virtual-worker.md
+++ b/_pages/policies/travel-and-leave-policies/leave-telework-and-virtual-worker.md
@@ -33,6 +33,14 @@ The maximum annual leave you can carry over from calendar year to calendar year 
 
 Sick leave accrues at four hours per pay period for all federal employees, regardless of how long they've worked for the federal government. There is no maximum amount of sick leave you can accrue, and all unused hours carry over to the next calendar year. If you transfer from another federal agency, your sick leave transfers with you.
 
+### Funeral leave
+
+Employees can take funeral leave to plan or attend services of an immediate relative who has suffered a combat-related death. Additionally, veterans can take funeral leave to participate in a funeral ceremony for a member of the Armed Forces.
+
+Employees can take up to 104 hours per year of sick leave for bereavement and funeral planning and attendance for family members.
+
+Further information can be found in OPM's Fact Sheets for [Leave for Funerals and Bereavement](https://www.opm.gov/policy-data-oversight/pay-leave/leave-administration/fact-sheets/leave-for-funerals-and-bereavement/) and [Definitions Related to Family Member...](https://www.opm.gov/policy-data-oversight/pay-leave/leave-administration/fact-sheets/definitions-related-to-family-member-and-immediate-relative-for-purposes-of-sick-leave/).
+
 ### Unpaid leave
 
 Employees can request unpaid leave of less than four weeks at any time.


### PR DESCRIPTION
I wanted it to be easier to find information about taking leave for bereavement and funerals, to make it more clear that for the most part, sick leave must be used to attend funerals.

Related OPM fact sheets are at:
- https://www.opm.gov/policy-data-oversight/pay-leave/leave-administration/fact-sheets/leave-for-funerals-and-bereavement/
- https://www.opm.gov/policy-data-oversight/pay-leave/leave-administration/fact-sheets/definitions-related-to-family-member-and-immediate-relative-for-purposes-of-sick-leave/
- https://www.opm.gov/policy-data-oversight/pay-leave/leave-administration/fact-sheets/sick-leave-for-family-care-or-bereavement-purposes/

It's a lot of information to distill into something more Handbook-sized, so the current language feels really rough. I'd very much appreciate suggestions to improve it.