### PR TITLE
Add TTS mission and values

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -122,6 +122,9 @@ navigation:
       - text: TTS Code of Conduct
         url: code-of-conduct/
         internal: true
+      - text: TTS mission, history, and values
+        url: tts-history/
+        internal: true
       - text: TTS org chart
         url: tts-org-chart/
         internal: true
@@ -143,9 +146,6 @@ navigation:
         internal: true
       - text: Records management
         url: records-management/
-        internal: true
-      - text: TTS history
-        url: tts-history/
         internal: true
       - text: Washington, D.C. Office
         url: washington-dc/

--- a/_pages/about-us/tts-history.md
+++ b/_pages/about-us/tts-history.md
@@ -1,9 +1,33 @@
 ---
-title: TTS history
+title: TTS mission, history, and values
 ---
 
-The roots of the Technology Transformation Services reach back to 1966 and a nationwide network of 26 Federal Information Centers that people could visit in person for answers to government questions. Over the next four decades, those information centers would add numerous responsibilities and change names a number of times before becoming the Office of Products and Programs (OPP).
+Our mission is to improve the lives of the public and public servants by transforming how government uses technology.
 
-While OPP was paving the way for government shared services and open data, there was a growing need to bring new technology talent into the government. In 2012, the White House created the Presidential Innovation Fellows (PIF) program to bring technologists in for short tours of duty in government. The next year, the PIF program found a permanent home at GSA and a group of PIFs started thinking about how they could extend their impact on government. In December 2013, eight PIFs left the fellowship to become GSA employees and created a lean startup inside government.
+## Our history
 
-That project became 18F when the office officially launched in March 2014. 18F quickly grew in size to help federal agencies work on technology projects while learning new skills. In 2016, 18F, PIF, and OPP came together under the newly-formed Technology Transformation Service office. In 2017, TTS added the IT Modernization Centers of Excellence to focus on whole-agency technology modernization, and all of TTS moved into GSA’s existing Federal Acquisition Service.
+The roots of the Technology Transformation Services reach back to 1966 and a nationwide network of 26 Federal Information Centers that people could visit in person for answers to government questions. Over the next four decades, those information centers would add numerous responsibilities and change names a number of times before becoming the [Office of Products and Programs (OPP)](https://handbook.18f.gov/office-of-products-and-programs/).
+
+While OPP was paving the way for government shared services and open data, there was a growing need to bring new technology talent into the government. In 2012, the White House created the [Presidential Innovation Fellows (PIF)](https://presidentialinnovationfellows.gov/) program to bring technologists in for short tours of duty in government. The next year, the PIF program found a permanent home at GSA and a group of PIFs started thinking about how they could extend their impact on government. In December 2013, eight PIFs left the fellowship to become GSA employees and created a lean startup inside government.
+
+That project became [18F](https://18f.gsa.gov/) when the office officially launched in March 2014. 18F quickly grew in size to help federal agencies work on technology projects while learning new skills. In 2016, 18F, PIF, and OPP came together under the newly-formed Technology Transformation Service office. In 2017, TTS added the [IT Modernization Centers of Excellence (CoEs)](https://coe.gsa.gov/) to focus on whole-agency technology modernization, and all of TTS moved into GSA’s existing Federal Acquisition Service.
+
+## Our values
+
+* **Listen, understand, and then act**  
+    We listen before acting. We ask questions, keep an open mind, and are conscious of assumptions. We consider all decisions in the context of the larger environment and think strategically. Then, act.
+
+* **Be authentic and collaborative**  
+    We are honest and forthright with our colleagues, partners, users and customers. We assume competence and good intentions and believe respectful candor leads to more productive collaboration.
+
+* **Design for users**  
+    Before making decisions on form and function, we seek to understand how they will impact those who will have to live with those decisions every day. We talk with and observe users, test our ideas with them, and design for and with them.
+
+* **Deliver results**  
+    We are outcome-focused and demand-driven. We work with intent to achieve meaningful results and our work is directed by market demand.
+
+* **Learn, iterate, improve**  
+    We are constantly learning and improving as individuals and as an organization. We collect data and feedback on everything we do, and we use that information to inform better ways to work.
+
+* **Reflect the diversity of the public we serve**  
+    A more diverse organization creates a broader spectrum of solutions and ideas, and helps us challenge status quo thinking.


### PR DESCRIPTION
Fixes #1239. I added the mission and values (as recently and aptly articulated) to the existing TTS History page, rather than creating a new page. Very open to other notes about the structure of this page, but I think it will be really nice to have these in the Handbook!

[😎 PREVIEW 😎](https://federalist-proxy.app.cloud.gov/preview/18f/handbook/tts-values/tts-history/)