### PR TITLE
Removing links to Mandrill and MailChimp pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -267,12 +267,6 @@ navigation:
       - text: Microsoft Office for OS X
         url: gsa-internal-tools/#get-a-copy-of-microsoft-office
         internal: true
-      - text: MailChimp
-        url: mailchimp/
-        internal: true
-      - text: Mandrill
-        url: mandrill/
-        internal: true
       - text: Mural.ly
         url: murally/
         internal: true


### PR DESCRIPTION
Because they're tools we're moving away from/no longer using.