### PR TITLE
Leave page updates

### DIFF
--- a/_pages/policies/travel-and-leave-policies/leave.md
+++ b/_pages/policies/travel-and-leave-policies/leave.md
@@ -46,6 +46,7 @@ You must be on the GSA wireless network or on the Windows virtual desktop (acces
 ***Note:*** *When your leave request is approved, you’ll receive a “The absence request has been approved…” email*
 
 ### HR Links tips
+
 - Partial day requests cannot be made in the middle of a multi-day request; more than one request will need to be made
 - AWS schedules are automatically factored into HR Links timekeeping
 - ETAMS/reconciliation is no longer needed because time off requests and time cards are linked in HR Links
@@ -71,6 +72,7 @@ Before taking leave, be sure to:
     - Submit [correct Tock entries](#time-tracking)
     - Update your Slack username and profile (ex: `@username, OOO through 6/27`)
     - Update the [18F Out of Office Calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_bth7useo0eeiicjgos2di6ph8k%40group.calendar.google.com)
+    - For a more detailed checklist, see [18F Out of Office expectations](https://docs.google.com/document/d/1qgA-vEQ1_t5plPCAs1aCOAjK0RXQzka2hHSVhoa6v5o/edit)
 
 ### Annual leave
 
@@ -166,7 +168,8 @@ In cases of serious disability or ailment, and when the exigencies of the situat
 * [Fact Sheet: Advanced Sick Leave](https://www.opm.gov/policy-data-oversight/pay-leave/leave-administration/fact-sheets/advanced-sick-leave/)
 * [Insite: Advanced Sick Leave](https://insite.gsa.gov/portal/category/510090)
 
-## Court Leave
+## Court leave (including jury duty)
+
 * Authorized absence without charge to leave or pay
 * Must be officially requested to serve in a judicial proceeding to which the Federal, a state, or local government is party
 * Requests for time off due to jury duty can now be made in [HR Links](https://corporateapps.gsa.gov/hr-links/); this option was not previously available in Aloha.
@@ -177,9 +180,7 @@ Adjusting work schedules for religious observances is handled differently than l
 
 ## Time tracking
 
-Whenever you take "leave" — be that vacation time, holiday time, or sick time  — you should log it under the `18F FY18 Out of Office` line (# 670) category in Tock (listed below). If you are at a training or conference that comes out of your chapter's training budget, log that time under the `18F FY18 Training and Conferences` line (# 671).
-
-If your leave begins prior to the release of a timecard (before Wednesday), please send your manager an email with your time entries and they will ensure they are entered. For longer leave requests, make sure you have your time entered on the "18F Out of Office" Google calendar — Ops tracks those entries and will enter your time. If you don't enter extended leave in the "18F Out of Office" calendar Ops won't know you are out, won't enter your time, and you will be delinquent.
+Whenever you take "leave" — be that vacation time, holiday time, or sick time  — you should log it under the appropriate Out of Office category for your office in Tock. If you are at a training or conference that comes out of your chapter's training budget, log that time under the appropriate "Training and Conferences" line for your office.
 
 [HR Links](https://corporateapps.gsa.gov/hr-links/) is GSA's out of office request system and is separate from [Tock](../tock), which is TTS's own timekeeping system. If you're taking time off, you'll need to make sure you're accounted for in both systems.
 


### PR DESCRIPTION
In the process of investigating #871, I ran into a few things that needed updating on this page. Changes include:

- Adding `(jury duty)` to the Court leave header for scanability
- Removing references to 18F-specific Tock lines, as those aren't relevant to all of TTS
- Adding link to 18F OOO procedures dock
- Removed some guidance about longer OOO time that's duplicative of guidance elsewhere (and also 18F-specific)