### PR TITLE
Update OLU travel course name

### DIFF
--- a/_pages/policies/travel-and-leave-policies/first-time-travel-get-in-concur-start.md
+++ b/_pages/policies/travel-and-leave-policies/first-time-travel-get-in-concur-start.md
@@ -8,7 +8,7 @@ navtitle: First Time Travel Vendor ID
 
 In order to get access to concur, you need to obtain a vendor id. The process varies a bit depending on if you have access to GSA's online learning platform OLU.
 
-Have completed your Mandatory Cyber Security and Privacy Training in [OLU](https://gsaolu.gsa.gov/) yet?
+Have you completed your Mandatory Cyber Security and Privacy Training in [OLU](https://gsaolu.gsa.gov/) yet?
 
 [Yes - I have taken the OLU class. ](/first-time-travel-get-in-concur-post-olu)
 

--- a/_pages/policies/travel-and-leave-policies/first-time-travel-get-in-concur-start.md
+++ b/_pages/policies/travel-and-leave-policies/first-time-travel-get-in-concur-start.md
@@ -8,7 +8,11 @@ navtitle: First Time Travel Vendor ID
 
 In order to get access to concur, you need to obtain a vendor id. The process varies a bit depending on if you have access to GSA's online learning platform OLU.
 
+<<<<<<< HEAD
 Have you completed your Mandatory Cyber Security and Privacy Training in [OLU](https://gsaolu.gsa.gov/) yet?
+=======
+Have completed your Mandatory Cyber Security and Privacy Training in [OLU](https://gsaolu.gsa.gov/) yet?
+>>>>>>> Jacklynn-patch-1
 
 [Yes - I have taken the OLU class. ](/first-time-travel-get-in-concur-post-olu)
 

--- a/_pages/policies/travel-and-leave-policies/first-time-travel-get-in-concur-start.md
+++ b/_pages/policies/travel-and-leave-policies/first-time-travel-get-in-concur-start.md
@@ -8,7 +8,7 @@ navtitle: First Time Travel Vendor ID
 
 In order to get access to concur, you need to obtain a vendor id. The process varies a bit depending on if you have access to GSA's online learning platform OLU.
 
-Have completed your  IT Security Awareness Training and Privacy Act Training in [OLU](https://gsaolu.gsa.gov/) yet?
+Have completed your Mandatory Cyber Security and Privacy Training in [OLU](https://gsaolu.gsa.gov/) yet?
 
 [Yes - I have taken the OLU class. ](/first-time-travel-get-in-concur-post-olu)
 


### PR DESCRIPTION
Updated the OLU required course name to be more descriptive. They combined the IT Security Awareness Training and the privacy trainings into one course. The course name is *2018 Mandatory Cyber Security and Privacy Training* (I omitted the year in my change).