### PR TITLE
Match ruby version in Dockerfile to version in Gemfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ruby:2.6.1
 
 # Node is required for search. Federalist uses version 10, match that: https://github.com/nodesource/distributions/blob/master/README.md
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -


### PR DESCRIPTION
* The Dockerfile installed form the `ruby2.6` image, which has since updated to `2.6.3`.
As a result of this, `bundle isntall` was failing due to a version mismatch.
Matching the versions fixes this issue. It may be that we want to update the ruby version in
the Gemfile to `2.6.3`, but that may introduce unforseen bugs and is best addressed
in a followup PR