### PR TITLE
Add Slack and email OOO provisions

### DIFF
--- a/_pages/policies/travel-and-leave-policies/leave.md
+++ b/_pages/policies/travel-and-leave-policies/leave.md
@@ -65,6 +65,8 @@ Before taking leave, be sure to:
 - Mark your out of office time on your calendar
 - Submit [correct Tock entries](#time-tracking)
 - Tell team members or partners via Slack or email, and make sure work is covered
+- Update your Slack username and profile (ex: `@username, OOO through 6/27`)
+- Set up an email autoresponder as appropriate
 - For 18F team members, update the [18F Out of Office Calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_bth7useo0eeiicjgos2di6ph8k%40group.calendar.google.com&ctz=America/Chicago)
 
 ### Annual leave

--- a/_pages/policies/travel-and-leave-policies/leave.md
+++ b/_pages/policies/travel-and-leave-policies/leave.md
@@ -68,7 +68,7 @@ Before taking leave, be sure to:
 - And, for 18F team members:
     - Submit [correct Tock entries](#time-tracking)
     - Update your Slack username and profile (ex: `@username, OOO through 6/27`)
-    - Update the [18F Out of Office Calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_bth7useo0eeiicjgos2di6ph8k%40group.calendar.google.com&ctz=America/Chicago)
+    - Update the [18F Out of Office Calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_bth7useo0eeiicjgos2di6ph8k%40group.calendar.google.com)
 
 ### Annual leave
 

--- a/_pages/policies/travel-and-leave-policies/leave.md
+++ b/_pages/policies/travel-and-leave-policies/leave.md
@@ -63,11 +63,12 @@ Before taking leave, be sure to:
 - Submit leave through [HR Links](https://corporateapps.gsa.gov/hr-links/)
 - Notify your Engagement Manager, Account Manager, or project lead
 - Mark your out of office time on your calendar
-- Submit [correct Tock entries](#time-tracking)
 - Tell team members or partners via Slack or email, and make sure work is covered
-- Update your Slack username and profile (ex: `@username, OOO through 6/27`)
 - Set up an email autoresponder as appropriate
-- For 18F team members, update the [18F Out of Office Calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_bth7useo0eeiicjgos2di6ph8k%40group.calendar.google.com&ctz=America/Chicago)
+- And, for 18F team members:
+    - Submit [correct Tock entries](#time-tracking)
+    - Update your Slack username and profile (ex: `@username, OOO through 6/27`)
+    - Update the [18F Out of Office Calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_bth7useo0eeiicjgos2di6ph8k%40group.calendar.google.com&ctz=America/Chicago)
 
 ### Annual leave
 


### PR DESCRIPTION
On the heels of #816, this PR adds a couple of suggestions that have been useful and common within 18F:
 * Temporarily update your Slack username and
 * Configure an email autoresponder