### PR TITLE
Add nested heading structure to index

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -150,6 +150,7 @@ navigation:
       - text: Washington, D.C. Office
         url: washington-dc/
         internal: true
+
     - text: Travel and Leave
       url: travel-and-leave/
       internal: true

--- a/_includes/nav-item.html
+++ b/_includes/nav-item.html
@@ -1,0 +1,18 @@
+{% if include.children.size > 0 %}
+<ol class="toc-nav-children toc-nav-children-level-{{ include.heading_level }}">
+  {% assign heading = "h" | append: include.heading_level %}
+  {% for child in include.children %}
+    <li id="{{ child.text | slugify }}" class="toc-nav-child-with-children {{ child.text | slugify }}">
+    {% if child.children != nil %}
+      <{{ heading }}>
+        {{ child.text }}
+      </{{ heading }}>
+      {% assign next_level = include.heading_level | plus: 1 %}
+      {% include nav-item.html children=child.children heading_level=next_level %}
+      {% else %}
+        <a href="{% if child.internal %}{{ site.baseurl }}/{% endif %}{{ child.url }}">{{ child.text }}</a>
+      {% endif %}
+    </li>
+  {% endfor %}
+</ol>
+{% endif %}

--- a/_includes/nav-item.html
+++ b/_includes/nav-item.html
@@ -1,18 +1,5 @@
-{% if include.children.size > 0 %}
-<ol class="toc-nav-children toc-nav-children-level-{{ include.heading_level }}">
-  {% assign heading = "h" | append: include.heading_level %}
-  {% for child in include.children %}
-    <li id="{{ child.text | slugify }}" class="toc-nav-child-with-children {{ child.text | slugify }}">
-    {% if child.children != nil %}
-      <{{ heading }}>
-        {{ child.text }}
-      </{{ heading }}>
-      {% assign next_level = include.heading_level | plus: 1 %}
-      {% include nav-item.html children=child.children heading_level=next_level %}
-      {% else %}
-        <a href="{% if child.internal %}{{ site.baseurl }}/{% endif %}{{ child.url }}">{{ child.text }}</a>
-      {% endif %}
+    <li id="{{ include.child.text | slugify }}" class="{{ include.child.text | slugify }}">
+        <a href="{% if include.child.internal %}{{ site.baseurl }}/{% endif %}{{ include.child.url }}">
+          {{ include.child.text }}
+        </a>
     </li>
-  {% endfor %}
-</ol>
-{% endif %}

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -26,9 +26,11 @@ layout: null
             {% if nav.blurb %}<p>{{ nav.blurb }}</p>{% endif %}
 
             {% unless nav.children == nil %}
+            {% include nav-item.html children=nav.children heading_level=2 %}
               <ol class="toc-nav-children">
                 {% for child in nav.children %}
                   {% if child.children != nil %}
+                  {% assign children = child.children %}
                   <li id="{{ child.text | slugify }}" class="toc-nav-child-with-children {{ child.text | slugify }}">
                     {{ child.text }}
                     <ol class="toc-nav-grandchildren">

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -18,39 +18,55 @@ layout: null
     <main id="main" role="main">
       <div class="wrapper">
 
-      <ol>
+        <ol>
         {% for nav in site.navigation %}
-          {% if nav.url == nil %}{% continue %}{% endif %}
+        {% if nav.url == nil %}{% continue %}{% endif %}
           <li>
             <h1 id="{{ nav.url | remove:"/" }}">{{ nav.text }}</h1>
             {% if nav.blurb %}<p>{{ nav.blurb }}</p>{% endif %}
 
             {% unless nav.children == nil %}
