### PR TITLE
remove references to the Managed Software Center

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -304,9 +304,6 @@ navigation:
     - text: How to get Microsoft Office for OS X
       url: office/
       internal: true
-    - text: Managed Software Center
-      url: managed-software-center/
-      internal: true
     - text: MailChimp
       url: mailchimp/
       internal: true

--- a/_pages/how-we-work/equipment.md
+++ b/_pages/how-we-work/equipment.md
@@ -23,9 +23,7 @@ TTS employees are issued an Apple MacBook Air/Pro computer. Note that this is no
 
 ### Rules
 
-**Install [Managed Software Center](/managed-software-center/).** This is how we'll send you software updates, optional software titles, and Apple updates that won't break your system.
-
-**Install [ClamXav](/clamxav)** immediately. This software will be **automatically** pushed to your system by the Managed Software Center, so you **must** complete that installation first. This is your antivirus software.
+**Install [ClamXav](/clamxav)** immediately. This is your antivirus software.
 
 **[Require a password](http://support.apple.com/kb/PH18669?viewlocale=en_US)** when your computer goes to sleep or shows a screensaver.
 


### PR DESCRIPTION
Follow-up to #645. That section about what needs to be installed on laptops needs an update anyway (#559), but that's so much in flux that I'm not sure we should bother right now. This pull request is just getting rid of broken links to fix the build.