### PR TITLE
Update to Office of Acquisition

### DIFF
--- a/_pages/about-us/teams/oa
+++ b/_pages/about-us/teams/oa
@@ -1,8 +1,8 @@
 ---
-title: Acquisition (aka AcqStack)
+title: Office of Acquisition
 ---
 
-Welcome to Acqstack’s team page!
+Welcome to OA’s team page!
 
 ## Our Vision
 
@@ -38,7 +38,7 @@ If your procurement need costs less than the micro-purchase threshold ($10,000) 
 
 If you’re looking to have the TTS Office of Acquisition (OA) procure anything over the micro-purchase threshold ($10,000), please fill out the [Intake Form](https://docs.google.com/forms/d/1bSoFcljv-hmUJsSCK04AsdIh03hor_T4m1yjopild6w/edit). As a prerequisite to submitting the form, please notify your team director of your request. Once the OA receives and processes your request form, we will contact you within 3 business days to discuss next steps.
 
-Have questions? Find us in Slack at [#acquisition](https://gsa-tts.slack.com/messages/acquisition)
+Have questions? Find us in Slack at [#tts-oa-internalbuy](https://gsa-tts.slack.com/messages/CD4F3TGB1/)
 
 ## TTS Office of Acquisition Operational Guidance
 TTS OA aims to redefine the culture of government acquisition of information technology by bringing agile practices to service level procurement policies. [TTS OA Operational Guidance](/acquisition-guidance), which includes standard operating procedures, #readme’s, templates, checklists and other operational guidance documents, were established to keep TTS procurement practices agile, current, applicable and in compliance at the Federal, Agency and Service levels. 
@@ -47,4 +47,4 @@ TTS OA aims to redefine the culture of government acquisition of information tec
 
 #### Still have questions?
 
-Ask in Slack: [#acquisition](https://gsa-tts.slack.com/messages/acquisition)
+Ask in Slack: [#tts-oa-internalbuy](https://gsa-tts.slack.com/messages/acquisition)


### PR DESCRIPTION
Change the name to Office fo Acquisition and change some of the links to match the new OA Slack page. The link name needs to change to https://handbook.18f.gov/oa