### PR TITLE
Widen site to 960px 

### DIFF
--- a/_pages/welcome-to-TTS/classes/travel-101.md
+++ b/_pages/welcome-to-TTS/classes/travel-101.md
@@ -52,7 +52,7 @@ If you’re traveling for a particular project as a member of 18F or the TTS Off
 
 If you have travel questions, you can ask them in [#travel](https://gsa-tts.slack.com/messages/travel), write to [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov), or simply book time during TTS travel team [office hours](https://sites.google.com/a/gsa.gov/tts-office-hours/) Monday through Friday from **11:30 to 12:30 PM** and again from **3:30 to 4:30 PM** (All times Eastern). All questions will be answered within one business day-- please avoid asking travel questions via DM :)
 
-The travel team also approves [authorizations](/travel-101/#authorizations) (request to travel) every afternoon. Please ensure that you have submitted your travel request following the guidance above before 3:30 PM Eastern so that approval may be finalized before the close of the business day. Travel submitted after hours will not be approved until the next business day.
+The travel team also approves [authorizations](/travel-101/#securing-an-authorization-to-travel) (request to travel) every afternoon. Please ensure that you have submitted your travel request following the guidance above before 3:30 PM Eastern so that approval may be finalized before the close of the business day. Travel submitted after hours will not be approved until the next business day.
 
 *Note:* Authorizations will be addressed within a day of being submitted, but vouchers (requests for reimbursement) may take up to 5 business days since they are handled them as the remaining travel approval time on the office hours calendar permits.
 

--- a/stylesheets/screen.css
+++ b/stylesheets/screen.css
@@ -91,7 +91,11 @@ img.travel-guide-hide{
   display: none;
 }
 
-@media screen and (min-width: 336.84px){ .wrapper{ width: 90%; }  }
+@media screen and (min-width: 336.84px){
+  .wrapper,
+  .page .wrapper
+  { width: 90%; }
+}
 
 .wrapper::after{
 	content: "";
@@ -552,11 +556,10 @@ input[type="search"]:focus::-webkit-search-cancel-button::after{
 .page{ padding-top: 1em; }
 
 .page .wrapper{
-	width: auto;
-	max-width: none;
+	max-width: 960px;;
 }
 
-.page .page-title,
+/*.page .page-title,
 .page h1,
 .page h2,
 .page h3,
@@ -573,7 +576,7 @@ input[type="search"]:focus::-webkit-search-cancel-button::after{
 	margin: 0 auto 0.7em;
 	max-width: 640px;
 	width: 90%;
-}
+}*/
 
 
 .page td{ line-height: 1.4em; }
@@ -651,7 +654,7 @@ a[id]{
 	line-height: 1.5em;
 	color: #444;
 	font-size: 18px;
-	margin: -1em auto 2em;
+	margin: -1em 0 2em;
 }
 
 .page h2{
@@ -660,8 +663,8 @@ a[id]{
 	line-height: 1.3em;
 	font-family: Merriweather, Georgia;
 	color: #c56815;
-	max-width: 640px;
-	margin: 28px auto 16px;
+	/*max-width: 640px;*/
+	margin: 28px 0 16px;
 }
 
 .page h3,
@@ -694,12 +697,14 @@ a[id]{
 
 .page blockquote{
 	padding-left: 1em;
+  margin-left: 1rem;
 	position: relative;
-	max-width: 640px;
-	margin: 0 auto;
+	/*max-width: 640px;*/
+	/*margin: 0 auto;*/
+  border-left: 3px solid #e3e3e3;
 }
 
-.page blockquote::after{
+/*.page blockquote::after{
 	content: "";
 	position: absolute;
 	left: 1px;
@@ -708,7 +713,7 @@ a[id]{
 	width: 3px;
 	background: #e3e3e3;
 	border-radius: 3px;
-}
+}*/
 
 .page blockquote p{
 	font-family: Merriweather, Georgia, serif;
@@ -735,10 +740,9 @@ a[id]{
 	.page ul,
 	.page ol,
 	.page dl,
-	.page li{
-		width: 90%;
-		margin-left: auto;
-		margin-right: auto;
+	.page li,
+  .page blockquote {
+		max-width: 66ch;
 	}
 	.page p,
 	.page figure,
@@ -747,7 +751,7 @@ a[id]{
 	.page dl,
 	.page li,
 	.page td {
-		margin: 0 auto 0.8em;
+		margin: 0 0 0.8em;
 		line-height: 1.6em;
 	}
 
@@ -784,11 +788,11 @@ a[id]{
 .page hr{
 	border: none;
 	height: 0.2em;
-	margin-top: 2em;
-	margin-bottom: 2em;
+	margin: 2em 0;
+	/*margin-bottom: 2em;*/
 	background: #f2f1ec;
-	width: 90%;
-	max-width: 640px;
+	/*width: 90%;*/
+	max-width: 66ch;
 }
 
 .page .h-card{
@@ -806,13 +810,12 @@ a[id]{
 .page table{
 	border-radius: 3px;
 	border: 1px solid #eee;
-	margin: 0 auto;
 	max-width: 640px;
 	table-layout: fixed;
 	box-shadow: 0 0 0 2px #fafafa;
 }
 
-.page .table-wrapper{
+/*.page .table-wrapper{
 	margin: 0 auto 1.8em;
 	padding-bottom: 0.2em;
 	max-width: 90%;
@@ -821,7 +824,7 @@ a[id]{
 
 @media screen and (min-width: 711.11px){
 	.page .table-wrapper{ max-width: 640px; }
-}
+}*/
 
 .page table tbody tr:first-child td:first-child{
 	border-radius: 3px;
@@ -1188,19 +1191,19 @@ a[id]{
 	.layout-article.with-inline-navigation .wrapper .inline-navigation{
 		float: right;
 		width: 256px;
-		margin-left: -256px;
+		/*margin-left: -256px;
 		left: 288px;
 		margin-right: 50vw;
-		position: relative;
+		position: relative;*/
 	}
 }
 
-@media screen and (min-width: 817.7777px) {
+/*@media screen and (min-width: 817.7777px) {
 	.layout-article.with-inline-navigation .wrapper .inline-navigation{
 		margin-left: -352px;
 		left: 384px;
 	}
-}
+}*/
 
 
 /* @end */

--- a/stylesheets/screen.css
+++ b/stylesheets/screen.css
@@ -559,26 +559,6 @@ input[type="search"]:focus::-webkit-search-cancel-button::after{
 	max-width: 960px;
 }
 
-/*.page .page-title,
-.page h1,
-.page h2,
-.page h3,
-.page h4,
-.page h5,
-.page nav,
-.page figure,
-.page p,
-.page ul,
-.page ol,
-.page dl,
-.page li{
-	line-height: 1.4em;
-	margin: 0 auto 0.7em;
-	max-width: 640px;
-	width: 90%;
-}*/
-
-
 .page td{ line-height: 1.4em; }
 
 .page h1,
@@ -663,7 +643,6 @@ a[id]{
 	line-height: 1.3em;
 	font-family: Merriweather, Georgia;
 	color: #c56815;
-	/*max-width: 640px;*/
 	margin: 28px 0 16px;
 }
 
@@ -699,21 +678,8 @@ a[id]{
 	padding-left: 1em;
   margin-left: 1rem;
 	position: relative;
-	/*max-width: 640px;*/
-	/*margin: 0 auto;*/
   border-left: 3px solid #e3e3e3;
 }
-
-/*.page blockquote::after{
-	content: "";
-	position: absolute;
-	left: 1px;
-	top: 0;
-	bottom: 0;
-	width: 3px;
-	background: #e3e3e3;
-	border-radius: 3px;
-}*/
 
 .page blockquote p{
 	font-family: Merriweather, Georgia, serif;
@@ -789,9 +755,7 @@ a[id]{
 	border: none;
 	height: 0.2em;
 	margin: 2em 0;
-	/*margin-bottom: 2em;*/
 	background: #f2f1ec;
-	/*width: 90%;*/
 	max-width: 66ch;
 }
 
@@ -814,17 +778,6 @@ a[id]{
 	table-layout: fixed;
 	box-shadow: 0 0 0 2px #fafafa;
 }
-
-/*.page .table-wrapper{
-	margin: 0 auto 1.8em;
-	padding-bottom: 0.2em;
-	max-width: 90%;
-	overflow: auto;
-}
-
-@media screen and (min-width: 711.11px){
-	.page .table-wrapper{ max-width: 640px; }
-}*/
 
 .page table tbody tr:first-child td:first-child{
 	border-radius: 3px;

--- a/stylesheets/screen.css
+++ b/stylesheets/screen.css
@@ -556,7 +556,7 @@ input[type="search"]:focus::-webkit-search-cancel-button::after{
 .page{ padding-top: 1em; }
 
 .page .wrapper{
-	max-width: 960px;;
+	max-width: 960px;
 }
 
 /*.page .page-title,


### PR DESCRIPTION
Widening the layout fixes the issue where tables would not fit in the content area.
I also kept the character limit for lines to 66 per the USWDS. 

**Table currently breaking layouts (640px wide)**
https://handbook.18f.gov/gsa-internal-tools/

**Preview of wider content (Fixed tables in layout)**
https://federalist-proxy.app.cloud.gov/preview/18f/handbook/sw-site-width/gsa-internal-tools/