### PR TITLE
Add Chrome extensions to Software page.

### DIFF
--- a/_pages/how-we-work/software.md
+++ b/_pages/how-we-work/software.md
@@ -61,6 +61,10 @@ The good news? You don’t have to worry about FITARA! The TTS SaaS PM and TTS O
 
 Once all of the attachments are in C2, the TTS Saas PM will contact you to set up a meeting to purchase your software! Make sure you reached out to the finance team (ASF or FCSF) for the correct accounting code if it is not already provided in the request. 
 
+## Chrome extensions
+
+Only use browser extensions approved by GSA IT. See [IT Service Catalog: Google Chrome Extension Request](https://insite.gsa.gov/topics/information-technology/assistance-and-help-desks/service-catalog/it-service-catalog-google-chrome-extension-request?term=google%20extensions) for the list of approved or rejected extensions, as well as how to request approval for a new extension.
+
 ## Contacts
 
 **TTS SaaS Project Manager:** Melanie Leopold [melanie.leopold@gsa.gov](mailto:melanie.leopold@gsa.gov)  


### PR DESCRIPTION
A follow-up to @melanienleopold’s [comment](https://github.com/18F/handbook/pull/1019#issuecomment-456803796) mentioning this was not intentionally removed, this page is what @lauraGgit was directed towards [yesterday in Slack](https://gsa-tts.slack.com/archives/CBY8D3M6E/p1548174064114300).

Thanks for keeping the handbook up-to-date, @melanienleopold! Sorry I ignored you in [the Slack thread yesterday](https://gsa-tts.slack.com/archives/C03EMDS6P/p1548173312171300), I was doing too many things at once. 🙈 My bad!