### PR TITLE
Fix up internal section links

### DIFF
--- a/_pages/how-we-work/purchase-requests.md
+++ b/_pages/how-we-work/purchase-requests.md
@@ -14,36 +14,36 @@ Some types of purchases are handled differently. See these pages for guidance ab
 
 ## C2
 
-[C2](http://requests.18f.gov) is used for all purchase requests under $10,000. In order to use C2, you will need to get an account set up. Fill out [this form](https://docs.google.com/forms/d/e/1FAIpQLSfZfBRRO_mBz2wwBHJTufi6kWONQhc64otCAYBCKV8keDvXVA/viewform) and you will be set up within one to two business days. Once you are set up in C2, you will be able to make either an event request (for training and conferences) or a purchase request (for anything else). All requests must be approved by a supervisor before submitting in C2. Do not make a purchase on your own because you will not be reimbursed! Please follow the below instructions to make your request.   
+[C2](http://requests.18f.gov) is used for all purchase requests under $10,000. In order to use C2, you will need to get an account set up. Fill out [this form](https://docs.google.com/forms/d/e/1FAIpQLSfZfBRRO_mBz2wwBHJTufi6kWONQhc64otCAYBCKV8keDvXVA/viewform) and you will be set up within one to two business days. Once you are set up in C2, you will be able to make either an event request (for training and conferences) or a purchase request (for anything else). All requests must be approved by a supervisor before submitting in C2. Do not make a purchase on your own because you will not be reimbursed! Please follow the below instructions to make your request.
 
-Please note that for training and conferences, someone from the TTS Ops team will enter the request in C2 on behalf of the requestor. Please be sure to follow the steps in the [training section](https://handbook.18f.gov/attending-conferences/#im-attending-training-that-is-not-at-a-conference) or [conferences section](https://handbook.18f.gov/attending-conferences/#im-attending-a-conference-including-training-offered-before-or-after-the-conference). 
+Please note that for training and conferences, someone from the TTS Ops team will enter the request in C2 on behalf of the requestor. Please be sure to follow the steps in the [training section](https://handbook.18f.gov/attending-conferences/#im-attending-training-that-is-not-at-a-conference) or [conferences section](https://handbook.18f.gov/attending-conferences/#im-attending-a-conference-including-training-offered-before-or-after-the-conference).
 
-Here's the information you'll need to enter in C2: 
+Here's the information you'll need to enter in C2:
 
 * **Purchase Type:** Software/Services/Etc.
 * **Product Name and Description:** Include the specifics of what you are requesting.
 * **Justification:** The justification section is very important. This is how you will get approval from TTS for what you need. It needs to be a strong justification for why you need it and you must include how it is different from something we have already procured and is available for use.
-* **Link to Product:** Provide a link to the product website, if available.  
+* **Link to Product:** Provide a link to the product website, if available.
 * **Cost per unit:** If the product costs less than $3,500 per unit, then you must enter the unit price (and not the total price) here. If the product costs over $3,500 per unit (still must be under $10,000), then you will need to enter the amount as $3,500 and put the actual amount in the description for now (we are working to update C2 accordingly).
 * **Quantity:** Include the quantity of what you are requesting.
-* **Additional Information:** Include your office/chapter/portfolio and your supervisor’s name.  
+* **Additional Information:** Include your office/chapter/portfolio and your supervisor’s name.
 
 After the C2 request is created:
 
-* Add your supervisor as an observer in C2 by scrolling all the way to the bottom where it says “Observers” and typing in their name or email. (If they have never used C2, you may need to request access for them, like you did for yourself at the beginning of the process.) 
-* Then, supervisor adds a comment “Approved” in your C2 request. Please note that for OPP purchases, the OPP Director’s approval is required in addition to the portfolio supervisor’s approval. 
+* Add your supervisor as an observer in C2 by scrolling all the way to the bottom where it says “Observers” and typing in their name or email. (If they have never used C2, you may need to request access for them, like you did for yourself at the beginning of the process.)
+* Then, supervisor adds a comment “Approved” in your C2 request. Please note that for OPP purchases, the OPP Director’s approval is required in addition to the portfolio supervisor’s approval.
 
 ## Business cards
 
 To make best use of our resources, we use business cards sparingly. However, if you expect to use them for outreach or a specific meeting with partners, you can request standard GSA business cards, which don’t reflect TTS or 18F branding.
 
-To initiate your request, 
+To initiate your request,
 
-* First head to [envisionprintservices.com](http://envisionprintservices.com/). Verify your email, then create an account for yourself. Use a password that you are comfortable sharing with a member of the TTS Ops team, as they will need to later log in as you and make the purchase. 
+* First head to [envisionprintservices.com](http://envisionprintservices.com/). Verify your email, then create an account for yourself. Use a password that you are comfortable sharing with a member of the TTS Ops team, as they will need to later log in as you and make the purchase.
 * After your account is set up, fill in the required information, finalize the design of your cards, and review your proof. Continue to checkout, choosing the quantity you'd like and adding the address that you'd like your business cards mailed to.
 * Once you are on the final step of the order and credit card information is requested, it’s time to request approval. Create a new purchase request in C2, and include your account credentials under "Link to Product". Your order in C2 will be reviewed by the TTS Director of Operations, and once approved, a member of the TTS Ops team will log into your Envision account and release payment. Your business cards will arrive 7-10 business days after that.
 
-If you want TTS/18F branding, you must purchase your own business cards. However, please get a final approval from the TTS Outreach team before placing the order. 
+If you want TTS/18F branding, you must purchase your own business cards. However, please get a final approval from the TTS Outreach team before placing the order.
 
 ## Office supplies
 
@@ -67,25 +67,25 @@ Examples of services TTS has procured:
 
 Please follow the recommended steps below when ordering services under $10,000:
 
-1. Please make a copy of this RFQ template then fill it out. 
-2. Once filled out, transfer the ownership of the RFQ to the TTS Micro-Purchase Project Manager (PM). Then submit the link to them via Slack. See the POC section for contact information. 
-3. Once received by the TTS Micro-Purchase PM, the RFQ will be reviewed by the OA Director. Please be ready to address any questions, comments, or feedback at your earliest convenience. 
+1. Please make a copy of this RFQ template then fill it out.
+2. Once filled out, transfer the ownership of the RFQ to the TTS Micro-Purchase Project Manager (PM). Then submit the link to them via Slack. See the POC section for contact information.
+3. Once received by the TTS Micro-Purchase PM, the RFQ will be reviewed by the OA Director. Please be ready to address any questions, comments, or feedback at your earliest convenience.
 4. After the RFQ is approved by the OA Director, please send it to the appropriate vendor(s) and cc TTS Micro-Purchase PM and OA Director. When sending the RFQ to vendor(s), keep in mind:
-    * If they’ve been government employees who worked in TTS within the past two years, we can’t hire them. 
+    * If they’ve been government employees who worked in TTS within the past two years, we can’t hire them.
     * Spread the wealth - this is not a formal rule or policy, but you don’t want to go back to the same person for every purchase, because that raises flags.
     * Make sure the vendor can accept payment via government purchase card (aka credit card) - this seems easy but isn’t always the case.
-5. Receive a quote from the vendor. When reviewing the quote, please keep in mind: 
-    * The requirement cannot exceed the micro-purchase threshold for the same service within a twelve-month period. 
+5. Receive a quote from the vendor. When reviewing the quote, please keep in mind:
+    * The requirement cannot exceed the micro-purchase threshold for the same service within a twelve-month period.
     * You can’t pay for similar services from both vendor A and B if the scope is the same and the combined cost exceeds the micro-purchase threshold within a twelve-month period. This is considered splitting purchases.
     * You need to avoid scope creep (adding extra work to the original agreement) that would go over the threshold.
     * If you need any assistance with negotiations, please contact the TTS Micro-Purchase PM and the OA Director.
-6. Follow the [C2/P-Card Purchase protocol](#C2), then do the following:
+6. Follow the [C2/P-Card Purchase protocol](#c2), then do the following:
     * Add the TTS Micro-Purchase PM and the TTS OA Director as observers to the request. You can do this by scrolling all the way to the bottom of the C2 page to where it says “Observers” and typing in their names or emails.
     * Attach the RFQ and vendor quote to the C2 request.
-  
+
 **Who to contact about purchasing services**
 
-**TTS Micro-Purchase Project Manager:** Melanie Leopold [melanie.leopold@gsa.gov](mailto:melanie.leopold@gsa.gov) | Slack: @melanie  
+**TTS Micro-Purchase Project Manager:** Melanie Leopold [melanie.leopold@gsa.gov](mailto:melanie.leopold@gsa.gov) | Slack: @melanie
 **TTS Office of Acquisition Director:** Esther Praske [esther.praske@gsa.gov](mailto:tts-purchasers@gsa.gov)
 
 Or find us in Slack: [#tts-oa-internalbuy](https://gsa-tts.slack.com/messages/tts-oa-internalbuy/).

--- a/_pages/policies/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
+++ b/_pages/policies/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
@@ -19,7 +19,7 @@ If you're traveling for 18F during your first two weeks (normally for orientatio
    Yes, you probably already filled out the EFT form at orientation, so this seems repetitive. However, there is a good reason for it. [Click here to find out why](https://docs.google.com/document/d/1cHGnvUVGzYJkSuW0-2ZEy4g4vwgNLLkZcI1j5JVozDQ/edit#bookmark=id.f206jlg5swxh).
 
 2.  **Attach your completed EFT form** to [this pre-populated email](https://mail.google.com/mail/?view=cm&ui=2&tf=0&fs=1&to=kc-vendor.number.requests%40gsa.gov&su=Request%20to%20Obtain%20Employee%20ID&body=To%20KC%20Vendor%2C%0A%0ACould%20I%20please%20have%20my%20employee%20ID%3F%0A%0AThank%20you%2C%0A) and send.
-[_Having trouble sending the EFT form?_](#having-trouble-sending-the-EFT-form)
+[_Having trouble sending the EFT form?_](#having-trouble-sending-the-eft-form)
 
 3. **Wait for a reply to your email.**
    You’ll get a number like **E000xxxxx** in the reply, which is important for the next step.

--- a/_pages/policies/travel-and-leave-policies/travel-guide-1-authorization.md
+++ b/_pages/policies/travel-and-leave-policies/travel-guide-1-authorization.md
@@ -25,7 +25,7 @@ Starting this process assumes that you are both in the Concur system and have a 
 
 Before making *any* reservations, you'll want to make sure that your trip has been pre-approved by someone who has the ability to obligate funds on behalf of the government. This person could be a division director or higher inside 18F if the travel is considered non-billable, or they could be someone outside 18F (who is designated on an inter-agency agreement or memorandum of understanding with 18F) if the travel is considered billable. There is a slightly different process for requesting approval depending on whether the travel is [billable](/travel-guide-1-authorization/#billable-travel-approval) or [nonbillable](/travel-guide-1-authorization/#non-billable-travel-approval).
 
-Know that you've already been approved to travel? Skip ahead to [I'm approved! What's next?](/travel-guide-1-authorization/#Im-approved-Whats-next)
+Know that you've already been approved to travel? Skip ahead to [I'm approved! What's next?](/travel-guide-1-authorization/#im-approved-whats-next)
 
 ## Non-billable travel approval
 
@@ -72,7 +72,7 @@ Project managers (or their delegates) are responsible for requesting written app
 * **Body:** Names, origins, and destinations, as well as dates/locations of any additional travel made in conjunction with official travel at the individual's personal expense. The template [below](/travel-guide-1-authorization/#template-email-of-approval)) may be used.
 * **As an attachment** An estimate of total travel expenses using [this template](https://docs.google.com/spreadsheets/d/1uJaGMXJOwURruaPdV7PU5B7Q22_iyF8Q2Gk2uamDG8Y/edit#gid=1000729692), which automatically calculates [round-trip City Pair fares](http://cpsearch.fas.gsa.gov/cpsearch/search.do?method=enter) and [hotel/M&IE estimates based on the GSA per diem rates](http://www.gsa.gov/portal/category/100120) (Mileage cost estimates will still need to be manually estimated using the [GSA Reimbursement rates](http://www.gsa.gov/portal/content/100715)).
 
- Once you have been cc'd on your client's email of approval, you are good to move on to [the next step](/travel-guide-1-authorization/#Im-approved-Whats-next).
+ Once you have been cc'd on your client's email of approval, you are good to move on to [the next step](/travel-guide-1-authorization/#im-approved-whats-next).
 
 #### Amending approval for billable travel
 Any changes to the itinerary approved by the client that require:

--- a/_pages/policies/travel-and-leave-policies/travel-guide-1-authorization.md
+++ b/_pages/policies/travel-and-leave-policies/travel-guide-1-authorization.md
@@ -125,7 +125,7 @@ Additional templates for emails involving other circumstances are available in t
 
 **Are you traveling in the next 3 business days?**
 
-[Yes - I need AdTrav](/travel-guide-1-authorization/#AdTrav)
+[Yes - I need AdTrav](/travel-guide-1-authorization/#adtrav)
 
 [No - I need to book an upcoming trip that will start later than 3 days. Go to normal booking.](/travel-guide-2-choose-your-itinerary)
 

--- a/_pages/policies/travel-and-leave-policies/travel-guide-table-of-contents.md
+++ b/_pages/policies/travel-and-leave-policies/travel-guide-table-of-contents.md
@@ -10,7 +10,7 @@ title: Travel Guide Table of Contents
 * [1. Confirm email of approval](/travel-guide-1-authorization)
     * [Non-billable travel](/travel-guide-1-authorization/#non-billable-travel-approval)
     * [Billable travel](/travel-guide-1-authorization/#billable-travel-approval)
-    * [Is travel less than 3 days away? (Call Ad Trav)](/travel-guide-1-authorization/#AdTrav)
+    * [Is travel less than 3 days away? (Call Ad Trav)](/travel-guide-1-authorization/#adtrav)
 * [2. Choose Your Itinerary](/travel-guide-2-choose-your-itinerary)
     * [Book your flight or rail](/travel-guide-2-choose-your-itinerary/#book-flight-or-rail)
     * [Book lodging through Fedrooms (recommended)](/travel-guide-2-choose-your-itinerary/#book-lodging)


### PR DESCRIPTION
# Notes

This fixes up CI errors caught by #1056. The HTML proofer in #1056 is picking up on more valid link errors than the `go_script` HTML proofer config was picking up, probably due to a config difference that I can't spot right now. This is a good thing — CI catching real errors! 🙌 

# How to review this PR

To review this PR, use the [Federalist preview build](https://federalist-proxy.app.cloud.gov/preview/18f/handbook/fix-up-internal-sectionlinks/) and check that the following 7 internal section links are fixed:

```
- ./_site/first-time-travel-get-in-concur-pre-olu/index.html
  *  linking to internal hash #having-trouble-sending-the-EFT-form that does not exist (line 73)
     <a href="#having-trouble-sending-the-EFT-form"><em>Having trouble sending the EFT form?</em></a>

- ./_site/purchase-requests/index.html
  *  linking to internal hash #C2 that does not exist (line 148)
     <a href="#C2">C2/P-Card Purchase protocol</a>

- ./_site/travel-guide-1-authorization/index.html
  *  linking to /travel-guide-1-authorization/#AdTrav, but AdTrav does not exist (line 196)
     <a href="/travel-guide-1-authorization/#AdTrav">Yes - I need AdTrav</a>
  *  linking to /travel-guide-1-authorization/#Im-approved-Whats-next, but Im-approved-Whats-next does not exist (line 83)
     <a href="/travel-guide-1-authorization/#Im-approved-Whats-next">I’m approved! What’s next?</a>
  *  linking to /travel-guide-1-authorization/#Im-approved-Whats-next, but Im-approved-Whats-next does not exist (line 136)
     <a href="/travel-guide-1-authorization/#Im-approved-Whats-next">the next step</a>

- ./_site/travel-guide-A-amended-authorization/index.html
  *  linking to internal hash #Manually-amending-dates-of-travel-in-Concur that does not exist (line 81)
     <a href="#Manually-amending-dates-of-travel-in-Concur">Manually amending dates of travel in Concur</a>

- ./_site/travel-guide-table-of-contents/index.html
  *  linking to /travel-guide-1-authorization/#AdTrav, but AdTrav does not exist (line 66)
     <a href="/travel-guide-1-authorization/#AdTrav">Is travel less than 3 days away? (Call Ad Trav)</a>
```