### PR TITLE
Change tool list to InSite page

### DIFF
--- a/_pages/about-us/teams/design.md
+++ b/_pages/about-us/teams/design.md
@@ -122,7 +122,7 @@ Most of the design team works on a mix of partner-agency projects and internal i
 
 Here are some common tools we use, how we use them, and how you can get access to them. If you can’t find the information you need in the chart below, get in touch with your design lead; they’ll be able to point you in the right direction.
 
-And one more thing: before you start using any new tool that asks for access to files/browser data, please check the [full list](https://docs.google.com/spreadsheets/d/1nrdfmL8DNjRJb45N3QZjvX8TeIcHth3Cy0rO5jVIvKo/edit#gid=1) of approved tools. If what you want to use isn’t there, you’ll need to ask in [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure) first. New tools often create hard-to-anticipate security problems.
+And one more thing: before you start using any new tool that asks for access to files/browser data, please check the [full list](https://ea.gsa.gov/#!/itstandards) of approved tools. If what you want to use isn’t there, you’ll need to ask in [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure) first. New tools often create hard-to-anticipate security problems.
 
 #### Drawing lines on a screen
 

--- a/_pages/about-us/teams/engineering.md
+++ b/_pages/about-us/teams/engineering.md
@@ -155,4 +155,4 @@ Most of the Engineering team works on a mix of partner agency projects and inter
 
 Here are some [common tools we use](/#tools), how we use them, and how you can get access to them. If you can’t find the information you need in the chart below, get in touch with your design lead; they’ll be able to point you in the right direction.
 
-And one more thing: before you start using any new tool that asks for access to files/browser data, please check the [full list](https://docs.google.com/spreadsheets/d/1nrdfmL8DNjRJb45N3QZjvX8TeIcHth3Cy0rO5jVIvKo/edit#gid=1) of approved tools. If what you want to use isn’t there, you’ll need to ask [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure) first. New tools often create hard-to-anticipate security problems.
+And one more thing: before you start using any new tool that asks for access to files/browser data, please check the [full list](https://ea.gsa.gov/#!/itstandards) of approved tools. If what you want to use isn’t there, you’ll need to ask [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure) first. New tools often create hard-to-anticipate security problems.


### PR DESCRIPTION
It is unclear if the spreadsheet is actively maintained (and if so, by whom) and the Insite IT standards link is hard to track down so I am replacing the google doc links with the Insite one.

If the Google doc is actively maintained, it would be great to note by whom so that people can easily follow up with questions. I will say that I _love_ the idea of having a list that doesn't require the VPN just to read it but it is also confusing to have two lists.