### PR TITLE
Update Chicago mailing address

### DIFF
--- a/_pages/about-us/offices/chicago.md
+++ b/_pages/about-us/offices/chicago.md
@@ -15,7 +15,7 @@ title: Chicago
       <tr>
         <td class="col-key"><strong>Point of contact</strong></td>
         <td class="col-value">
-        <a href="https://gsa-tts.slack.com/messages/@eth/">Ethan Heppner</a> 
+        <a href="https://gsa-tts.slack.com/messages/@eth/">Ethan Heppner</a>
         </td>
       </tr>
       <tr>
@@ -32,7 +32,7 @@ title: Chicago
         </td>
         <td class="col-value">
            230 S Dearborn, on the corner of Jackson and Dearborn streets, is also known as the <a href="http://www.gsa.gov/portal/content/101886">John C. Kluzinscki Federal building</a>, or <em>JCK</em>. It is right between the famous <a href="https://en.wikipedia.org/wiki/Flamingo_(sculpture)">Calder Flamingo sculpture</a> and the historic Monadnock Building. The Regional Administrator is Brad Hansher.<br /><br />
-       TTS's office is in the south side of the 33rd floor (note that our mailing address is Suite #3500 but our office is on 33).
+       TTS's office is in the south side of the 33rd floor.
         </td>
       </tr>
       <tr>
@@ -85,7 +85,7 @@ Fingerprints and badge can be done at the security office on the second floor (R
 
 ### <a id="enter-the-building-with-badge"></a>Enter the building with a GSA badge
 
-Your GSA ID grants you access to the building at any time between 7 a.m. and 6 p.m. After-hours access is allowed, but you will have to log your name in a guestbook. The gates are located by the elevator banks on the south side of the building. 
+Your GSA ID grants you access to the building at any time between 7 a.m. and 6 p.m. After-hours access is allowed, but you will have to log your name in a guestbook. The gates are located by the elevator banks on the south side of the building.
 
 ### <a id="onboarding"></a>Attend onboarding?
 
@@ -134,7 +134,7 @@ Refer to [our printer information document](https://docs.google.com/document/d/1
 
 ### <a id="transit-subsidy"></a>Transit subsidy
 
-All GSA employees are eligible for transit subsidies which cover the cost of your Metro travel. 
+All GSA employees are eligible for transit subsidies which cover the cost of your Metro travel.
 
 See the [Transit Benefit](/transit-benefit) page for information on enrollment and deactivation.  This [page on InSite](https://insite.gsa.gov/portal/content/500219) has additional information.
 


### PR DESCRIPTION
# What 

List Chicago mailing address as simply 33rd floor, remove reference to Suite 3500.

# Why

I ran into a bit of an issue the other week picking up a shipment of 🌈 stickers ... I listed the address at 3500 and the shipment ended up in a FAS mailroom on the 35th floor, and eventually a FAS storage room on that floor... I was expecting them to go to the mail center on 33.

I talked to Lee in the mail center on our floor (33), he said that simply writing "33rd floor" will get mail to the mail center on 33, including FedEx, USPS, and UPS.

Note that this is based on my own experiences and conversations so far, there may be other 📫 related information or circumstances I'm not aware of... 

Pinging you @ethanheppner for review when you're feeling better. 🤒 💟

# Note 

My Sublime settings auto-introduced some whitespace changes here.