### PR TITLE
Remove #dc-lunch-club from the Washington, DC office guide.

### DIFF
--- a/_pages/about-us/offices/washington-dc.md
+++ b/_pages/about-us/offices/washington-dc.md
@@ -24,7 +24,7 @@ title: Washington, D.C.
           <strong>Slack&nbsp;channels</strong>
         </td>
         <td class="col-value">
-          <a href="https://gsa-tts.slack.com/messages/dc/">#dc</a>, <a href="https://gsa-tts.slack.com/messages/dc-lunchbell/">#dc-lunchbell</a>, <a href="https://gsa-tts.slack.com/messages/dc-lunch-club/">#dc-lunch-club</a>, <a href="https://gsa-tts.slack.com/messages/dc-snack-inventory/">#dc-snack-inventory</a>
+          <a href="https://gsa-tts.slack.com/messages/dc/">#dc</a>, <a href="https://gsa-tts.slack.com/messages/dc-lunchbell/">#dc-lunchbell</a>, <a href="https://gsa-tts.slack.com/messages/dc-snack-inventory/">#dc-snack-inventory</a>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
The channel was archived March 6, 2017, and the last message at the time was April 26, 2016.