### PR TITLE
Fix links to Slack #talent

### DIFF
--- a/_pages/policies/employee-resources-policies/overtime-and-comp-time.md
+++ b/_pages/policies/employee-resources-policies/overtime-and-comp-time.md
@@ -11,4 +11,4 @@ tags:
 
 Updates coming soon to this page!
 
-Please reach out to TTS Talent via [#talent](https://gsa-tts.slack.com/messagse/talent/) or [email](mailto:tts-talentteam@gsa.gov) for information regarding overtime and comp time.
+Please reach out to TTS Talent via [#talent](https://gsa-tts.slack.com/messages/talent/) or [email](mailto:tts-talentteam@gsa.gov) for information regarding overtime and comp time.

--- a/_pages/policies/employee-resources-policies/promotions.md
+++ b/_pages/policies/employee-resources-policies/promotions.md
@@ -8,4 +8,4 @@ tags:
 
 Updates coming soon to this page!
 
-Please reach out to TTS Talent via [#talent](https://gsa-tts.slack.com/messagse/talent/) or [email](mailto:tts-talentteam@gsa.gov) for information regarding promotions.
+Please reach out to TTS Talent via [#talent](https://gsa-tts.slack.com/messages/talent/) or [email](mailto:tts-talentteam@gsa.gov) for information regarding promotions.


### PR DESCRIPTION
When looking at the links for the `#talent` channel in Slack, I noticed that they weren't correct. This fixes the typo. :+1: