### PR TITLE
Tell circleci to use Ruby 2.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/handbook
     docker:
-       - image: circleci/ruby:2.6-node
+       - image: circleci/ruby:2.6.0-node
     environment:
       # fix encoding
       - LANG: C.UTF-8


### PR DESCRIPTION
# Notes

CircleCI using 2.6.1 and the Gemfile specifying 2.6.0 has been causing builds to fail: 

_https://circleci.com/gh/18F/handbook/1092?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link_

If this build passes then this PR should be good to 🚢.