### PR TITLE
Outreach and Github page updates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -92,8 +92,8 @@ navigation:
     - text: Benefits
       url: benefits/
       internal: true
-    - text: GitHub
-      url: github/
+    - text: GitHub 101
+      url: intro-to-github/
       internal: true
     - text: GSA tools and transit
       url: gsa-tools-equipment-and-transit/

--- a/_config.yml
+++ b/_config.yml
@@ -92,8 +92,8 @@ navigation:
     - text: Benefits
       url: benefits/
       internal: true
-    - text: GitHub and the 18F website
-      url: github-and-18f-site/
+    - text: GitHub
+      url: github/
       internal: true
     - text: GSA tools and transit
       url: gsa-tools-equipment-and-transit/

--- a/_pages/about-us/teams/outreach.md
+++ b/_pages/about-us/teams/outreach.md
@@ -14,16 +14,28 @@ The Outreach team is situated in the 18F Front Office within [TTS](https://www.g
 * [#tweet-this](https://gsa-tts.slack.com/archives/tweet-this) is where we coordinate activity for 18F&rsquo;s Twitter account. Hop in here if you want us to respond to something, retweet someone, or tweet something interesting. You can also contact us if you&rsquo;d like to be added to [18F&rsquo;s team Twitter list](https://twitter.com/18F/lists/team).
 * [#press](https://gsa-tts.slack.com/archives/press) is for collecting press mentions of 18F (non tweets).
 * [#18f-site](https://gsa-tts.slack.com/archives/18f-site) is for managing issues and updates to the current 18f.gsa.gov.
-* [#beta-18f-site](https://gsa-tts.slack.com/archives/beta-18f-site) is for coordinating work on the new redesign of 18f.gsa.gov. 
-* [#inbox](https://gsa-tts.slack.com/archives/inbox) is for coordinating responses to emails that come into 18f@gsa.gov. 
+* [#beta-18f-site](https://gsa-tts.slack.com/archives/beta-18f-site) is for coordinating work on the new redesign of 18f.gsa.gov.
+* [#inbox](https://gsa-tts.slack.com/archives/inbox) is for coordinating responses to emails that come into 18f@gsa.gov.
 
 
 ## Project announcements
 
 If you're a project manager or storyteller working on an 18F project, ping us in [#outreach](https://gsa-tts.slack.com/archives/outreach) for help creating a lightweight communications plan that will help you connect with your most important stakeholders. [Comms plans for other 18F projects are in Google Drive](https://goo.gl/2VMKe9)
 
+## 18F site
+
+[18f.gsa.gov](http://18f.gsa.gov/) is a **static site** based on the Jekyll platform. (We use Jekyll pretty extensively at 18F. The [pages.18f.gov](https://pages.18f.gov) platform is built around Jekyll, and that&rsquo;s basically our version of GitHub pages). We publish the site with [Federalist](https://federalist.18f.gov).
+
+The name of our master branch is `staging`. We publish by making branches off of and submitting pull requests to `staging`. Once pushed, a branch will publish through Federalist as a preview URL. Once merged, Federalist will publish the site at 18f.gsa.gov.
+
+18F&rsquo;s website also uses **continuous integration** to [run tests on the site](https://github.com/18F/18f.gsa.gov/blob/staging/go#L77-L82) on each pull request. For CI, we currently use Travis and plan to switch to Circle soon.
+
+We use [Google Analytics](/google-analytics/) and participate in the [Digital Analytics Program](https://www.digitalgov.gov/services/dap/) to track site usage.
+
+The site team works in [#beta-18f-site](https://gsa-tts.slack.com/messages/beta-18f-site/).
+
 ## Blog
-Outreach publishes the [18F blog](https://18f.gsa.gov/blog/). We write about progress on our projects, how we work, the culture of 18F, and to educate digital workers in the federal government about important topics. We also use our blog to highlight good work being done by other federal agencies and as a recruiting tool for 18F. The primary contacts for the blog are [Andre Francisco](https://gsa-tts.slack.com/messages/andre/) and [Greg Boone](https://gsa-tts.slack.com/messages/gregboone/). 
+Outreach publishes the [18F blog](https://18f.gsa.gov/blog/). We write about progress on our projects, how we work, the culture of 18F, and to educate digital workers in the federal government about important topics. We also use our blog to highlight good work being done by other federal agencies and as a recruiting tool for 18F. The primary contacts for the blog are [Andre Francisco](https://gsa-tts.slack.com/messages/andre/) and [Greg Boone](https://gsa-tts.slack.com/messages/gregboone/).
 
 Everyone at 18F is encouraged to write for the blog; you don’t have to be at 18F for a certain amount of time to have interesting ideas to share. The first step is to meet with us and [turn your idea into an outline](https://docs.google.com/document/d/1vv5OwsUmaxAGubpY_9za7JJmvL-8SE27HKaEQBumPiA/edit) shaped for a distinct audience. From there, check out the [18F Blogging Guide](https://blogging-guide.18f.gov/), which details the process more formally (including necessary approvals), and can tell you more about our mission and process. We’re happy to meet you wherever you are in the writing process.
 
@@ -59,7 +71,7 @@ Here's the guide on [how to draft and publish the internal newsletter](https://d
 
 If you’re speaking at an event, ping us in [#outreach](https://gsa-tts.slack.com/archives/outreach) so we can provide you with team talking points, take a look at your presentation, and help you promote the event. If you've been asked to speak at an event or you want to submit a proposal, see the [Getting Event/Conference Approval](https://docs.google.com/document/d/1OjxymrHIU1VREv93HrG1sESzyrtx8B2kl_Ey4IL_4xc/edit) guide.
 
-If you’re looking for help with a slide deck for a presentation, you can find resources on the [18F Branding site](https://pages.18f.gov/brand/presentation-themes/). We also have a couple previous decks that have ready-to-use slides about 18F’s history, the digital service ecosystem, and the basics of 18F’s model. 
+If you’re looking for help with a slide deck for a presentation, you can find resources on the [18F Branding site](https://pages.18f.gov/brand/presentation-themes/). We also have a couple previous decks that have ready-to-use slides about 18F’s history, the digital service ecosystem, and the basics of 18F’s model.
 
 * [Adobe Digital Government Assembly](https://docs.google.com/presentation/d/1vE9yp92vx2ZCgEmb0xPEyZr6wUorzLjs5-APQjwN5vI/edit#slide=id.p)
 * [Tech Summit San Diego](https://docs.google.com/presentation/d/1gkqQsDdNAzoXm1kXgsOrUoNY8ObWHJWpHh1o30eo204/edit#slide=id.g11f3f786cd_0_0)

--- a/_pages/about-us/teams/outreach.md
+++ b/_pages/about-us/teams/outreach.md
@@ -14,7 +14,6 @@ The Outreach team is situated in the 18F Front Office within [TTS](https://www.g
 * [#tweet-this](https://gsa-tts.slack.com/archives/tweet-this) is where we coordinate activity for 18F&rsquo;s Twitter account. Hop in here if you want us to respond to something, retweet someone, or tweet something interesting. You can also contact us if you&rsquo;d like to be added to [18F&rsquo;s team Twitter list](https://twitter.com/18F/lists/team).
 * [#press](https://gsa-tts.slack.com/archives/press) is for collecting press mentions of 18F (non tweets).
 * [#18f-site](https://gsa-tts.slack.com/archives/18f-site) is for managing issues and updates to the current 18f.gsa.gov.
-* [#beta-18f-site](https://gsa-tts.slack.com/archives/beta-18f-site) is for coordinating work on the new redesign of 18f.gsa.gov.
 * [#inbox](https://gsa-tts.slack.com/archives/inbox) is for coordinating responses to emails that come into 18f@gsa.gov.
 
 

--- a/_pages/about-us/teams/outreach.md
+++ b/_pages/about-us/teams/outreach.md
@@ -31,7 +31,7 @@ The name of our master branch is `staging`. We publish by making branches off of
 
 We use [Google Analytics](/google-analytics/) and participate in the [Digital Analytics Program](https://www.digitalgov.gov/services/dap/) to track site usage.
 
-The site team works in [#beta-18f-site](https://gsa-tts.slack.com/messages/beta-18f-site/).
+The site team works in [#18f-site](https://gsa-tts.slack.com/messages/18f-site/).
 
 ## Blog
 Outreach publishes the [18F blog](https://18f.gsa.gov/blog/). We write about progress on our projects, how we work, the culture of 18F, and to educate digital workers in the federal government about important topics. We also use our blog to highlight good work being done by other federal agencies and as a recruiting tool for 18F. The primary contacts for the blog are [Andre Francisco](https://gsa-tts.slack.com/messages/andre/) and [Greg Boone](https://gsa-tts.slack.com/messages/gregboone/).

--- a/_pages/about-us/teams/outreach.md
+++ b/_pages/about-us/teams/outreach.md
@@ -78,10 +78,6 @@ If you’re looking for help with a slide deck for a presentation, you can find 
 * [18F General Slides](https://docs.google.com/presentation/d/1-RSrdIJzrOE8YBG6V_DHHRkBNo5fxecl8EtIxksqeUk/edit#slide=id.g11b16e26a9_0_5)
 * You can find a number of other decks in the ["Presentations" Google Drive folder](https://drive.google.com/drive/folders/0B-y3CqI2T1nneHViZUx5b3FHLVE) and templates for one page print outs in the ["Branded Materials for Outreach" Google Drive folder](https://drive.google.com/drive/folders/0B8kn3cuJUwEkT3lZRmN1QV9mdVk)
 
-## 18f.gsa.gov
-
-Learn more about the technical details of 18f.gsa.gov on the [GitHub and 18F website handbook page](https://handbook.18f.gov/github-and-18f-site/)
-
 ---
 
 #### Still have questions?

--- a/_pages/how-we-work/tools/github.md
+++ b/_pages/how-we-work/tools/github.md
@@ -6,7 +6,7 @@ GitHub is a closed-source platform for [open-source](https://github.com/18F/open
 
 ## Documentation
 
-- Greg Boone gives [a brief class on GitHub and the 18F website](/intro-to-github).
+- Greg Boone gives [a brief class on GitHub](/intro-to-github).
 
 - The 18F [Open Source Policy](https://github.com/18F/open-source-policy/blob/master/policy.md) and accompanying [practice guide](https://github.com/18F/open-source-policy/blob/master/practice.md) explain why and how we write code and documentation in the open.
 

--- a/_pages/how-we-work/tools/github.md
+++ b/_pages/how-we-work/tools/github.md
@@ -6,7 +6,7 @@ GitHub is a closed-source platform for [open-source](https://github.com/18F/open
 
 ## Documentation
 
-- Greg Boone gives [a brief class on GitHub and the 18F website](/github-and-18f-site).
+- Greg Boone gives [a brief class on GitHub and the 18F website](/intro-to-github).
 
 - The 18F [Open Source Policy](https://github.com/18F/open-source-policy/blob/master/policy.md) and accompanying [practice guide](https://github.com/18F/open-source-policy/blob/master/practice.md) explain why and how we write code and documentation in the open.
 

--- a/_pages/welcome-to-18f/classes.md
+++ b/_pages/welcome-to-18f/classes.md
@@ -142,7 +142,7 @@ Even if you don’t plan to travel much in the federal government, it’s import
 **When:** Last Thursday of the month ([calendar](https://www.google.com/calendar/b/1/embed?src=gsa.gov_vpfql4425bt1kj5fatahokgg94@group.calendar.google.com&ctz=America/New_York)).
 **Tags:** [#travel](https://gsa-tts.slack.com/messages/travel)
 
-### <a id="github-18F-site" href="/github-and-18f-site">Introduction to GitHub and 18F site</a>
+### <a id="github-18F-site" href="/intro-to-github">Introduction to GitHub and 18F site</a>
 
 We use GitHub to share code, communicate, and collaborate on projects. Learn how 18F uses GitHub and add your bio and picture to the 18F site.
 

--- a/_pages/welcome-to-18f/classes/github.md
+++ b/_pages/welcome-to-18f/classes/github.md
@@ -1,20 +1,10 @@
 ---
-title: Intro to GitHub and the 18F website
-navtitle: GitHub and the 18F website
+title: Intro to GitHub
+navtitle: GitHub
 ---
 
-_This section covers the basics of how 18F&rsquo;s website works and includes a brief overview of Git._
+_This section provides a brief overview of GitHub._
 
-
-### Leadership
-
-[Outreach](/outreach) is responsible for maintaining the 18F website. [Elaine Kamlley](https://gsa-tts.slack.com/messages/@elainekamlley) is the product leads.
-
-### Communication
-
-Find us in Slack:
-
-- Use [#18f-site](https://gsa-tts.slack.com/messages/18f-site) to report issues.
 
 ### Documentation
 
@@ -69,28 +59,3 @@ Another pro tip: Search the existing issues before you add one. It may make more
 To submit an issue, Log in, find the appropriate repo on GitHub, and click the Issues tab in the right column. Then, click the New Issue button. Your issue should have a title and explainer text. You&rsquo;ll probably know what to put there, but teams sometimes have guidance on how to format issues or things to include. The [#blog](https://gsa-tts.slack.com/archives/blog), for example, has [a specific set of things we require](https://github.com/18F/blog-drafts#readme) submissions to have before we&rsquo;ll consider them.
 
 Final pro tip: If your project wants issues formatted in a specific way, you can add an issue template file. [This is the one we have for filing new blog post ideas](https://github.com/18F/blog-drafts/blob/master/ISSUE_TEMPLATE.md). Every new post auto-fills with that information.
-
-
-## 18F site
-
-[18f.gsa.gov](http://18f.gsa.gov/) is a **static site** based on the Jekyll platform. (We use Jekyll pretty extensively at 18F. The [pages.18f.gov](https://pages.18f.gov) platform is built around Jekyll, and that&rsquo;s basically our version of GitHub pages). We publish the site with [Federalist](https://federalist.18f.gov).
-
-The name of our master branch is `staging`. We publish by making branches off of and submitting pull requests to `staging`. Once pushed, a branch will publish through Federalist as a preview URL. Once merged, Federalist will publish the site at 18f.gsa.gov.
-
-18F&rsquo;s website also uses **continuous integration** to [run tests on the site](https://github.com/18F/18f.gsa.gov/blob/staging/go#L77-L82) on each pull request. For CI, we currently use Travis and plan to switch to Circle soon.
-
-We use [Google Analytics](/google-analytics/) and participate in the [Digital Analytics Program](https://www.digitalgov.gov/services/dap/) to track site usage.
-
-### Add your photo
-
-Everyone at 18F should submit a photo that we'll use whenever we represent you on the website. This isn't mandatory, of course, but we&rsquo;d really like it if everyone had a photo. (We use the 18F logo in place of a photo if you don't have one.)
-
-Photos should follow these three guidelines. You should submit a photo:
-
-* Of you and only you from the shoulders up
-* Where your whole face is visible
-* Taken in a public place like a park, library, or a local federal building
-
-To get going, find or take an appropriate photo and upload it to [this Google Drive folder](https://drive.google.com/a/gsa.gov/folderview?id=0B8kn3cuJUwEkLUMwWXE2VVczbUU&usp=sharing). We have some guidelines about good photos, [here](https://docs.google.com/a/gsa.gov/document/d/1xEFRPtJBrsJH-0ZhL9Wq1T8iILGydM-7R11iPTVWJVg/edit?usp=drive_web).
-
-The site team works in [#beta-18f-site](https://gsa-tts.slack.com/messages/beta-18f-site/).

--- a/_pages/welcome-to-18f/classes/intro-to-github.md
+++ b/_pages/welcome-to-18f/classes/intro-to-github.md
@@ -1,6 +1,6 @@
 ---
 title: Intro to GitHub
-navtitle: GitHub
+navtitle: Intro to GitHub
 ---
 
 _This section provides a brief overview of GitHub._

--- a/_pages/welcome-to-18f/onboarding-schedule.md
+++ b/_pages/welcome-to-18f/onboarding-schedule.md
@@ -26,7 +26,7 @@ Note: The titles below are linked to our handbook pages for each subject. Descri
 * [Equipment and useful government websites](/gsa-tools-equipment-and-transit) ([Description](/classes/#equipment))
 
 ### Thursday
-* [Introduction to GitHub and the 18F website](/github-and-18f-site) ([Description](/classes/#github-18F-site))
+* [Introduction to GitHub and the 18F website](/intro-to-github) ([Description](/classes/#github-18F-site))
 
 ### Friday
 * [Time tracking and Tock](/tock) ([Description](/classes/#tock))


### PR DESCRIPTION
Removed 18f site information from Github page and moved it over to
Outreach per Andre’s request.