### PR TITLE
reflect new guild leaders in this doc!

### DIFF
--- a/_pages/how-we-work/research-guidelines.md
+++ b/_pages/how-we-work/research-guidelines.md
@@ -72,5 +72,5 @@ Carefully restricting access to personally identifiable information is a matter 
 
 ## Join the research guild!
 
-The Guild talks in [#research](https://gsa-tts.slack.com/archives/research) and meets once a week to discuss the theory and practice of asking questions. The current guild leader is [Jeremy Canfield](https://gsa-tts.slack.com/team/jeremy).
+The Guild talks in [#research](https://gsa-tts.slack.com/archives/research) and meets once a week to discuss the theory and practice of asking questions. The current guild leaders are [Colin MacArthur](https://gsa-tts.slack.com/team/colinpmacarthur) and [Joanne McGovern](https://gsa-tts.slack.com/team/joannemcgovern).
 


### PR DESCRIPTION
Late this spring, we held nominations to transition the role of guild leadership, and selected a panel of research-minded individuals from across TTS to interview and evaluate the candidates. At the end of that process, the two mentioned in the document were selected. :tada: :tada: