### PR TITLE
Update Acquisition Page with 18F Acquisition

### DIFF
--- a/_pages/about-us/teams/acqstack.md
+++ b/_pages/about-us/teams/acqstack.md
@@ -10,29 +10,29 @@ title: Acquisition
 
 Welcome to the 18F Acquisition Chapter — we’re happy you’re here! We’ve compiled some information to help you get started.  We’ll update this guide as we receive feedback, so don’t be shy to share your thoughts. 
 
-### Who We Are
+### Who we are
 
 Members of the Acquisition team come from all over: inside GSA, consulting firms, peace corps, and other government agencies. Collectively, we work as the acquisition part of the overall 18F cross-functional team bringing our expertise to help agency partners (experts in their mission) produce more effective procurement strategies, implement modern procurement practices, and better vendor outcomes. We’re experienced in a wide variety of procurements and have tons of stories of procurements that have gone well and some that haven’t.  Ask us!
 
-### Our Vision & Mission
+### Our vision & mission
 
 The Acquisition Chapter exists to prove that government acquisitions can be joyful for our employees, agency partners, and industry partners. We do this, by ensuring that informed buyers can easily and confidently access the right products and services to meet their agency’s  mission. No matter what the agency partner is undertaking or trying to solve, the acquisition process will be unavoidable and it can be used as an amazing point for leverage to improve overall outcomes.
 
 As a team, we are dedicated to bringing an agile, human centered, and cross-functional approach to procurements that will better prepare our partners to work with modern vendor teams iteratively; developing open source software products to help agencies achieve their mission.
 
-### Our Value Proposition
+### Our value proposition
 
 18F Acquisition Consulting helps agencies buy digital services in a way that reduces risk and provides value to end-users more rapidly than traditional methods.
 We seek to design and evangelize acquisition approaches that are better aligned with current industry practices to ensure the successful delivery of digital products and services that truly meet the needs of our agency partners and the people they serve.
 
-### Our Principles
+### Our principles
 
 * Use **human-centered design** to focus on software that meets actual people's needs/
 * Leverage **open-source software**, and select modern tech stacks to ensure long-term sustainability.
 * Utilize **product thinking** to prioritize, focus work, and deliver demonstrable value.
 * Structure contracts to **support modularity, lower costs, increase quality, and avoid vendor lock-in.**
 * Ensure that **agile development methodologies** are employed to deliver working code sooner.
-* **Communicate clearly** about methods, lessons-learned, and recommendations.
+* **Communicate clearly** about methods, lessons learned, and recommendations.
 
 ### What We Do
 
@@ -48,18 +48,18 @@ In pursuit of this strategy, we:
 
 ### How we communicate
 
-The majority of our conversations take place on Slack and video.  There are a number of slack channels for acquisition discussions. 
+The majority of our conversations take place on Slack and video.  There are a number of Slack channels for acquisition discussions. 
 
