### PR TITLE
Update org code & other FAS items.

### DIFF
--- a/_pages/policies/employee-resources-policies/transit-benefit.md
+++ b/_pages/policies/employee-resources-policies/transit-benefit.md
@@ -32,7 +32,7 @@ Use `T-TECH TRANSFORMATION SERVICE` as your organizational code.  Make sure to s
     * Select Transportation Method (i.e. Bus, Other Bus, Rail, Other Method, Van Pool)
         * Fill out corresponding information for each transportation method selected
     * Fill out "Transit Benefit Program Application"
-        * Organization Code: **T - Tech Transformation Service**
+        * Organization Code: **Q - Federal Acquisition Service**
         * Common identifier: **TRANSIT**
     * Fill out "Approver Information Section"
         * Select your Supervisor - If your supervisor is not listed, have your supervisor follow these steps:      
@@ -42,7 +42,7 @@ Use `T-TECH TRANSFORMATION SERVICE` as your organizational code.  Make sure to s
             * DC employees: **CO-Transit Subsidy** 
             * Other regions: consult the [transit subsidy coordinators list](https://insite.gsa.gov/topics/hr-pay-and-leave/benefits/transit-subsidy/transit-subsidy-coordinators)
         * Point of Contact: 
-            * DC employees: **Central Office Non FAS Transit Subsidy**
+            * DC employees: **Central Office FAS Transit Subsidy**
             * Other regions: enter region code (Ex: Chicago employees enter **Region 5**)
 - Scroll down and click **Continue** to submit
 


### PR DESCRIPTION
T- Technology Transformation Service doesn't exist anymore.

Also DC employees: **Central Office FAS Transit Subsidy** said Non-FAS which isn't accurate anymore.