### PR TITLE
Removed the out-of-date journey map

### DIFF
--- a/_pages/how-we-work/purchase-requests.md
+++ b/_pages/how-we-work/purchase-requests.md
@@ -51,6 +51,6 @@ See [the Equipment page](../equipment/#software).
 
 ## Purchases over $3,500
 
-Purchases over $3,500 require the involvement of a contracting officer. For these sorts of needs, the TTS Office of Acquisition has a process [here](https://acqstack-journeymap.18f.gov/internal-clients/intake/) and the TTS Acquisition Intake Form [here](https://docs.google.com/forms/d/e/1FAIpQLSeGoLWQ_6yEmxlrHuztlZWH6sX3t_0J0PPnzZxhwlK6nq1KoQ/viewform). 
+Purchases over $3,500 require the involvement of a contracting officer. For these sorts of needs, the TTS Office of Acquisition has the TTS Acquisition Intake Form [here](https://docs.google.com/forms/d/e/1FAIpQLSeGoLWQ_6yEmxlrHuztlZWH6sX3t_0J0PPnzZxhwlK6nq1KoQ/viewform). 
 
 *Got questions? Ask [#c2-purchase-questions](https://gsa-tts.slack.com/messages/C0E1APHGU/)*, [tts-purchasers@gsa.gov](mailto:tts-purchasers@gsa.gov), or book office hours [here](https://sites.google.com/a/gsa.gov/tts-office-hours/)


### PR DESCRIPTION
We are in the process of updating this journey map, so removing the link and leaving only the Intake Form for the time being.