### PR TITLE
updated link to service now

### DIFF
--- a/_pages/how-we-work/tools/anyconnect.md
+++ b/_pages/how-we-work/tools/anyconnect.md
@@ -6,7 +6,7 @@ AnyConnect is a VPN client that we use to connect to GSA's intranet.
 
 ## Setup
 
-1. Download [AnyConnect](https://drive.google.com/open?id=0B4CdALyekcYXOWNaeVRSZy05TXM) and launch the installer.
+1. Download AnyConnect via [ServiceNow](https://gsa.service-now.com/sp?id=sc_cat_item&sys_id=1bfdfdca78d3a400ce3ddff91a64940b&sysparm_category=b628125b7cec0100a6e757fe35f45fb8) and launch the installer.
 2. Follow the prompts to install the VPN client.
 3. Install only the following components:
       * VPN


### PR DESCRIPTION
The google drive link is deprecated. Per GSA, we are supposed to request it from ServiceNow.