### PR TITLE
Updated SF wi-fi instructions

### DIFF
--- a/_pages/about-us/offices/san-francisco.md
+++ b/_pages/about-us/offices/san-francisco.md
@@ -160,7 +160,7 @@ Refer to [our printer information document](https://docs.google.com/document/d/1
 
 ### Get on the wireless?
 
-The Wi-Fi network is "gsa-wireless". For type of security choose "WPA2 Enterprise" and enter your ENT username and password.
+The Wi-Fi network is "gsa-wireless". For type of security, choose "WPA2 Enterprise" and enter your ENT username and password.
 
 The guest Wi-Fi network is "GSA-Guest". The password changes monthly. To get the current password, type “GSA Wireless” into any room on Slack (eg. in a DM to yourself) and the current password will pop up.
 

--- a/_pages/about-us/offices/san-francisco.md
+++ b/_pages/about-us/offices/san-francisco.md
@@ -160,9 +160,9 @@ Refer to [our printer information document](https://docs.google.com/document/d/1
 
 ### Get on the wireless?
 
-The guest Wi-Fi network is GSA Guest. The password changes monthly. To get the current password, type “GSA Wireless” into any room on Slack and the current password will pop up.
+The Wi-Fi network is "gsa-wireless". For type of security choose "WPA2 Enterprise" and enter your ENT username and password.
 
-Non-guest wireless access is available using gsa-wireless and authenticating using your ENT username and password.
+The guest Wi-Fi network is "GSA-Guest". The password changes monthly. To get the current password, type “GSA Wireless” into any room on Slack (eg. in a DM to yourself) and the current password will pop up.
 
 ### Access GSA websites from inside the building?
 


### PR DESCRIPTION
Updated so that wi-fi info for SF folks comes first, guest info second; added security info for the former (choosing WPA2 Enterprise).