### PR TITLE
Remove outdated and redundant transit subsidy info on DC page

### DIFF
--- a/_pages/about-us/offices/washington-dc.md
+++ b/_pages/about-us/offices/washington-dc.md
@@ -216,9 +216,7 @@ Take the elevator to seventh floor for wireless and a beautiful view of the Nati
 
 ### Transit subsidy
 
-All GSA employees are eligible for transit subsidies, which cover the cost of your mass transportation travel to/from work. To receive a transit subsidy for MARC, VRE, and Commuter Buses, fill out [GSA form 3675](https://insite.gsa.gov/graphics/cpo/gsa3675_022009.pdf). The form asks for your supervisor&rsquo;s signature. For Metro, you need [GSA form 3675A](https://insite.gsa.gov/graphics/cpo/gsa3675A022009.pdf) (it will have a &ldquo;SmarTrip Card Serial Number&rdquo; field in the upper right). You must already have a SmarTrip card and have registered it on the Metro website. It should be a distinct card from what you use for personal travel.
-
-After you've obtained your supervisor&rsquo;s signature, send the completed form to [co-transit-subsidy@gsa.gov](mailto:co-transit-subsidy@gsa.gov) for processing. It can take a while to for the subsidy to appear on your card, so do this ASAP.
+See the instructions for [enrolling or cancelling your transit subsidy benefit]({{site.baseurl}}/transit-benefit/).
 
 ### Helpful contacts
 


### PR DESCRIPTION
Fixes #489 