### PR TITLE
Adding guidance of 18F microsite approval

### DIFF
--- a/_pages/how-we-work/tools/federalist.md
+++ b/_pages/how-we-work/tools/federalist.md
@@ -17,6 +17,8 @@ We use Federalist to build websites.
 
 * TTS teams can use Federalist for internal or TTS-specific projects without cost.  However, if the site is part of a project you're doing for another agency, it must be included in and paid for by the agreement with that agency.  
 
+* For 18F staff only - The Outreach team is responsible of 18F's web presence. If you are looking to create a 18F microsite (`xyz.18f.gov`), like a guide or resource, the Outreach team will need to approve it. Where to start: Tell us about the site you want to create by [filling out this form](https://goo.gl/forms/gnknCoYSRIF0gGrA3) or by going to the [Outreach page](https://handbook.18f.gov/outreach/#f-branding-and-microsites-approval) to learn more. If you have any questions, head over to #outreach on Slack.  
+
 ## Communication
 
 * Slack: [#federalist](https://gsa-tts.slack.com/messages/federalist/)

--- a/_pages/how-we-work/tools/federalist.md
+++ b/_pages/how-we-work/tools/federalist.md
@@ -17,7 +17,7 @@ We use Federalist to build websites.
 
 * TTS teams can use Federalist for internal or TTS-specific projects without cost.  However, if the site is part of a project you're doing for another agency, it must be included in and paid for by the agreement with that agency.  
 
-* For 18F staff only - The Outreach team is responsible for 18F's web presence. If you are looking to create an 18F microsite (`xyz.18f.gov`), such as a guide or resource, the Outreach team will need to approve it. *Where to start:* Tell us about the site that you want to create by [filling out this form](https://goo.gl/forms/gnknCoYSRIF0gGrA3) or by going to the [Outreach page](https://handbook.18f.gov/outreach/#f-branding-and-microsites-approval) to learn more. If you have any questions, head over to [#outreach]((https://gsa-tts.slack.com/messages/outreach/) on Slack.  
+* For 18F staff only - The Outreach team is responsible for 18F's web presence. If you are looking to create an 18F microsite (`xyz.18f.gov`), such as a guide or resource, the Outreach team will need to approve it. *Where to start:* Tell us about the site that you want to create by [filling out this form](https://goo.gl/forms/gnknCoYSRIF0gGrA3) or by going to the [Outreach page](https://handbook.18f.gov/outreach/#f-branding-and-microsites-approval) to learn more. If you have any questions, head over to [#outreach](https://gsa-tts.slack.com/messages/outreach/) on Slack.  
 
 ## Communication
 

--- a/_pages/how-we-work/tools/federalist.md
+++ b/_pages/how-we-work/tools/federalist.md
@@ -17,7 +17,7 @@ We use Federalist to build websites.
 
 * TTS teams can use Federalist for internal or TTS-specific projects without cost.  However, if the site is part of a project you're doing for another agency, it must be included in and paid for by the agreement with that agency.  
 
-* For 18F staff only - The Outreach team is responsible of 18F's web presence. If you are looking to create a 18F microsite (`xyz.18f.gov`), like a guide or resource, the Outreach team will need to approve it. Where to start: Tell us about the site you want to create by [filling out this form](https://goo.gl/forms/gnknCoYSRIF0gGrA3) or by going to the [Outreach page](https://handbook.18f.gov/outreach/#f-branding-and-microsites-approval) to learn more. If you have any questions, head over to #outreach on Slack.  
+* For 18F staff only - The Outreach team is responsible for 18F's web presence. If you are looking to create an 18F microsite (`xyz.18f.gov`), such as a guide or resource, the Outreach team will need to approve it. *Where to start:* Tell us about the site that you want to create by [filling out this form](https://goo.gl/forms/gnknCoYSRIF0gGrA3) or by going to the [Outreach page](https://handbook.18f.gov/outreach/#f-branding-and-microsites-approval) to learn more. If you have any questions, head over to [#outreach]((https://gsa-tts.slack.com/messages/outreach/) on Slack.  
 
 ## Communication
 


### PR DESCRIPTION
Outreach is responsible for maintaining a unified 18F brand and its web presence. We have created a lightweight process on approving 18F microsites. Adding that information on the Federalist page specifically for 18F staff.

@wslack @keithrwilson 