### PR TITLE
Change redirect to current mission statement

### DIFF
--- a/_pages/about-us/mission.md
+++ b/_pages/about-us/mission.md
@@ -1,5 +1,5 @@
 ---
 title: Mission
-url: https://github.com/18F/core-values/blob/mission-vision/pages/vision-mission.md#mission
+url: https://18f.gsa.gov/about/#our-mission
 layout: redirect
 ---


### PR DESCRIPTION
Changes redirect for the Mission page to the mission statement on the 18F site about page. The current link is to an old, private repo. 