### PR TITLE
Update the Provisioning Section

### DIFF
--- a/_pages/how-we-work/software.md
+++ b/_pages/how-we-work/software.md
@@ -148,7 +148,6 @@ Here’s what will happen behind the scenes:
 
 #### Software we already own
 
-Software, domains, and SSLs currently managed by OPP are being migrated into the [TTS software library](https://docs.google.com/spreadsheets/d/1KhPN9gmDJYjp0sqQA3_OFto45MzlqGkb1R2YDKedpC8/edit#gid=164775379) over the next month. New requests for software that is in the library may be made via email to [tts-software@gsa.gov](mailto:tts-software@gsa.gov) or Slack message in #tts-oa-internalbuy. A license for software currently in the TTS Software Library will generally be provided to you within 1-2 business days.
 
 #### Software we need to acquire more of
 


### PR DESCRIPTION
The Software we already own section is out of date. the linked spreadsheet is marked as deprecated when you click on it, so it is providing the wrong information about what we have access to. In addition, it says "managed by OPP" and I think the products are managed by TTS OA, but I guess that's a question for @estherkpraske . cc @melanienleopold @annepetersen maybe others? Not sure who can provide the accurate update, but use of this spreadsheet has caused a one month delay for my current team.

The inaccurate language is: 
"Software, domains, and SSLs currently managed by OPP are being migrated into the [TTS software library](https://docs.google.com/spreadsheets/d/1KhPN9gmDJYjp0sqQA3_OFto45MzlqGkb1R2YDKedpC8/edit#gid=164775379) over the next month. New requests for software that is in the library may be made via email to [tts-software@gsa.gov](mailto:tts-software@gsa.gov) or Slack message in #tts-oa-internalbuy. A license for software currently in the TTS Software Library will generally be provided to you within 1-2 business days."