### PR TITLE
Update open source policy information

### DIFF
--- a/_pages/welcome-to-TTS/classes/intro-to-product-and-open-source.md
+++ b/_pages/welcome-to-TTS/classes/intro-to-product-and-open-source.md
@@ -39,7 +39,7 @@ The last 5-6 years have seen a slow but steady growth in the government in the o
 - Using other open source projects
 - Contributing and being involved in open source communities
 
-In 2016 the White House published a governmentwide open source policy, the [Federal Source Code Policy](https://sourcecode.cio.gov). We helped with that work and with the creation of [code.gov](https://www.code.gov), the accompanying code sharing platform. We have our own [strong open source policy](/open-source) and have also brought together in one place [many resources that agencies find useful](http://pages.18f.gov/open-source-program/).
+In 2016, the White House published a government-wide open source policy: the [Federal Source Code Policy](https://sourcecode.cio.gov). 18F helped with that work and with the creation of [code.gov](https://www.code.gov), the accompanying code sharing platform. We have our own [strong open source policy](/open-source) and have also brought together in one place [many resources that agencies find useful](http://pages.18f.gov/open-source-program/).
 
 Everything we as a team do should be public and available for collaboration. An open source project isn’t just code - think of it as many forms of contribution working together, including documentation, support, design, and code.
 

--- a/_pages/welcome-to-TTS/classes/intro-to-product-and-open-source.md
+++ b/_pages/welcome-to-TTS/classes/intro-to-product-and-open-source.md
@@ -39,7 +39,7 @@ The last 5-6 years have seen a slow but steady growth in the government in the o
 - Using other open source projects
 - Contributing and being involved in open source communities
 
-In 2016, the White House published a government-wide open source policy: the [Federal Source Code Policy](https://sourcecode.cio.gov). 18F helped with that work and with the creation of [code.gov](https://www.code.gov), the accompanying code sharing platform. We have our own [strong open source policy](/open-source) and have also brought together in one place [many resources that agencies find useful](https://pages.18f.gov/open-source-program/).
+In 2016, the White House published a government-wide open source policy: the [Federal Source Code Policy](https://sourcecode.cio.gov). 18F helped with that work and with the creation of [code.gov](https://www.code.gov), the accompanying code sharing platform. We have our own [strong open source policy](/open-source) and have also brought together in one place [many resources that agencies find useful](https://open-source-program.18f.gov/).
 
 Everything we as a team do should be public and available for collaboration. An open source project isn’t just code - think of it as many forms of contribution working together, including documentation, support, design, and code.
 

--- a/_pages/welcome-to-TTS/classes/intro-to-product-and-open-source.md
+++ b/_pages/welcome-to-TTS/classes/intro-to-product-and-open-source.md
@@ -39,7 +39,7 @@ The last 5-6 years have seen a slow but steady growth in the government in the o
 - Using other open source projects
 - Contributing and being involved in open source communities
 
-In 2016, the White House published a government-wide open source policy: the [Federal Source Code Policy](https://sourcecode.cio.gov). 18F helped with that work and with the creation of [code.gov](https://www.code.gov), the accompanying code sharing platform. We have our own [strong open source policy](/open-source) and have also brought together in one place [many resources that agencies find useful](http://pages.18f.gov/open-source-program/).
+In 2016, the White House published a government-wide open source policy: the [Federal Source Code Policy](https://sourcecode.cio.gov). 18F helped with that work and with the creation of [code.gov](https://www.code.gov), the accompanying code sharing platform. We have our own [strong open source policy](/open-source) and have also brought together in one place [many resources that agencies find useful](https://pages.18f.gov/open-source-program/).
 
 Everything we as a team do should be public and available for collaboration. An open source project isn’t just code - think of it as many forms of contribution working together, including documentation, support, design, and code.
 

--- a/_pages/welcome-to-TTS/classes/intro-to-product-and-open-source.md
+++ b/_pages/welcome-to-TTS/classes/intro-to-product-and-open-source.md
@@ -39,7 +39,7 @@ The last 5-6 years have seen a slow but steady growth in the government in the o
 - Using other open source projects
 - Contributing and being involved in open source communities
 
-The White House committed to publishing a government-wide open source policy this year, and the CTO Megan Smith&rsquo;s team is working on making that happen. We&rsquo;ve been doing our part by bringing together in one place [all of the resources that agencies find useful](http://pages.18f.gov/open-source-program/). Our team has also adopted a very strong [open source policy](/open-source).
+In 2016 the White House published a governmentwide open source policy, the [Federal Source Code Policy](https://sourcecode.cio.gov). We helped with that work and with the creation of [code.gov](https://www.code.gov), the accompanying code sharing platform. We have our own [strong open source policy](/open-source) and have also brought together in one place [many resources that agencies find useful](http://pages.18f.gov/open-source-program/).
 
 Everything we as a team do should be public and available for collaboration. An open source project isn’t just code - think of it as many forms of contribution working together, including documentation, support, design, and code.
 


### PR DESCRIPTION
This commit:
 * Adds a link to the Federal Source Code Policy and moves it from the future tense.
 * Adds a link to code.gov.
 * Proposes a few minor copy changes.

Fixes #716. (We may add something more specific about agencies' obligations under the Federal Source Code Policy, though.)