### PR TITLE
Adding in digital.gov communities feed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ gem 'jekyll', '~> 3.0.0'
 gem 'redcarpet'
 gem 'rouge'
 gem 'go_script'
+gem 'json'
+gem 'hash-joiner'
 
 group :jekyll_plugins do
   gem 'guides_style_18f'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,8 @@ GEM
       jekyll_pages_api_search
       rouge
       sass
+    hash-joiner (0.0.7)
+      safe_yaml
     html-proofer (3.8.0)
       activesupport (>= 4.2, < 6.0)
       addressable (~> 2.3)
@@ -54,6 +56,7 @@ GEM
     jekyll_pages_api_search (0.5.0)
       jekyll_pages_api (~> 0.1.4)
       sass (~> 3.4)
+    json (2.1.0)
     kramdown (1.16.2)
     liquid (3.0.6)
     listen (3.1.5)
@@ -92,8 +95,10 @@ PLATFORMS
 DEPENDENCIES
   go_script
   guides_style_18f
+  hash-joiner
   html-proofer
   jekyll (~> 3.0.0)
+  json
   redcarpet
   rouge
 

--- a/_config.yml
+++ b/_config.yml
@@ -66,6 +66,11 @@ jekyll_pages_api_search:
 generate_nodes: true
 flat_namespace: true
 
+jekyll_get:
+  - data: dgcommunities
+    json: 'https://digital.gov/communities/index.json'
+
+
 navigation:
 - text: Table of Contents
   internal: true

--- a/_includes/dg-communities.html
+++ b/_includes/dg-communities.html
@@ -1,0 +1,7 @@
+{{/* See this loop at:
+https://handbook.18f.gov/general-contacts-and-listservs/#digitalgov-communities */}}
+
+{% for item in site.data.dgcommunities.items %}
+  <h4>{{ item.title }}</h4>
+  <p><strong>About:</strong> {{ item.summary }} <a href="{{ item.url }}" title="{{ item.title }}"><strong>Join »</strong></a></p>
+{% endfor %}

--- a/_includes/dg-communities.html
+++ b/_includes/dg-communities.html
@@ -3,5 +3,5 @@ https://handbook.18f.gov/general-contacts-and-listservs/#digitalgov-communities 
 
 {% for item in site.data.dgcommunities.items %}
   <h4>{{ item.title }}</h4>
-  <p><strong>About:</strong> {{ item.summary }} <a href="{{ item.url }}" title="{{ item.title }}"><strong>Join »</strong></a></p>
+  <p><strong>About:</strong> {{ item.summary }} <a href="https://digital.gov{{ item.url }}" title="{{ item.title }}"><strong>Join »</strong></a></p>
 {% endfor %}

--- a/_includes/dg-communities.html
+++ b/_includes/dg-communities.html
@@ -3,5 +3,5 @@ https://handbook.18f.gov/general-contacts-and-listservs/#digitalgov-communities 
 
 {% for item in site.data.dgcommunities.items %}
   <h4>{{ item.title }}</h4>
-  <p><strong>About:</strong> {{ item.summary }} <a href="https://digital.gov{{ item.url }}" title="{{ item.title }}"><strong>Join »</strong></a></p>
+  <p>{{ item.summary }} <a href="https://digital.gov{{ item.url }}" title="{{ item.title }}"><strong>Join »</strong></a></p>
 {% endfor %}