-            {% include nav-item.html children=nav.children heading_level=2 %}
-              <ol class="toc-nav-children">
-                {% for child in nav.children %}
-                  {% if child.children != nil %}
-                  {% assign children = child.children %}
-                  <li id="{{ child.text | slugify }}" class="toc-nav-child-with-children {{ child.text | slugify }}">
-                    {{ child.text }}
-                    <ol class="toc-nav-grandchildren">
-                      {% for grandchild in child.children %}
-                        <li class="{{ grandchild.text | slugify }}">
-                          <a href="{% if grandchild.internal %}{{ site.baseurl }}/{% endif %}{{ grandchild.url }}">{{ grandchild.text }}</a>
-                        </li>
-                      {% endfor %}
+            {% for child in nav.children %}
+              <h2>{{ child.text }}</h2>
+              {% if child.children.size > 0 %}
+              <ol class="toc-nav-children-level-3">
+              {% for child in child.children %}
+                {% if child.children.size > 0 %}
+                <h3>{{ child.text }}</h3>
+                <ol class="toc-nav-children-level-4">
+                {% for child in child.children %}
+                  {% if child.children.size > 0 %}
+                    <h4>{{ child.text }}</h4>
+                    <ol class="toc-nav-children-level-5">
+                    {% for child in child.children %}
+                      {% if child.children.size > 0 %}
+                        <h5>{{ child.text }}</h5>
+                        <ol class="toc-nav-children-level-6">
+                        {% for child in child.children %}
+                          {% include nav-item.html child=child %}
+                        {% endfor %}
+                        </ol>
+                      {% else %}
+                        {% include nav-item.html child=child %}
+                      {% endif %}
+                    {% endfor %}
                     </ol>
                   {% else %}
-                  <li class="{{ child.text | slugify }}">
-                    <a href="{% if child.internal %}{{ site.baseurl }}/{% endif %}{{ child.url }}">{{ child.text }}</a>
+                    {% include nav-item.html child=child %}
                   {% endif %}
-                  </li>
                 {% endfor %}
+                </ol>
+                {% else %}
+                  {% include nav-item.html child=child %}
+                {% endif %}
+              {% endfor %}
               </ol>
+              {% endif %}
+            {% endfor %}
             {% endunless %}
           </li>
         {% endfor %}
-      </ol>
+        </ol>
       </div>
     </main>
     {% include site-footer.html %}

--- a/stylesheets/screen.css
+++ b/stylesheets/screen.css
@@ -1212,3 +1212,29 @@ a[id]{
 /* @end */
 
 /* @end */
+
+
+h1 {
+  color: darkblue;
+  font-size: 3rem;
+}
+
+h2 {
+  color: blue;
+  font-size: 2.5rem;
+}
+
+h3 {
+  color: royalblue;
+  font-size: 2rem;
+}
+
+h4 {
+  color: deepskyblue;
+  font-size: 1.5rem;
+}
+
+h5 {
+  color: lightskyblue;
+  font-size: 1.3rem;
+}

--- a/stylesheets/screen.css
+++ b/stylesheets/screen.css
@@ -1046,6 +1046,22 @@ a[id]{
 	padding-top: 0.6em;
 }
 
+.toc-nav-children-level-3 {
+  padding-left: 1rem;
+}
+
+.toc-nav-children-level-4 {
+  padding-left: 2rem;
+}
+
+.toc-nav-children-level-5 {
+  padding-left: 3rem;
+}
+
+.toc-nav-children-level-6 {
+  padding-left: 4rem;
+}
+
 .layout-table-of-contents .wrapper ol li.policies{
 	padding-bottom: 1em;
 }
@@ -1212,29 +1228,3 @@ a[id]{
 /* @end */
 
 /* @end */
-
-
-h1 {
-  color: darkblue;
-  font-size: 3rem;
-}
-
-h2 {
-  color: blue;
-  font-size: 2.5rem;
-}
-
-h3 {
-  color: royalblue;
-  font-size: 2rem;
-}
-
-h4 {
-  color: deepskyblue;
-  font-size: 1.5rem;
-}
-
-h5 {
-  color: lightskyblue;
-  font-size: 1.3rem;
-}


### PR DESCRIPTION
The current approach of headings is hardcoded, checking only for children and grandchildren. There are cases where we have more nesting than that, so I thought it made sense to create a recursive template. However, I couldn't figure out how to get Jekyll to "remember" which level of indentation it should return to (for example, a top-level item might have great-grandchildren, and by the time the engine is done rendering the great-grandchildren, it doesn't reliably return to the right heading level for the top-level item). So the approach I took was not very DRY, but it is predictable and repeatable.

Currently looks pretty blah:
<img width="695" alt="screen shot 2019-01-15 at 9 57 39 pm" src="https://user-images.githubusercontent.com/509309/51227238-9f0b4d80-1910-11e9-839a-3161b0b860a0.png">
