### PR TITLE
Update writing lab link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -130,7 +130,7 @@ navigation:
       url: working-groups-and-guilds-101/
       internal: true
     - text: Writing Lab
-      url: intro-to-writing-lab/
+      url: writing-lab/
       internal: true
 - text: About us
   blurb: |


### PR DESCRIPTION
I've made a small change to the filename for the writing lab page. Correcting the link here so that it's no longer broken.