### PR TITLE
Glossary updates

### DIFF
--- a/_pages/how-we-work/glossary.md
+++ b/_pages/how-we-work/glossary.md
@@ -13,6 +13,8 @@ tags:
 
 * **508** - The federal regulation that requires government IT projects be accessible to people with disabilities.
 
+* **Agile** - A software development methodology based on collaboration, iteration, feedback, and constant improvement.
+
 * **API** - Application programming interface. Think of them as a way for computers to interact, either internally or between one another. If you wanted to make a website that shows the current temperature wherever you are, your code talks to one API to get your location, then another to find out the weather in that area.
 
 * **ATO** - Authority to Operate. It's a sign-off from an authorized agency official for a website to be allowed to engage with citizens, including security and some other stuff. Learn more about ATOs in the [Before You Ship guide](https://before-you-ship.18f.gov/ato/).
@@ -26,12 +28,17 @@ tags:
     * Gather all of the information for search to work
     * Trigger emails being sent
 
-
 * **CHRIS** – GSA’s Comprehensive Human Resources Integrated System was an e-Tool that enabled employees to access their personnel files online. GSA now uses HRLinks.
+
+* **CMS** - Content Management System. Software for creating, managing, and publishing content.
+
+* **CMS** - Centers for Medicare & Medicaid Services. Agency within Health and Human Services (HHS). One of the Ms is silent.
 
 * **CoEs** – The [Centers of Excellence](https://coe.gsa.gov/) accelerate the modernization of IT infrastructure across government by leveraging private sector innovation and existing government services, and by centralizing best practices and expertise. The CoEs are a division within TTS.
 
 * **Color of money** - Slang for the legal parameters around how federal money for goods or services can be spent. This usually comes up in the context of inter-agency agreements with other federal agencies. The different “colors” of money include multi-year, no year, or one year money.
+
+* **CRM** - Customer relationship management software, which can help organizations track contacts and interactions with customers.
 
 * **Dev** - Someone who does software development. A "coder."
 
@@ -47,7 +54,7 @@ tags:
 
 * **FAS** - The [Federal Acquisition Service](https://www.gsa.gov/about-us/organization/federal-acquisition-service) is a GSA office dedicated to helping federal agencies buy products and services. TTS is part of FAS.
 
-* **Front end developer** - The people who work on the parts of the site that you see, making the page look the way it's supposed to, have buttons in the right places, etc. They write HTML, CSS, and usually JavaScript (though it can be anywhere from "I've copied-and-pasted a couple of things" to expert).
+* **Front end developer** - The people who work on the parts of the site that you see, making the page look the way it's supposed to, have buttons in the right places, etc. They write HTML, CSS, and usually JavaScript.
 
 * **Full stack developer** - Someone who does both front end and back end development.
 
@@ -63,43 +70,68 @@ tags:
 
 * **HR Links** - [HR Links](https://corporateapps.gsa.gov/hr-links/) is GSA's system for HR actions, including requesting leave and managing performance review documents.
 
-* **IAA** - Interagency agreement. A contract between federal agencies.
+* **IAA** - Interagency agreement: a contract between federal agencies.
 
-* **MOA** - The [Memorandum of agreement](https://docs.google.com/a/gsa.gov/file/d/0B84F26FpUP0lQU5aWkplWDVtS2M/edit), created between GSA and FAS establishes us through 2018.
+* **IaaS** - Infrastructure as a Service. A service that provides on-demand computing services such as storage. This is the foundation on which organizations can build and maintain cloud services.
+
+* **MOA** - The [Memorandum of Agreement](https://docs.google.com/a/gsa.gov/file/d/0B84F26FpUP0lQU5aWkplWDVtS2M/edit), created between GSA and FAS, established 18F through 2018.
 
 * **MOU** - Memorandum of understanding.
 
-* **OGC** - Office of General Counsel: GSA's legal team.
+* **OAuth** - Open Authorization. An open standard for authentication and authorization, which allows a user's account information to be used by third-party services without exposing their password.
+
+* **OGC** - Office of General Counsel, aka GSA's legal team.
+
+* **OKR** - Objectives and Key Results. A system for setting individual and organizational goals with clear ways to measure success.
 
 * **OLU** - On-Line University, where our agency's mandatory training classes are hosted.
 
-* **OPP** - The [Office of Products and Programs](../office-of-products-and-programs/) helps the public use and understand government, and helps agencies understand and serve the public. To achieve this, they create, discover, connect and share practical solutions and products that transform government. OPP is a division within TTS.
+* **Open source software** - Software that does not charge users a purchase or licensing fee for modifying or redistributing the source code. Anyone can study, change, or distribute the code for any purpose. 18F has an [open source policy](https://github.com/18F/open-source-policy/blob/master/policy.md).
 
-* **OSC** - Office of Strategic Communications: GSA’s resource for external and internal communication needs. They respond to inquiries from journalists and work closely with the [TTS Outreach](https://handbook.18f.gov/outreach/) team.
+* **OPP** - [Office of Products and Programs](../office-of-products-and-programs/). OPP helps the public use and understand government, and helps agencies understand and serve the public. To achieve this, they create, discover, connect and share practical solutions and products that transform government. OPP is a division within TTS.
+
+* **OSC** - Office of Strategic Communications. GSA’s resource for external and internal communication needs. They respond to inquiries from journalists and work closely with the [TTS Outreach](https://handbook.18f.gov/outreach/) team.
 
 * **OTP** - One-time password. (If you're in Atlanta, this might refer to "outside the perimeter," as opposed to ITP (inside the perimeter).)
 
+* **PaaS** - Platform as a Service. An online application that manages a number of the behind-the-scenes tasks for you when you maintain a website or other online service. There are many PaaS options, but TTS has created [cloud.gov](https://cloud.gov) specifically to meet the security and regulatory needs of federal agencies.
+
 * **PBS** - The [Public Buildings Service](https://www.gsa.gov/about-us/organization/public-buildings-service) is the landlord for the civilian federal government. It is the other major service provided by the GSA besides FAS.
 
-* **PD** - Position Description: Description of the roles, responsibilities, qualifications, and expectations of an employee in a given position. Often called a job description.
+* **PD** - Position Description: description of the roles, responsibilities, qualifications, and expectations of an employee in a given position. Often called a job description.
 
-* **PIF** - The [Presidential Innovation Fellows program](https://presidentialinnovationfellows.gov/) pairs innovators with top civil-servants in the highest levels of the federal government to tackle some of the biggest challenges. The PIF team is a division within TTS.
+* **PIF** - The [Presidential Innovation Fellows program](https://presidentialinnovationfellows.gov/) pairs innovators with top civil servants in the highest levels of the federal government to tackle some of the biggest challenges. PIF is a division within TTS.
 
 * **PII** - personally identifiable information.
 
-* **PRA** - the Paperwork Reduction Act, enacted in 1980 aims to reduce the burden of federally imposed paperwork for U.S. businessess and the public.
+* **PRA** - The Paperwork Reduction Act, enacted in 1980, aims to reduce the burden of federally imposed paperwork for U.S. businessess and the public.
 
-* **SLT** - Senior Leadership Team. 
+* **Repo** - Repository. A place to store code or data in a central location (such as GitHub).
+
+* **SaaS** - Software as a Service. Individuals or agencies subscribe to an application, and then access it over the internet. Most online applications, such as Salesforce and Google Drive, fall into this category. Need to purchase a SaaS product? [Here's how to get software](https://handbook.18f.gov/software/).
+
+* **Scrum master** - The facilitator for an agile development team.
+
+* **SME** - Subject Matter Expert. Specialist with expertise in a particular discipline or subject matter.
+
+* **SMT** - Senior Management Team. 18F's shorthand for its management team.
+
+* **SOP** - Standard Operating Procedure. Step-by-step instructions to help employees carry out routine operations efficiently and uniformly while maintaining compliance.
+
+* **SOW** - Statement of work. Document that defines project-specific activities, deliverables, and timelines for a vendor providing services to the client. May be part of an IAA.
+
+* **TTS** - The [Technology Transformation Services](https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services) aim to improve the public’s experience with the government by helping agencies build, buy, and share technology that allows them to better serve the public. This is the TTS Handbook, and you're probably reading it because you're an employee of TTS. TTS is part of FAS, which is part of GSA. 
 
 * **USDS** - The [United States Digital Service](https://www.usds.gov/) is a startup at The White House, using design and technology to deliver better services to the American people.
 
-* **UX** - User experience. Basically, this means building things with a focus on who the user is and what they want to do, rather than just what it should look like.
+* **UX** - User experience. The overall experience that people have when they use a product or service. UX also refers to the field of user experience _design_, which focuses on building things with a focus on who the user is and what they want to do, rather than just what it should look like.
 
 * **VPN** - Virtual Private Network is a way to pretend that you're on the GSA network when you're not in a GSA building, which also makes your Internet connection more secure. It's required for access to some GSA sites. See [VMware Horizon](../vmware-horizon/) or [AnyConnect](../anyconnect/).
 
+* **Waterfall development** - An approach to software development projects based on upfront planning and linear, sequential execution.
+
 ## More
 
-* [TTS Plain Language Glossary](https://docs.google.com/document/d/1vGleN0yTwibTp8ClXcGGiKVxgM8dTewG_IFeErxU-3Y/edit#)
 * [This Ars Technica article](http://arstechnica.com/uncategorized/2012/03/cracking-the-cloud-an-amazon-web-services-primer/) is a good primer on Amazon Web Services jargon.
 * [See a list of federal agency name acronyms](http://api.data.gov/docs/regulations/federalagencies/).
 * [Here's an additional library of government acronyms](https://github.com/unitedstates/acronym).

--- a/_pages/how-we-work/glossary.md
+++ b/_pages/how-we-work/glossary.md
@@ -7,7 +7,7 @@ tags:
 - Words
 ---
 
-* **18F** - [18F](https://18f.gsa.gov/) develops partnerships with agencies to help them deliver exceptional digital experiences that address their strategic initiatives. They also aim to strengthen government technology practices in ways that last beyond their formal partnerships. 18F is a division within TTS.
+* **[18F](https://18f.gsa.gov/)** - 18F is a division within TTS. 18F develops partnerships with agencies to help them deliver exceptional digital experiences that address their strategic initiatives. They also aim to strengthen government technology practices in ways that last beyond their formal partnerships.
 
 * **2FA** - Two-factor authentication: entering a second, temporary code in addition to a username and password. 2FA provides added security when logging in to programs, like GitHub, remotely.
 
@@ -15,9 +15,9 @@ tags:
 
 * **API** - Application programming interface. Think of them as a way for computers to interact, either internally or between one another. If you wanted to make a website that shows the current temperature wherever you are, your code talks to one API to get your location, then another to find out the weather in that area.
 
-* **ATO** - Authority to Operate. It's a sign-off from an authorized agency official for a website to be allowed to engage with citizens, including security and some other stuff.
+* **ATO** - Authority to Operate. It's a sign-off from an authorized agency official for a website to be allowed to engage with citizens, including security and some other stuff. Learn more about ATOs in the [Before You Ship guide](https://before-you-ship.18f.gov/ato/).
 
-* **AWS** - Amazon Web Services. When we make websites, this is where they all live. Read easy-to-understand descriptions of the different pieces [here](https://www.expeditedssl.com/aws-in-plain-english).
+* **AWS** - Amazon Web Services. Some TTS services use AWS to host websites. Read easy-to-understand descriptions of the different pieces [here](https://www.expeditedssl.com/aws-in-plain-english).
 
 * **AWS** - Alternative Work Schedule. Working eight, 10-hour days or working nine, nine-hour days in a pay period.
 
@@ -31,7 +31,11 @@ tags:
 
 * **CoEs** – The [Centers of Excellence](https://coe.gsa.gov/) accelerate the modernization of IT infrastructure across government by leveraging private sector innovation and existing government services, and by centralizing best practices and expertise. The CoEs are a division within TTS.
 
-* **Dev** - someone who does software development. A "coder."
+* **Color of money** - Slang for the legal parameters around how federal money for goods or services can be spent. This usually comes up in the context of inter-agency agreements with other federal agencies. The different “colors” of money include multi-year, no year, or one year money.
+
+* **Dev** - Someone who does software development. A "coder."
+
+* **[Digital Gov](https://digital.gov/)** - A platform to help those in agencies working on providing digital services and information for the public. Posts information on what government is doing in digital, general digital news, trends and issues on implementing digital for the public.
 
 * **Dogfooding** - To "[eat your own dog food](https://en.wikipedia.org/wiki/Eating_your_own_dog_food)." For our purposes, this means using the things we build.
 
@@ -40,6 +44,8 @@ tags:
     * GSA two-factor authentication
     * BookIT
     * Logging on to `gsa-wireless`
+
+* **FAS** - The [Federal Acquisition Service](https://www.gsa.gov/about-us/organization/federal-acquisition-service) is a GSA office dedicated to helping federal agencies buy products and services. TTS is part of FAS.
 
 * **Front end developer** - The people who work on the parts of the site that you see, making the page look the way it's supposed to, have buttons in the right places, etc. They write HTML, CSS, and usually JavaScript (though it can be anywhere from "I've copied-and-pasted a couple of things" to expert).
 
@@ -53,6 +59,8 @@ tags:
 
 * **Grok** - To fully [understand](http://www.urbandictionary.com/define.php?term=grok) something.
 
+* **GSA** - The [General Services Administration](https://www.gsa.gov/) is an independent agency whose mission is to deliver value and savings in real estate, acquisition, technology, and other mission-support services across government. TTS is part of FAS, which is part of GSA.
+
 * **HR Links** - [HR Links](https://corporateapps.gsa.gov/hr-links/) is GSA's system for HR actions, including requesting leave and managing performance review documents.
 
 * **IAA** - Interagency agreement. A contract between federal agencies.
@@ -61,11 +69,19 @@ tags:
 
 * **MOU** - Memorandum of understanding.
 
+* **OGC** - Office of General Counsel: GSA's legal team.
+
 * **OLU** - On-Line University, where our agency's mandatory training classes are hosted.
 
 * **OPP** - The [Office of Products and Programs](../office-of-products-and-programs/) helps the public use and understand government, and helps agencies understand and serve the public. To achieve this, they create, discover, connect and share practical solutions and products that transform government. OPP is a division within TTS.
 
-* **OTP** - One-time password. In Atlanta, this refers to "outside the perimeter," as opposed to ITP (inside the perimeter).
+* **OSC** - Office of Strategic Communications: GSA’s resource for external and internal communication needs. They respond to inquiries from journalists and work closely with the [TTS Outreach](https://handbook.18f.gov/outreach/) team.
+
+* **OTP** - One-time password. (If you're in Atlanta, this might refer to "outside the perimeter," as opposed to ITP (inside the perimeter).)
+
+* **PBS** - The [Public Buildings Service](https://www.gsa.gov/about-us/organization/public-buildings-service) is the landlord for the civilian federal government. It is the other major service provided by the GSA besides FAS.
+
+* **PD** - Position Description: Description of the roles, responsibilities, qualifications, and expectations of an employee in a given position. Often called a job description.
 
 * **PIF** - The [Presidential Innovation Fellows program](https://presidentialinnovationfellows.gov/) pairs innovators with top civil-servants in the highest levels of the federal government to tackle some of the biggest challenges. The PIF team is a division within TTS.
 


### PR DESCRIPTION
This PR fixes #612 by incorporating most missing terms into the existing glossary page. It also includes several minor edits for style, clarity, tone, or TTS-wide-ness. I did _not_ incorporate the parts-of-18F section, as that's already in the Handbook and best accessed through the table of contents.

I did remove the link to the GDoc version, since we've now pulled everything in and it was getting out of date. Thanks for gathering all this @qmanderson1!