### PR TITLE
Adding CoE instructions for billable travel auth

### DIFF
--- a/_pages/policies/travel-and-leave-policies/travel-guide-1-authorization.md
+++ b/_pages/policies/travel-and-leave-policies/travel-guide-1-authorization.md
@@ -53,7 +53,8 @@ Any amendment to approved non-billable travel that would require an additional d
 
 Any other amendment with a minimal impact on the budget (i.e. change of dates, adding additional days at the traveler's personal expense, changing origin or destination airports with no significant cost increase) requires only that the immediate supervisor approve the change and communicate it to [tts-travelauths@gsa.gov](mailto:tts-travelauths@gsa.gov).
 
-## Billable travel approval
+## Billable travel approval (18F only)
+*Billiable travel for Centers of Execelence is handled the same as non-billable travel*
 
 ### Who is responsible, and how do I make my request?
 


### PR DESCRIPTION
I found out CoE has different instructions for billable travel and wanted to make sure the handbook is up to date. I don't know OPP's policy for billable travel or if they have billable travel. 

Flagging @bwhttkr for a second pair of eyes- FYI his is based on the email from Rachel Nov 13:

```
For official travel you must have an e-mail approval from Bob De Luca for your trip, prior to any bookings. If you are travelling you need to have a Concur account (e-Gov travel system) as well as a GSA travel card. If you have travel plans and do not have a Concur account or travel card, pleas establish these accounts immediately. Steps on travel, including FAQs, are included in the TTS Handbook. 

High Level Travel Instructions: 
Notify your site lead of the travel.
Get e-mail approval from Bob De Luca for your trip, and CC: your Site Lead [Guidance on the Approval Email, there is an example if you scroll down]
Communicate your approval to the 18F Travel Team at tts.travelauths@gsa.gov (CC: Bob De Luca, Brian Whittaker, Your Site Lead)
Create your itinerary
Submit for Concur Approval
Travel (retain receipts for everything but meals and incidentals) 
Create and Submit your travel voucher

Thank you for your continued support in coordination efforts. If you have any questions please consult with CoE leadership and your fellow CoE Leads. 
```