### PR TITLE
Add "Emojify yourself" to Slack setup steps

### DIFF
--- a/_pages/how-we-work/tools/slack.md
+++ b/_pages/how-we-work/tools/slack.md
@@ -4,7 +4,7 @@ tags:
 - TTS legend
 ---
 
-Slack is a chat client that might or might not have been invented by TTS alum Will Slack that provides us with a centralized way to communicate without overloading our inboxes.
+Slack is a chat client that provides us with a centralized way to communicate without overloading our inboxes.
 
 ## Setup
 
@@ -14,6 +14,7 @@ Because Slack is a web application, there’s no installation necessary. You can
 
 - **Complete [your profile](https://gsa-tts.slack.com/account/profile).** A complete profile gives everyone a better chance of knowing who you are. This includes your first name, last name (optionally followed by your location and [personal pronouns](http://pronoun.is/) in parenthesis), profile picture (photos are preferred, but not required), phone number, and a summary of what you do and what teams you’re on.
 - **[Enable two-factor authentication (2FA)](https://slack.zendesk.com/hc/en-us/articles/204509068-Enabling-two-factor-authentication).** You can either do this through SMS or an authentication tool. Slack provides detailed instructions for both options. If you need to reset 2FA, Slack admins will re-verify your identity.
+- **[Add yourself to our custom emojis](https://gsa-tts.slack.com/customize/emoji).** Add your profile picture as a custom emoji with your name as the alias ("first-last"). This allows the whole TTS community to celebrate your contributions and serves as your introduction to our prolific custom emoji database. Post your emoji (and any other custom emojis you add) to the [#emoji-showcase](https://gsa-tts.slack.com/messages/C0X2T36AY) channel.
 - **Abide by [the TTS Code of Conduct]({{site.baseurl}}/code-of-conduct).**  If you see anyone violating our Code of Conduct, see the reporting section.
 - **Do not post anything that would make our systems vulnerable or would impact the privacy of others if it fell into the wrong hands.** See [18F's list of alternatives](../sensitive-information/#tools).
 - **Assume everything you share will be made public**. Treat Slack as a public forum — you have _no_ privacy. This includes file uploads to Slack and any audio or video transmitted using a Slack Call.


### PR DESCRIPTION
Preview here: https://federalist-proxy.app.cloud.gov/preview/18f/handbook/Emoji-onboarding/slack/

Make sure each new hire has a custom emoji created for themselves. This also introduces them to our prolific emoji-creation community. 

Also removing the reference to Will Slack in the heading (no shade!) because it's a bit insider-jokey.