### PR TITLE
De-duplicate leave info

### DIFF
--- a/_pages/policies/travel-and-leave-policies/leave.md
+++ b/_pages/policies/travel-and-leave-policies/leave.md
@@ -22,7 +22,7 @@ tags:
 
 This page provides instructions for entering leave requests (also known as absence requests) in <a href="https://corporateapps.gsa.gov/hr-links/">HR Links</a> and information on the various types of leave.
 
-You can also see your remaining leave balances in HR Links (shows up to the right while making a vacation request) and in your leave balance on your paystub in [Employee Express](#employee-express).
+You can also see your remaining leave balances in HR Links (shows up to the right while making a vacation request) and in your leave balance on your paystub in [Employee Express]({{site.baseurl}}/gsa-internal-tools/#employee-express).
 
 ## Submitting leave in HR Links
 

--- a/_pages/policies/travel-and-leave-policies/leave.md
+++ b/_pages/policies/travel-and-leave-policies/leave.md
@@ -20,7 +20,9 @@ tags:
 
 ---
 
-This page provides instructions for entering leave requests (also known as absence requests) in HR Links and information on the various types of leave.
+This page provides instructions for entering leave requests (also known as absence requests) in <a href="https://corporateapps.gsa.gov/hr-links/">HR Links</a> and information on the various types of leave.
+
+You can also see your remaining leave balances in HR Links (shows up to the right while making a vacation request) and in your leave balance on your paystub in [Employee Express](#employee-express).
 
 ## Submitting leave in HR Links
 

--- a/_pages/welcome-to-TTS/classes/gsa-internal-tools.md
+++ b/_pages/welcome-to-TTS/classes/gsa-internal-tools.md
@@ -112,17 +112,9 @@ See [Benefits]({{site.baseurl}}/benefits) for more details about Employee Expres
 
 ## <a id="hr-links">HR Links</a>
 
-<a href="https://corporateapps.gsa.gov/hr-links/">HR Links</a> is what you'll use to request and document leave (sick, annual, bereavement, and more) as well as access your personnel file (your salary, your GS level, your supervisor, your past performance rating(s), and information about health insurance plan).
+<a href="https://corporateapps.gsa.gov/hr-links/">HR Links</a> is what you'll use to [request and document leave]({{site.baseurl}}/leave/) (sick, annual, bereavement, and more) as well as access your personnel file (your salary, your GS level, your supervisor, your past performance rating(s), and information about health insurance plan).
 
 You must [be on the VPN](https://docs.google.com/document/d/1nBNXt6Ov4KWmpz6y9rgKw93mxZucVsoYC4PFABTeIA4/edit#heading=h.bbs2uvvcjvcg) to connect to HR Links, if you work remotely.
-
-In general, you should request leave ahead of time (although it is possible to request leave retroactively) and document any absences as soon as possible. If you&rsquo;re planning to take leave, please ask your project team(s) as well as your director or direct supervisor if it&rsquo;s okay. Once you get your supervisor's approval, sign in to [HR Links](https://corporateapps.gsa.gov/hr-links/) and submit your leave request.
-
-You can see your remaining leave balances in HR Links (shows up to the right while making a vacation request) and in your leave balance on your paystub in [Employee Express](#employee-express).
-
-We also ask that you update your Slack profile so that your name reads _FirstName LastName OOO (1/1 - 1/5)_ so that it's apparent, at a glance, that you're not at work.
-
-For 18F employees: after you've created your leave request, add your planned absence to the shared [Out of Office](https://calendar.google.com/calendar/embed?src=gsa.gov_bth7useo0eeiicjgos2di6ph8k%40group.calendar.google.com&ctz=America%2FChicago) Google calendar; that way, everyone will know when you're going to be out of the office. Finally, please note that [HR Links]({{site.baseurl}}/leave) is GSA's system and separate from [Tock]({{site.baseurl}}/tock), which is 18F's own timekeeping system. If you're taking time off, you'll need to make sure you're accounted for in both.
 
 ## <a id="it-service-desk">IT Service Desk</a>
 


### PR DESCRIPTION
Fixes #641 

This issue had been mostly addressed, but there was some remaining duplicate information on the Leave and GSA internal tools pages. I removed duplicate leave info from the GSA internal tools page and added a link to the Leave page.