### PR TITLE
Proposed banner for out-of-date pages

### DIFF
--- a/_includes/page-outdated.html
+++ b/_includes/page-outdated.html
@@ -1,0 +1,5 @@
+{% if page.outdated %}
+<div class="page-outdated">
+  This page is out of date
+</div>
+{% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,8 +3,9 @@
   {% include head.html %}
   <body class="no-js layout-article layout-article-{{ page.title | slugify }}">
     <a class="a-skip-to-main" href="#main">Skip to main content</a>
-    {% include site-header.html %}
-    {% if page.breadcrumbs %}{% guides_style_18f_include breadcrumbs.html %}{% endif %}
+    {% include site-header.html %} {% if page.breadcrumbs %}{%
+    guides_style_18f_include breadcrumbs.html %}{% endif %} {% include
+    page-outdated.html %}
     <main class="article" role="main" id="main">
       <div class="page">
         <div class="wrapper">

--- a/_pages/about-us/teams/ops.md
+++ b/_pages/about-us/teams/ops.md
@@ -1,5 +1,6 @@
 ---
 title: Ops
+outdated: true
 ---
 
 _Team Ops (Operations) handles all activities related to travel, non-travel purchases, legal matters, and equipment requests._

--- a/stylesheets/screen.css
+++ b/stylesheets/screen.css
@@ -352,6 +352,13 @@ input[type="search"]:focus::-webkit-search-cancel-button::after{
 
 /* @end */
 
+.page-outdated {
+	padding: 4px 0;
+	background: #FEC42C;
+	color: #000;
+	text-align: center;
+}
+
 /* @group .site-footer */
 
 .site-footer{

--- a/stylesheets/screen.css
+++ b/stylesheets/screen.css
@@ -354,8 +354,8 @@ input[type="search"]:focus::-webkit-search-cancel-button::after{
 
 .page-outdated {
 	padding: 4px 0;
-	background: #FEC42C;
-	color: #000;
+	background: #D8F7FF;
+	color: #202020;
 	text-align: center;
 }
 


### PR DESCRIPTION
(Partially?) addresses #1227.  Adds an out-of-date header to any pages that include `outdated: true` in their frontmatter.  I wasn't sure how bold the banner should be so I went with more visible over less, but happy to change it however would be appropriate.

![image](https://user-images.githubusercontent.com/1775733/57472928-46abe300-7254-11e9-8399-69d574c62848.png)

ping @coreycaitlin