### PR TITLE
Run HTML proofer in CI instead of through the go_script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
 
       - run:
           name: install dependencies
-          command: bundle install --jobs=4 --retry=3 --path vendor/bundle
+          command: bundle install --jobs=4 --retry=3
 
       - run:
           name: build that site

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,10 @@ jobs:
           command: bundle install --jobs=4 --retry=3 --path vendor/bundle
 
       - run:
+          name: install html-proofer
+          command: gem install html-proofer
+
+      - run:
           name: htmlproofer
           command: htmlproofer
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
 
       - run:
           name: htmlproofer
-          command: htmlproofer ./_site
+          command: htmlproofer ./_site htmlproofer --disable-external
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,10 @@ jobs:
           command: bundle install --jobs=4 --retry=3 --path vendor/bundle
 
       - run:
+          name: build that site
+          command: jekyll build
+
+      - run:
           name: install html-proofer
           command: gem install html-proofer
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
 
       - run:
           name: htmlproofer
-          command: htmlproofer
+          command: htmlproofer ./_site
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,12 +16,16 @@ jobs:
           - v2-dependencies-{{ checksum "Gemfile.lock" }}
           # fallback to using the latest cache if no exact match is found
           - v2-dependencies-
+
       - run:
           name: install dependencies
           command: bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+      - run:
+          name: htmlproofer
+          command: htmlproofer
+
       - save_cache:
           paths:
             - ./vendor/bundle
           key: v2-dependencies-{{ checksum "Gemfile.lock" }}
-
-      - run: ./go ci_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           command: bundle install --jobs=4 --retry=3
 
       - run:
-          name: build that site
+          name: build site
           command: jekyll build
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
 
       - run:
           name: build site
-          command: jekyll build
+          command: bundle exec jekyll build
 
       - run:
           name: install html-proofer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,10 +31,6 @@ jobs:
           command: bundle exec jekyll build
 
       - run:
-          name: install html-proofer
-          command: gem install html-proofer
-
-      - run:
           name: htmlproofer
-          command: htmlproofer ./_site htmlproofer --disable-external
+          command: bundle exec htmlproofer ./_site htmlproofer --disable-external
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,12 @@ jobs:
 
       - run:
           name: install dependencies
-          command: bundle install --jobs=4 --retry=3
+          command: bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v2-dependencies-{{ checksum "Gemfile.lock" }}
 
       - run:
           name: build site
@@ -33,7 +38,3 @@ jobs:
           name: htmlproofer
           command: htmlproofer ./_site htmlproofer --disable-external
 
-      - save_cache:
-          paths:
-            - ./vendor/bundle
-          key: v2-dependencies-{{ checksum "Gemfile.lock" }}

--- a/go
+++ b/go
@@ -50,15 +50,4 @@ def_command :build, 'Build the site' do |args|
   build_jekyll args
 end
 
-def_command :ci_build, 'Run the CI tests' do |args|
-  build_jekyll
-  require 'html-proofer'
-  HTMLProofer.check_directory('./_site',
-    disable_external: true,
-    url_ignore: [
-      /group\.calendar\.google\.com/
-    ]
-  ).run
-end
-
 execute_command ARGV


### PR DESCRIPTION
# Why?

As a developer, if you notice that continuous integration is failing (#1052), one of the first places to check is the CI config: in this case, `.circleci/config.yml`. 

The current setup introduces indirection — html proofing isn't directly described in  `.circleci/config.yml`, but rather through the go script. Moving the functionality to the CI config will make errors easier to trace.

Additionally, the go script library is read-only and hasn't been updated in 3 years at this point (https://github.com/18F/go_script). Factoring html proofing out of the go script is a step towards incrementally removing it. 

To quote @tbaxter-18f: "every dependency should be in a perennial mortal struggle for it's continued existence."