--- a/_pages/about-us/general-contacts-and-listservs.md
+++ b/_pages/about-us/general-contacts-and-listservs.md
@@ -79,51 +79,14 @@ Information you might need for filling out GSA forms:
 
 There are a number of groups that are good for collaborating across government. If any of these topics interest you, consider joining &mdash; even if you prefer to lurk. (Consider [filtering messages like these](https://support.google.com/mail/answer/6579?hl=en) so they appear in their own Gmail label.)
 
-### DigitalGov communities
 
-DigitalGov [hosts several mailing list communities](http://www.digitalgov.gov/communities/) for people in the U.S. government, including the following:
+### Digital.gov communities
 
-#### Challenges and prizes community of practice
+Digital.gov [hosts several mailing list communities](http://digital.gov/communities/) for people in the U.S. government, including the following:
 
-**About:** Thinking about running a challenge and prize competition at your agency, but really want to talk to someone who has done it? Better yet, want to talk to somebody at your own agency, or someone who has run the same type of challenge you want to run?
 
-**To join:** [Instructions are here](https://www.digitalgov.gov/communities/challenges-prizes-community/).
+{% include dg-communities.html %}
 
-#### Customer experience community of practice
-
-**About:** The government Customer Experience Community of Practice (CX-COP) is an interagency group of customer experience practitioners, with over 500 members across 140 federal, state and local U.S. government offices and agencies.
-
-**To join:** [Instructions are here](http://www.digitalgov.gov/communities/customer-experience-community/).
-
-#### Mobile gov community of practice
-
-**About:** Mobile Gov Community of Practice members work across federal government to create anytime, anywhere government resources and solutions for today and tomorrow.
-
-**To join:** [Instructions are here](http://www.digitalgov.gov/communities/mobile/).
-
-#### Multilingual community of practice
-
-**About:** We are a group of federal, state, and local government content managers, formerly known as the Federal Multilingual Websites Committee, who are working to expand and improve digital content in languages other than English.
-
-**To join:** [Instructions are here](https://www.digitalgov.gov/communities/government-multilingual-websites-community/).
-
-#### Social media community of practice
-
-**About:** The Federal SocialGov Community unites digital managers and specialists at more than 160 agencies and offices in a collaborative program aimed at improving the creation, adoption and evaluation of digital engagement programs.
-
-**To Join:** Contact [Justin Herman (justin.herman@gsa.gov)](mailto:justin.herman@gsa.gov) with “Subscribe to #SocialGov” in the subject line of your email to subscribe to our listserv. Include your name and job title in the message body.
-
-#### User experience community of practice
-
-**About:** Connect with user experience practitioners from across the federal government and learn about UX events across the federal government.
-
-**To join:** [Instructions are here](https://digital.gov/communities/user-experience/).
-
-#### Web content managers forum
-
-**About:** The Web Content Managers listserv is open to content managers from any level of U.S. government: federal, state, local, and tribal. Since the purpose of this group is to exchange ideas amongst U.S. government Web practitioners, we do not admit contractors or other private individuals.
-
-**To join:** [Instructions are here](https://www.digitalgov.gov/communities/web-managers-forum/web-content-managers-listserv/).
 
 ### Other groups within the U.S. government
 
@@ -173,6 +136,6 @@ DigitalGov [hosts several mailing list communities](http://www.digitalgov.gov/co
 
 #### GSA Press Clips
 
-**About:** This is an internal GSA google group we set up to bring together the various press clips that are sent out by the Communications office.  
+**About:** This is an internal GSA google group we set up to bring together the various press clips that are sent out by the Communications office.
 
 **To join:** [Apply via Google Groups](https://groups.google.com/a/gsa.gov/forum/?hl=en#!forum/18f-clips).

--- a/_plugins/jekyll_get.rb
+++ b/_plugins/jekyll_get.rb
@@ -1,0 +1,40 @@
+require 'json'
+require 'hash-joiner'
+require 'open-uri'
+
+module Jekyll_Get
+  class Generator < Jekyll::Generator
+    safe true
+    priority :highest
+
+    def generate(site)
+      config = site.config['jekyll_get']
+      if !config
+        return
+      end
+      if !config.kind_of?(Array)
+        config = [config]
+      end
+      config.each do |d|
+        begin
+          target = site.data[d['data']]
+          source = JSON.load(open(d['json']))
+          if target
+            HashJoiner.deep_merge target, source
+          else
+            site.data[d['data']] = source
+          end
+          if d['cache']
+            data_source = (site.config['data_source'] || '_data')
+            path = "#{data_source}/#{d['data']}.json"
+            open(path, 'wb') do |file|
+              file << JSON.generate(site.data[d['data']])
+            end
+          end
+        rescue
+          next
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change inserts the list of digital.gov communities into the handbook via API.
It ensures that as this list of communities changes, that it always stays up to date on the TTS Handbook.

To install, I added in the `jekyll-get` plugin and installed two gems as dependencies.

**Current page:** https://handbook.18f.gov/general-contacts-and-listservs/#digitalgov-communities
**Preview:** https://federalist-proxy.app.cloud.gov/preview/18f/handbook/dg-communities-feed/general-contacts-and-listservs/#digitalgov-communities