### PR TITLE
Clarify the p-card limits of training spending

### DIFF
--- a/_pages/welcome-to-18f/classes/professional-development-and-training.md
+++ b/_pages/welcome-to-18f/classes/professional-development-and-training.md
@@ -104,7 +104,7 @@ The review and approval processes can take a bit of time, so it’s best if you 
 *Requests like these must be [made in C2 (Step 4)](/professional-development-and-training/#submit-an-event-request-in-C2) at least one week in advance.*
 * **Three to four weeks in advance:** For trainings that are less than $3,000 altogether, don't require an outside source of funding, and are either at a conference, require travel, or involve more than one person from TTS attending.
 *Requests like these must be [made in C2 (Step 4)](/professional-development-and-training/#submit-an-event-request-in-C2) at least two weeks in advance.*
-* **Five to six weeks in advance:** For individual or group trainings (or conferences) that cost more than $3,000 altogether, anything involving an outside source of funding, or international travel.
+* **Five to six weeks in advance:** For individual or group trainings (or conferences) that cost more than $3,000 altogether, anything involving an outside source of funding, or international travel. If a training costs more than $3,500 altogether try to submit the request two or more months in advance as it *cannot be purchased on a purchase card and must go through a full procurement.*
 *Requests like these must be [made in C2 (Step 4)](/professional-development-and-training/#submit-an-event-request-in-C2) at least four weeks in advance.*
 
 Requests that don't make it to [C2 (Step 4)](/professional-development-and-training/#submit-an-event-request-in-C2) in time will not be approved.

--- a/_pages/welcome-to-18f/classes/professional-development-and-training.md
+++ b/_pages/welcome-to-18f/classes/professional-development-and-training.md
@@ -104,7 +104,7 @@ The review and approval processes can take a bit of time, so it’s best if you 
 *Requests like these must be [made in C2 (Step 4)](/professional-development-and-training/#submit-an-event-request-in-C2) at least one week in advance.*
 * **Three to four weeks in advance:** For trainings that are less than $3,000 altogether, don't require an outside source of funding, and are either at a conference, require travel, or involve more than one person from TTS attending.
 *Requests like these must be [made in C2 (Step 4)](/professional-development-and-training/#submit-an-event-request-in-C2) at least two weeks in advance.*
-* **Five to six weeks in advance:** For individual or group trainings (or conferences) that cost more than $3,000 altogether, anything involving an outside source of funding, or international travel. If a training costs more than $3,500 altogether try to submit the request two or more months in advance as it *cannot be purchased on a purchase card and must go through a full procurement.*
+* **Five to six weeks in advance:** For individual or group trainings (or conferences) that cost more than $3,000 altogether, anything involving an outside source of funding, or international travel. If the training itself costs more than $3,500 try to submit the request two or more months in advance as it *cannot be purchased on a purchase card and must go through a full procurement.*
 *Requests like these must be [made in C2 (Step 4)](/professional-development-and-training/#submit-an-event-request-in-C2) at least four weeks in advance.*
 
 Requests that don't make it to [C2 (Step 4)](/professional-development-and-training/#submit-an-event-request-in-C2) in time will not be approved.


### PR DESCRIPTION
Trainings over $3500 trigger a full procurement process and it'd be good to point that out before people get too far along in the process. We might also consider telling people they can mitigate that by agreeing to pay the excess balance (or applying a discount coupon if they have one). This is helpful if the training is, say, $3501. Someone might choose to pay the extra dollar out of pocket rather than do market research the full gamut of procurement. We'd have to word it carefully to make it clear this is simply *an* option, not a requirement for more costly trainings.