### PR TITLE
Remove commands from go script and add to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,16 @@ We're careful about publishing [information collected during research](https://h
 
 ## Development
 
-``` bash
-git clone https://github.com/18F/handbook.git
-cd handbook
+Install dependencies:
+
+```bash
 bundle install
-./go serve
+```
+
+Serve the site:
+
+```bash
+bundle exec jekyll serve
 ```
 
 See the 18F Pages documentation to learn how to [make a new page](https://pages.18f.gov/guides-template/add-a-new-page/) and [add it to the homepage navigation links](https://pages.18f.gov/guides-template/update-the-config-file/).

--- a/go
+++ b/go
@@ -38,16 +38,4 @@ def_command :update_theme, 'Update the guides_style_18f gem' do
   GuidesStyle18F.update_theme
 end
 
-def_command :update_gems, 'Update Ruby gems' do |gems|
-  update_gems gems
-end
-
-def_command :serve, 'Serve the site at localhost:4000' do |args|
-  serve_jekyll args
-end
-
-def_command :build, 'Build the site' do |args|
-  build_jekyll args
-end
-
 execute_command ARGV


### PR DESCRIPTION
# Notes

+ This is part of incrementally moving away from the `go_script`, moving forward from #1056.

+ Using `jekyll` commands is more idiomatic and probably more familiar to most devs than the go script pattern. 