### PR TITLE
Fixing a conflict

### DIFF
--- a/_pages/about-us/general-contacts-and-listservs.md
+++ b/_pages/about-us/general-contacts-and-listservs.md
@@ -87,44 +87,6 @@ Digital.gov [hosts several mailing list communities](http://digital.gov/communit
 
 {% include dg-communities.html %}
 
-<<<<<<< HEAD
-#### Customer experience community of practice
-
-**About:** The government Customer Experience Community of Practice (CX-COP) is an interagency group of customer experience practitioners, with over 500 members across 140 federal, state and local U.S. government offices and agencies.
-
-**To join:** [Instructions are here](http://www.digitalgov.gov/communities/customer-experience-community/).
-
-#### Mobile gov community of practice
-
-**About:** Mobile Gov Community of Practice members work across federal government to create anytime, anywhere government resources and solutions for today and tomorrow.
-
-**To join:** [Instructions are here](http://www.digitalgov.gov/communities/mobile/).
-
-#### Multilingual community of practice
-
-**About:** We are a group of federal, state, and local government content managers, formerly known as the Federal Multilingual Websites Committee, who are working to expand and improve digital content in languages other than English.
-
-**To join:** [Instructions are here](https://www.digitalgov.gov/communities/government-multilingual-websites-community/).
-
-#### Social media community of practice
-
-**About:** The Federal SocialGov Community unites digital managers and specialists at more than 160 agencies and offices in a collaborative program aimed at improving the creation, adoption and evaluation of digital engagement programs.
-
-**To Join:** Email [SM-COP-subscribe-request@listserv.gsa.gov](mailto:SM-COP-subscribe-request@listserv.gsa.gov) with the subject line "SocialGov listserv".  
-
-#### User experience community of practice
-
-**About:** Connect with user experience practitioners from across the federal government and learn about UX events across the federal government.
-
-**To join:** [Instructions are here](https://digital.gov/communities/user-experience/).
-
-#### Web content managers forum
-
-**About:** The Web Content Managers listserv is open to content managers from any level of U.S. government: federal, state, local, and tribal. Since the purpose of this group is to exchange ideas amongst U.S. government Web practitioners, we do not admit contractors or other private individuals.
-
-**To join:** [Instructions are here](https://www.digitalgov.gov/communities/web-managers-forum/web-content-managers-listserv/).
-=======
->>>>>>> master
 
 ### Other groups within the U.S. government
 


### PR DESCRIPTION

There is a conflict on this page: https://handbook.18f.gov/general-contacts-and-listservs/#heading-36
`«««< HEAD #### Customer experience community of practice`
This change removes the conflicting text.