-Team meetings are generally over google hangouts and zoom. If you would like your own zoom account, hop on over to [#admins-zoom](https://gsa-tts.slack.com/messages/admins-zoom/) to request one.
+Team meetings are generally over Google Hangouts and Zoom. If you would like your own zoom account, hop on over to [#admins-zoom](https://gsa-tts.slack.com/messages/admins-zoom/) to request one.
 
 ### Stuff to do, sign, and read
 
 #### Do
 
-##### Acquisition Training 
+##### Acquisition training 
 
-[On boarding Training for COs](https://docs.google.com/document/d/1rQYUP1ARL0OnxUD5FNHKmt-ExiFWxSVeE6lHmKaMvxE/edit)
-[Acquisition Training for non 1102s](https://docs.google.com/document/d/1xmRsU4_07fvEyPaWmwBMNtpw4saT4gGSMMH6S97MxAs/edit)
+[On boarding Training for Contracting Officers](https://docs.google.com/document/d/1rQYUP1ARL0OnxUD5FNHKmt-ExiFWxSVeE6lHmKaMvxE/edit)
+[Acquisition Training for non-1102s (non-contracting specialists)](https://docs.google.com/document/d/1xmRsU4_07fvEyPaWmwBMNtpw4saT4gGSMMH6S97MxAs/edit)
 
 #### Sign
 
@@ -97,7 +97,7 @@ These are a couple of suggested reading materials meant to give you a better sen
 * **Start small and build.** It can be overwhelming starting a new project with an excited partner. Encourage them to focus on one piece of functionality to deliver to users. This is your starting point. Trying to deliver an entire end-to-end system is likely to stall the project due to lack of focus. You will also encounter the same principles and practices on a small project that would be applied to a far larger one. Don’t try to win a marathon before you’ve learned to run in the first place.
 * **Retros are your friend.** Recognize that there isn’t a one-size-fits-all approach to procurement or product development and it’s necessary to meet the agency partner where they are.  Allow for incremental learning over time. Ensure that these are blameless spaces, because without transparent and honest communication the dynamics will slowly fester and create the kinds of legacy environments that can stymie progress at the partner agencies.
 
-#### Situational Awareness
+#### Situational awareness
 
 * **Build your empathy muscle.** Take time to understand the problem space, past challenges, and the goals of the product team. 
 * **Product owners are key to success.** Be wary of starting post-procurement work with an agency partner if there is no empowered, dedicated product owner to lead the work.

--- a/_pages/about-us/teams/acqstack.md
+++ b/_pages/about-us/teams/acqstack.md
@@ -50,7 +50,7 @@ In pursuit of this strategy, we:
 
 The majority of our conversations take place on Slack and video.  There are a number of Slack channels for acquisition discussions. 
 
-Team meetings are generally over Google Hangouts and Zoom. If you would like your own zoom account, hop on over to [#admins-zoom](https://gsa-tts.slack.com/messages/admins-zoom/) to request one.
+Team meetings are generally over Google Hangouts and Zoom. If you would like your own Zoom account, hop on over to [#admins-zoom](https://gsa-tts.slack.com/messages/admins-zoom/) to request one.
 
 ### Stuff to do, sign, and read
 

--- a/_pages/about-us/teams/acqstack.md
+++ b/_pages/about-us/teams/acqstack.md
@@ -1,48 +1,118 @@
 ---
-title: Acquisition (aka AcqStack)
+title: Acquisition
 ---
 
-Welcome to Acqstack’s team page!
+# Welcome to the Acquisition Chapter
 
-## Our Vision
+## *Making Procurement Joyful*
 
-The TTS Office of Acquisition (OA) exists to prove that government contracting can be joyful for our employees, customers, and industry partners, by ensuring that informed buyers can easily and confidently access the right products and services to meet the customer’s mission.
+## Welcome!
 
-## Our Mission
+Welcome to the 18F Acquisition Chapter — we’re happy you’re here! We’ve compiled some information to help you get started.  We’ll update this guide as we receive feedback, so don’t be shy to share your thoughts. 
 
-We seek to design and evangelize acquisition approaches that are better aligned with current industry practices to ensure the successful delivery of technology products and services that truly meet the needs of our agency partners and the people they serve.
+### Who We Are
 
-## Our Values
-- **Start small and iterate.** In both our own work and the work we help acquire from vendors, we believe that starting small, getting feedback, and continuously iterating and improving over time yields exponentially better results than planning a large effort out in advance and executing in one fell swoop.
-- **Question the status quo.** To support our partners in achieving the best possible results in their technology acquisitions, we sometimes have to ask them to step outside of what may be standard procedure in their agency. While we may push the boundaries of “norms” and “practices,” we always maintain legal integrity and compliance with the FAR in all of our work.
-- **Work in cross-functional teams.** Including diverse expertise in the process from the very beginning is key to a successful acquisition. That’s why we work in cross-functional teams representing design, technical, product and procurement expertise from day one on each of our projects, and encourage our partners to do the same.
-- **Focus on the user need.** We believe that happy users are the sign of great digital services, so we engage with end-users early and often to make sure that our procurements and products address their needs.
-- **Treat all parties in the process with empathy.** We work collaboratively with our agency partners, vendors, and the rest of TTS to achieve our mission. As such, we approach each of these stakeholders with the same empathy and open-mindedness as we do the end-users of the products and services we procure.
-- **Work in the open.** We believe transparency, accountability and collaboration ultimately result in better-quality products and services. We are committed to opening up our process and our source code as much a possible, and encourage our partners and vendors to do the same.
-- **Continuously improve.** Our work is never done - there is always room to improve. We conduct regular retrospectives on our projects, with our team, and with our partners and vendors to continuously improve our methods and practices over time.
+Members of the Acquisition team come from all over: inside GSA, consulting firms, peace corps, and other government agencies. Collectively, we work as the acquisition part of the overall 18F cross-functional team bringing our expertise to help agency partners (experts in their mission) produce more effective procurement strategies, implement modern procurement practices, and better vendor outcomes. We’re experienced in a wide variety of procurements and have tons of stories of procurements that have gone well and some that haven’t.  Ask us!
 
+### Our Vision & Mission
 
-## What We Do
-We focus on procurements of intentionally modest scope for open-source digital products and services, which we procure and deliver incrementally, so that we can assess the results more quickly, and refine our approaches over time.
+The Acquisition Chapter exists to prove that government acquisitions can be joyful for our employees, agency partners, and industry partners. We do this, by ensuring that informed buyers can easily and confidently access the right products and services to meet their agency’s  mission. No matter what the agency partner is undertaking or trying to solve, the acquisition process will be unavoidable and it can be used as an amazing point for leverage to improve overall outcomes.
+
+As a team, we are dedicated to bringing an agile, human centered, and cross-functional approach to procurements that will better prepare our partners to work with modern vendor teams iteratively; developing open source software products to help agencies achieve their mission.
+
+### Our Value Proposition
+
+18F Acquisition Consulting helps agencies buy digital services in a way that reduces risk and provides value to end-users more rapidly than traditional methods.
+We seek to design and evangelize acquisition approaches that are better aligned with current industry practices to ensure the successful delivery of digital products and services that truly meet the needs of our agency partners and the people they serve.
+
+### Our Principles
+
+* Use **human-centered design** to focus on software that meets actual people's needs/
+* Leverage **open-source software**, and select modern tech stacks to ensure long-term sustainability.
+* Utilize **product thinking** to prioritize, focus work, and deliver demonstrable value.
+* Structure contracts to **support modularity, lower costs, increase quality, and avoid vendor lock-in.**
+* Ensure that **agile development methodologies** are employed to deliver working code sooner.
+* **Communicate clearly** about methods, lessons-learned, and recommendations.
+
+### What We Do
+
+We focus on procurements of intentionally modest scope for digital products and services (procures and deliver incrementally), so that we can deliver end-user value more rapidly, assess the results more quickly, and refine our approaches over time.
 
 In pursuit of this strategy, we:
 
-- **Buy digital products and services for our own organization (TTS) and for partner agencies** to pilot our own procurement tools and processes, and to demonstrate that compliance can still be achieved in the context of more efficient and effective acquisition approaches;
-- **Develop and pilot novel methods of working with industry** which engage vendors of all sizes and encourages them to compete in the market and deliver better results; and
-- **Consult with clients on acquisition strategy, and provide post-award coaching and support** rooted in real project work to assist our clients in the development of the skills needed to be more savvy consumers of digital products and services moving forward, and ensure their long-term success beyond the scope of our work together.
+* Consult with our agency partners to help them buy digital products and services  demonstrating that compliance can still be achieved in the context of more efficient and effective acquisition approaches.
+* Develop innovative acquisition strategies within the confines of the Federal Acquisition Regulations (FAR). 
+* Develop and pilot novel methods of working with industry and encourage vendors of all sizes to compete for work and offer their unique skills to government. 
+* Work in the open. We strive to publicly share as much information about our work with agencies partners as possible. Vendors we partner with commit to using open-source technologies.
+* Consult with partner agencies on acquisition strategy, conduct workshops, provide pre-award and post-award coaching. Our work is rooted in real project work to assist our partner agencies to develop the skills needed to be more savvy consumers of digital products and services moving forward, and ensure their long-term success beyond the scope of our work together.
 
-Let us help you. Please email us at [inquiries18f@gsa.gov](mailto:inquiries18f@gsa.gov)
+### How we communicate
 
-## TTS Internal Procurement
-If your procurement need costs less than the micro-purchase threshold ($10,000) please visit the [Purchase Request](/purchase-requests) section in the handbook.
+The majority of our conversations take place on Slack and video.  There are a number of slack channels for acquisition discussions. 
 
-If you’re looking to have the TTS Office of Acquisition (OA) procure anything over the micro-purchase threshold ($10,000), please fill out the [Intake Form](https://docs.google.com/forms/d/1bSoFcljv-hmUJsSCK04AsdIh03hor_T4m1yjopild6w/edit). As a prerequisite to submitting the form, please notify your team director of your request. Once the OA receives and processes your request form, we will contact you within 3 business days to discuss next steps.
+Team meetings are generally over google hangouts and zoom. If you would like your own zoom account, hop on over to [#admins-zoom](https://gsa-tts.slack.com/messages/admins-zoom/) to request one.
 
-Have questions? Find us in Slack at [#acquisition](https://gsa-tts.slack.com/messages/acquisition)
+### Stuff to do, sign, and read
 
-## TTS Office of Acquisition Operational Guidance
-TTS OA aims to redefine the culture of government acquisition of information technology by bringing agile practices to service level procurement policies. [TTS OA Operational Guidance](/acquisition), which includes standard operating procedures, #readme’s, templates, checklists and other operational guidance documents, were established to keep TTS procurement practices agile, current, applicable and in compliance at the Federal, Agency and Service levels. 
+#### Do
 
+##### Acquisition Training 
+
+[On boarding Training for COs](https://docs.google.com/document/d/1rQYUP1ARL0OnxUD5FNHKmt-ExiFWxSVeE6lHmKaMvxE/edit)
+[Acquisition Training for non 1102s](https://docs.google.com/document/d/1xmRsU4_07fvEyPaWmwBMNtpw4saT4gGSMMH6S97MxAs/edit)
+
+#### Sign
+
+The first order of business is to read and sign the linked [NDA](https://docs.google.com/document/d/14WdpMB-PqDPyIFEZNKioCS_1JqYPDjrPEHdhNure6TQ/edit#).  If you want to more more about what these are to protect, review the Federal Acquisition Regulation (FAR) Parts [3](http://farsite.hill.af.mil/reghtml/regs/far2afmcfars/fardfars/far/03.htm) and [9](http://farsite.hill.af.mil/reghtml/regs/far2afmcfars/fardfars/far/09.htm) (we can wait and general tradecraft tip -- use the [US Air Force FAR](http://farsite.hill.af.mil/) website because acquisition.gov is less reliable). When you are done please let us know in the [#18f-acquisitions](https://gsa-tts.slack.com/messages/18f-acquisitions/) channel and we’ll put it in the folder. 
+
+#### Read
+These are a couple of suggested reading materials meant to give you a better sense of our approach to acquisition consulting and modular procurement.  
+ 
+* Case Study on Modular Contracting: [Open Forest](https://docs.google.com/presentation/d/1mnCEsa5vSJWMVH9UAA5XsAZxQKry0GkksTHd9Dn_mQM/edit#slide=id.g4c4e3bde85_0_74)
+* Presentation on the [Acquisition Lifecycle](https://docs.google.com/presentation/d/16UOr3OSsMYQzlCGk6dwjPQrsBnoE6Mzl-8tW3api1Kw/edit#slide=id.g418713fe3b_0_63
+* An agile view of acquisition
+  * [Improving Government Outcomes through an Agile Contract Format](https://18f.gsa.gov/2017/11/30/improving-government-outcomes-through-an-agile-contract-format/) 
+  * [What We Learned from Building a Pool of Agile Vendors](https://18f.gsa.gov/2018/07/26/what-we-learned-from-building-a-pool-of-agile-vendors/) 
+  * [Five Contract Tweaks That Have Yielded 18F Better Procurements](https://18f.gsa.gov/2018/07/17/five-contracting-tweaks-that-have-yielded-18f-better-procurements/) 
+  * [Win Big by Going Small](https://18f.gsa.gov/2018/03/13/win-big-by-going-small/) 
+  * [Am I doing this right?: Antipatterns in agile contracting](https://18f.gsa.gov/2018/09/27/antipatterns-in-agile-contracting/)
+  * [Modular Contracting and Working in the Open](https://18f.gsa.gov/2018/10/25/modular-contracting-and-working-in-the-open/) 
+  * [Getting DevOps buy-in to Facilitate Agile](https://18f.gsa.gov/2018/01/25/getting-devops-buy-in/)
+  * [Using Agile Methods to Improve the RFP Process](https://18f.gsa.gov/2018/05/22/using-agile-methods-to-improve-the-rfp-process/)
+  * [Agile Fundamentals](https://agile.18f.gov/agile-fundamentals/)
+* Project xyz
+  * [Using RFPs Make Every Dollar Count](https://18f.gsa.gov/2016/10/03/using-rfps-make-every-dollar-count/) 
+* Brief descriptions of the Acquisition Chapters’ [most successful projects](https://docs.google.com/document/d/1MPBSUYw3jOVMdMlOZ4afmcVLzGb6QS-nRn7kf2IuFeg/edit#heading=h.dlahkkoneeur)
+* [Intro to Acquisition Consulting](https://docs.google.com/presentation/d/1_SP25AV8CB2-2nxyFPSk3V0t6SClafwZmDs9jQRvHzo/edit?pli=1#slide=id.g4be6f7f337_0_12)
+* Keep this for later, but if you ever need to know the answer to the question “Can you…” when it comes to a contract save yourself the time and use the [Government Attorney’s Desk Reference](http://www.loc.gov/rr/frd/Military_Law/Contract-Fiscal-Law-Department.html) (called the “Blue Book”, whereas the fiscal law guide is the “Red Book”).
+
+### Pro-tips for working with our partners
+
+*(these are from your Acq Chapter friends)
+
+#### Teach partners how to fish
+
+* **Success is working ourselves out of a job.** We strive to increase our partners’ knowledge and capacity until we can transfer the entire project back to them; comfortable that they have the tools and resources to continue seamlessly.  
+* **Encourage and foster failure, fast.** One of the underlying tenets of our principles and methods is that you cannot avoid failure. Instead the goal is to reduce the impact of such failures as much as possible to create a feedback loop for learning that only grows exponentially. For example, with typical contracting cycles of 2-3 years for a “major” contract it means that you will only have 10-12 examples in a typical federal employee’s career. Contrast this with ours whereby the procurement process occurs every 1-3 months and you now have generated far greater experience in a much briefer period of time. We’re literally hacking time here.
+* **Start small and build.** It can be overwhelming starting a new project with an excited partner. Encourage them to focus on one piece of functionality to deliver to users. This is your starting point. Trying to deliver an entire end-to-end system is likely to stall the project due to lack of focus. You will also encounter the same principles and practices on a small project that would be applied to a far larger one. Don’t try to win a marathon before you’ve learned to run in the first place.
+* **Retros are your friend.** Recognize that there isn’t a one-size-fits-all approach to procurement or product development and it’s necessary to meet the agency partner where they are.  Allow for incremental learning over time. Ensure that these are blameless spaces, because without transparent and honest communication the dynamics will slowly fester and create the kinds of legacy environments that can stymie progress at the partner agencies.
+
+#### Situational Awareness
+
+* **Build your empathy muscle.** Take time to understand the problem space, past challenges, and the goals of the product team. 
+* **Product owners are key to success.** Be wary of starting post-procurement work with an agency partner if there is no empowered, dedicated product owner to lead the work.
+* **Engage with security early and often.** We’ve learned that security is one of the sticking points for delivering government products. If you are not an expert in security, bring somebody who is.
+* **Post it everywhere.**  We post on e-buy, FBO.gov, and github
+
+#### Work with (not for) the vendors
+
+* **Our highest duty is to our agency partners.** (Not the partners’ vendor)  We work closely with the vendor intent on developing good working relationships, AND we always prioritize our client’s best interests above all else.
+* **Vendor lock-in is bad for everyone.** We encourage our agency partners to prioritize internalizing expertise and using vendors as interchangeable complements to their own team. That includes 18F, which is also a vendor.
+* **Talk to industry!** We are comfortable having conversations with industry as the FAR advises us to do.
+
+#### 18F is here for you
+* **Ask for help.** Know there is a powerful ecosystem of 18Fers who are on-call to help with any areas where you need more assistance, whether it’s design, security practices, or product management best practices. We see new things every day, but it’s unlikely that someone hasn’t seen something like what you’re experiencing before and can offer a hand, ear, or whatever other body part you may need given the circumstances.
+* **Not everyone is ready for the 18F way.** We have a certain point of view when it comes to agile procurement and modular contracting.  It doesn’t work for all partners in every situation.  It’s ok to recognize that this may not be the right fit. What’s worse would be to force it onto someone not ready and see them stumble in [very predictable ways](https://18f.gsa.gov/2018/09/27/antipatterns-in-agile-contracting/). This wouldn’t normally be a problem but you may encounter folks who say something like, “Yea we tried that Agile thing once and it wasn’t for us, so we’re sticking with this.”
 ---
 
 #### Still have questions?


### PR DESCRIPTION
The Acquisition page had OA content, instead of 18F Acquisition Content. The 18F Acquisition Team asked for this content to be put in their page. 