### PR TITLE
Improve error message for internal links missing site.baseurl.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,11 @@ jobs:
 
       - run:
           name: checking internal links
-          # grep returns a success code if it finds any results and an error
-          # if it doesn't; we want the opposite of that
-          command: '! grep -rl "(/" _pages'
+          # grep for pages with markdown links to local pages (links with "(/").
+          # if found, fail build with error message (grep returns the opposite
+          # exit code from what we’re hoping for, so the '!' negates the
+          # expression to pass/fail the build as expected).
+          command: '! (grep -rl "(/" _pages && echo "ERROR: Internal links must be prefixed with {{ site.baseurl }} to work correctly with Federalist Previews. Fix the above pages.")'
 
       - run:
           name: build site


### PR DESCRIPTION
This CI step was introduced in #1137 — and is a great test! 

Unfortunately, this is currently broken on `master`, and when I went to fix the issue just now, it took me a while to figure out what the build output meant:

```
checking internal links

#!/bin/bash -eo pipefail
! grep -rl "(/" _pages
_pages/how-we-work/procurements-over-10000.md
Exited with code 1
```

I figured it out after 15 minutes or so — but I hope to save that time next time with this pull request! Here’s the new build output (still failing — will open a different PR to fix the link shortly): 

```
checking internal links

#!/bin/bash -eo pipefail
! (grep -rl "(/" _pages && echo "ERROR: Internal links must be prefixed with {{ site.baseurl }} to work correctly with Federalist Previews. Fix the above pages.")
_pages/how-we-work/procurements-over-10000.md
ERROR: Internal links must be prefixed with {{ site.baseurl }} to work correctly with Federalist Previews. Fix the above pages.
Exited with code 1
```