### PR TITLE
Add "how we collaborate" page to 18F resources

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -459,6 +459,9 @@ navigation:
       - text: Doing research at 18F
         url: research-guidelines/
         internal: true
+      - text: How we collaborate
+        url: how-we-collaborate/
+        internal: true
       - text: How we relate to partners
         url: how-we-relate-to-partners/
         internal: true

--- a/_pages/how-we-work/how-we-collaborate.md
+++ b/_pages/how-we-work/how-we-collaborate.md
@@ -1,0 +1,81 @@
+---
+title: How we collaborate
+---
+
+We [work with partners]({{site.baseurl}}/how-we-relate-to-partners/) to model agile, open, and inclusive teams that demonstrate the value of technical experts, procurement decision-makers, strategic deciders, and frontline public servants working together toward the same goal.
+
+In many parts of government, hierarchical processes and communication patterns make it unusual for decision-makers (like managers, contracting officers, agency leadership) to work together with “doers” (like designers, customer service staff, software developers, program staff) on a daily basis.
+
+Hierarchy can be a good tool for specialization and focus — but **it takes healthy multidisciplinary collaboration to build effective, resilient technology products** in a rapidly changing environment. Our hope is that working with us will equip our partners to build (and hire) healthy, high-functioning teams for the long term.
+
+## Project rituals and meetings
+
+We use agile rituals to hold ourselves accountable, build momentum, and get comfortable working iteratively and changing processes. If you’re new to agile, start with the [agile manifesto](http://agilemanifesto.org/) or drop by [#g-agile](https://gsa-tts.slack.com/messages/g-agile/).
+
+Project teams at 18F tend to use a “best of both” hybrid of lightweight [Scrum](https://www.scrum.org/resources/what-is-scrum) (planning, standups, and retros) and [Kanban](https://drive.google.com/file/d/0B0Qfvc1P_XBFVk5rM2tGcDBoUjQ/view) (project boards and continuous prioritization). Most teams default to two-week sprints, but might try shorter or longer sprints if the team thinks they’d be more effective.
+
+Teams adapt the length, format, and cadence of meetings to fit their needs. You can expect most teams to have these meetings:
+
+* **Sprint planning:** identify, document, assign, and prioritize upcoming goals and tasks. Some teams also hold a separate backlog grooming meeting.
+* **Standups:** daily or near-daily check-ins to ensure everyone on the team has what they need, is making progress, and knows what to focus on.
+* **Demo or review:** review sprint goals and present progress. Some teams treat this as one meeting, some hold two meetings and invite a wider set of stakeholders to demo.
+* **Retrospective:** reflect on processes and identify how the team could work together better.
+
+**Including agency partners in sprint rituals** is a powerful way to model how we work on a daily basis. Most teams include partners in most (or all) sprint rituals by the end of the Path Analysis or early in the Experiment & Iterate phase.
+
+**Further reading**
+
+* [Introduction to agile](https://docs.google.com/presentation/d/1492vzbeA2xXsajOYEugn3CzfRIZ3rCkrqQZ8F3_m8GM/edit#)
+* [Overview of sprint ceremonies](https://docs.google.com/presentation/d/1OyU8-PL4-iQ9P_K21OWuoYYgLdWTDSSOuGvehIzpfVk/edit#)
+
+## Making remote collaboration work
+
+Collaboration at 18F depends on navigating the tools and norms of distributed work. We hire remote workers (or full-time [teleworkers]({{site.baseurl}}/telework/#if-you-work-a-full-time-telework-schedule-often-called-virtual-or-remote-you), to use the government term) because it’s how we attract and hire folks with the skills we need. Having a distributed team also increases our geographic diversity and forces us to maintain healthy, intentional communication.
+
+In many federal agencies, remote work has a reputation for impeding collaboration, so it's incumbent on us to demonstrate that a distributed team can be an asset, not a liability. Here are some of the practices that make it work well for us:
+
+* **Overcommunicate — with intentionality.** Don't feel like you're bothering someone by restating or asking questions: it may save the whole team time and headaches in the long run. For example, [let people know where you are when you’re traveling or out of office](https://docs.google.com/document/d/1qgA-vEQ1_t5plPCAs1aCOAjK0RXQzka2hHSVhoa6v5o/edit).
+* **Default to open.** Have conversations with your team in the widest appropriate channel. For instance, discuss decisions in the partner project channel, rather than in direct messages.
+* **Make the work visible.** Use tools that make it possible for the team to see each others’ work (like GitHub, Trello, or Mural). This blog post about [making a distributed design team work](https://18f.gsa.gov/2016/04/27/making-a-distributed-design-team-work/) has good examples.
+* **Treat everyone as remote.** There’s no such thing as a half-remote team; if anyone on the team is not co-located, default to remote practices. Even if this means having people sitting separately in the same office plugged into the same remote meeting, it can help streamline participation. In other words, everyone should get to operate their own mute button.
+* **Set aside time for meeting prep.** Getting the right tools or documents queued up pre-meeting helps move quickly and makes meetings feel more productive. It also helps everyone come ready to contribute, even if they’re uncomfortable speaking off the cuff. ([18F blog post: How to run an efficient meeting](https://18f.gsa.gov/2016/12/14/how-to-run-an-efficient-meeting/))
+* **Documentation is crucial.** Write it down, whatever it is. When the team makes a decision or decides on a next step, make sure it’s reflected in GitHub, notes, or email. If people are storing information in their heads or notebooks, it makes handoff and collaboration slower.
+
+### Making the most of remote meetings
+
+Generally, treat remote meetings the same way you would treat in-person meetings: be at your workspace, on time, and focused.
+
+* **Work from a quiet space** without much background noise. If you need to discuss sensitive topics, present to partners or stakeholders, or handle personnel issues, make sure you have privacy.
+* **Default to using video** so colleagues can see your face and gestures. Nonverbal feedback and cues help keep the conversation moving while building empathy and trust. If you do “facemute” (for instance, because you’re eating), turn video back on when you can. For more about our video conferencing tool, see [meetings and meeting tools]({{site.baseurl}}/meetings-and-meeting-tools/).
+* **Mute your microphone** when you aren’t speaking in large meetings so your background noise doesn’t override others’ mics. Un-muting also signals that you’d like to speak, much like leaning forward in an in-person meeting.
+* **Occasionally** you may need to take a meeting from transit or from a non-workspace; that should be rare, and only for meetings that don’t involve screen-sharing, remote collaboration, or presentations.
+
+## Creating inclusive teams and meetings
+
+The foundation and principles of our approach to inclusion are outlined in the [TTS Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md); we also expect project teams to be **proactive about creating inclusive environments** for collaboration in everything they do.
+
+### Be intentional about forging new teams
+
+Each time a new team forms—or anytime someone joins an existing team—is a chance to set an inclusive tone and re-establish team norms.
+
+* **Use introductions to set the tone.** Take a moment at the beginning of each meeting to make sure everyone’s met, and (if not) introduce the team and welcome new attendees. In introductions, **include your name, pronouns, and role**. Location can also be nice, if only to know what time it is for everyone.
+* **Get to know each other!** If you’re working with someone new, set up a virtual tea to learn about their life, background, and strengths. A little investment in the relationship often pays dividends later on as you collaborate.
+* **Establish team norms** for communication, working hours, feedback, and decision-making. A [team charter](https://docs.google.com/document/d/1J8MqOA-JkLKzSFTVxeXDQub7ZTsWuNq5nOZ_ACICdig/edit#) can help facilitate this conversation.
+* **Talk about roles and expectations.** Knowing who’s [leading the project]({{site.baseurl}}/leading-projects/) and what each team member expects to contribute can help everyone feel comfortable owning their work and asking for what they need from others.
+
+### Make space for each other’s voices
+
+Pay attention to what voices and perspectives voices dominate. If you notice imbalance, be proactive about helping new perspectives come through:
+
+* **Concurrent silent writing** in a shared document (like Google Docs or Mural), can help gather ideas and make sure everyone’s contributed their thoughts without forcing folks to speak.
+* **Careful facilitation** (for instance, “Let's go around the room, 30 seconds each”) can balance voices so everyone has space to speak.
+* **Explicitly invite input or questions** from quieter team members, either in public (“Herbert, what do you think? I know you have expertise in this area”) or privately (by DMing them to note that you’d value their voice on an issue).
+
+### Appreciate and harness creative tension
+
+Disagreement is inevitable on projects. Creative tension is a feature of diverse cross-functional teams, not a bug. Here are some ways for teams to build trust as they manage differences of opinion, style, or approach:
+
+* **Use retros to surface concerns early.** When things feel a little off or the team is struggling, raise issues early instead of waiting for them to boil over. This also helps partners see how we work together to improve how the team functions. (Note: retros aren’t the right place to surface tough feedback that would be best delivered directly to individuals.)
+* **Be proactive about honest conversation.** Remote work can make it tempting to avoid difficult conversations. When there’s real disagreement about the path forward, schedule time to discuss it. (For instance, “it surfaced in the retro that we have different ideas about how to move forward. Let’s schedule 60 minutes to talk about this as a team and come to a decision together.”)
+* **Allow space for exploratory conversations.** We often work on hard issues without easy or immediate answers. Focusing on solutions too early can lead teams to [avoid systemic issues](https://nonprofitaf.com/2019/04/solutions-privilege-how-privilege-shapes-the-expectations-of-solutions-and-why-its-bad-for-our-work-addressing-systemic-injustice/) or shortcut necessary collaborative thinking. Scheduling regular, timeboxed space for revisiting [wicked problems](https://en.wikipedia.org/wiki/Wicked_problem) can help those larger questions fit in with other work productively.
+

--- a/_pages/welcome-to-TTS/classes/intro-to-open-source.md
+++ b/_pages/welcome-to-TTS/classes/intro-to-open-source.md
@@ -4,6 +4,7 @@ navtitle: Open source
 tags:
 - open source
 - guide
+outdated: true
 ---
 
 ## What is open source software?

--- a/_pages/welcome-to-TTS/classes/meetings-and-meeting-tools.md
+++ b/_pages/welcome-to-TTS/classes/meetings-and-meeting-tools.md
@@ -4,56 +4,35 @@ title: Meetings and meeting tools
 
 Here, you'll find a list of tools folks at TTS use to schedule meetings, along with information about some specific meetings at TTS.
 
-## <a id="general-meetings">General meetings</a>
+## <a id="meetings-tools">Meeting tools</a>
 
-### <a id="gsa-policy">Compliance with GSA policies</a>
-Our agency maintains a formal meeting, conference, and event policy which may be found [here](http://www.gsa.gov/portal/mediaId/205471/fileName/OAS_57851_Conference_and_Event_Management_(Signed_on_January_28__2015).action). The most applicable part of this policy for TTS is the approval requirement for internal meetings that _require the travel of more than six employees or will cost more than $10,000._ For these meetings, approval of both the Commissioner of the Technology Transformation Service and the Deputy Administrator of GSA via the [Salesforce Event Tracker](https://gsa.my.salesforce.com/a1b/o) system. For further information and help getting your request submitted, please go to the [#training-conferences](https://gsa-tts.slack.com/messages/training-conferences) Slack channel.
-
-### <a id="your-own">Your own meetings</a>
-
-Remember that you can book time on your own calendar. We recommend blocking off your own "free" time in two-to-four hour chunks to complete tasks.
-
-Also, meetings can and should be designed. If you're planning a meeting, be sure to state your goal -- what the meeting is and what it isn't -- in an agenda. The [#wg-workshops](https://gsa-tts.slack.com/messages/workshops) Slack channel is a good place to ask for help about meeting design. You can also use the "Discover" and "Decide" methods from 18F's [Design Methods](https://methods.18f.gov/) as a starting point.
-
-### <a id="townhalls">TTS Townhalls</a>
-
-TTS brings everyone together for monthly Townhalls. You'll hear well in advance about any upcoming townhalls, which should give you ample time to plan (and rearrange your schedule, if necessary). Conversations during Townhall meetings take place in the Slack channel [#townhall](https://gsa-tts.slack.com/messages/townhall).
-
-### <a id="location-specific">Location-specific meetings</a>
-
-Individual offices have rituals that you might want to take part in. Check in your local office Slack channel for more information!
-
-### <a id="working-group">Working-group meetings</a>
-
-[Working groups]({{site.baseurl}}/working-groups-and-guilds-101) shape the culture, frameworks, and work style across TTS. They often meet weekly. If you're interested in a working group's focus, you should join the group and attend meetings. And you don't have to become a permanent member of a working group to attend the occasional meeting. For example, newcomers occasionally join the onboarding working group's meetings (even if they don't want to take part in the working group itself) to voice their concerns about the onboarding process.
-
-### <a id="opp-all-hands">OPP All Hands</a>
-
-OPP All Hands are a monthly, 1.5 hour opportunity for OPPers to hear updates from leadership, share kudos, welcome new teammates, learn about new initiatives within the team and across the division, and hear news and updates from existing programs. They typically take place on the third Tuesday of the month at 1 pm EST.
-
-### <a id="standups">Project standups</a>
-
-Standups are generally daily meetings that teams use to track work and stay in touch. Work with your project team to decide what format and cadence of standup will be most productive for your team.
-
-### <a id="retrospectives">Project retrospectives</a>
-
-Another project-specific meeting is the retrospective (called a retro, for short). This usually happens at the end of a two-week-long design or development sprint.
-
-The idea behind the retro is pretty simple: This meeting provide an opportunity for the team to reflect on how it's working. Like standups, retros are another project-governance meeting.
-
-They generally take between 30 and 45 minutes, and involve a few chunks of time: between five and eight minutes to write down what worked, between five and eight minutes to write down what needs addressing, and between five and eight minutes to write down what didn't work. Lastly, people can vote on issues and then discuss the most-voted-for ones as a team. The product of the meeting is "action items" that help the team function better next time.
-
-### <a id="sprint-planning">Sprint planning</a>
-
-The last project-specific meeting is sprint planning. Sprint planning takes many forms, but the goal is to come together to decide what to do (and how to estimate the work being done) during an upcoming sprint.
-
-## <a id="meetings-tools">Tools</a>
-
-Here are some of the tools TTS uses to facilitate meetings.
+Here are some of the tools TTS uses to facilitate meetings:
 
 - [Google Meet]({{site.baseurl}}/google-meet/)
 - [Google Calendar]({{site.baseurl}}/google-calendar/)
 - [Zoom]({{site.baseurl}}/zoom/)
 - [Meeting Space]({{site.baseurl}}/gsa-internal-tools/#meeting-space) (for conference lines)
 - Adobe Connect
+
+## <a id="general-meetings">General meetings</a>
+
+### <a id="gsa-policy">Compliance with GSA policies</a>
+
+Our agency maintains a formal meeting, conference, and event policy which may be found [here](http://www.gsa.gov/portal/mediaId/205471/fileName/OAS_57851_Conference_and_Event_Management_(Signed_on_January_28__2015).action). The most applicable part of this policy for TTS is the approval requirement for internal meetings that _require the travel of more than six employees or will cost more than $10,000._ For these meetings, approval of both the Commissioner of the Technology Transformation Service and the Deputy Administrator of GSA via the [Salesforce Event Tracker](https://gsa.my.salesforce.com/a1b/o) system. For further information and help getting your request submitted, go to the [#training-conferences](https://gsa-tts.slack.com/messages/training-conferences) Slack channel.
+
+### <a id="townhalls">TTS Townhalls</a>
+
+You'll hear well in advance about any upcoming townhalls, which should give you ample time to plan (and rearrange your schedule, if necessary). Conversations during Townhall meetings take place in the Slack channel [#townhall](https://gsa-tts.slack.com/messages/townhall).
+
+### <a id="location-specific">Location-specific meetings</a>
+
+Individual offices have rituals that you might want to take part in. Check in your local office Slack channel for more information!
+
+### <a id="working-group">Guilds and working groups</a>
+
+[Working groups and guilds]({{site.baseurl}}/working-groups-and-guilds-101) shape culture, frameworks, and discipline best practices across TTS. You don't have to become a permanent member of a working group to attend meetings.
+
+### <a id="opp-all-hands">OPP All Hands</a>
+
+OPP All Hands are a monthly, 1.5 hour opportunity for OPPers to hear updates from leadership, share kudos, welcome new teammates, learn about new initiatives within the team and across the division, and hear news and updates from existing programs. They typically take place on the third Tuesday of the month at 1 pm EST.
 


### PR DESCRIPTION
This PR adds content about how 18F works ([drafted here](https://docs.google.com/document/d/1XvCxOP0dMle3gR4BMII3Zm-FcaHMbp1g1JjtcFnCW_I/edit#)) to the Handbook. Many thanks to @awfrancisco, @thebestsophist, @edmullen, @alexsoble, @ecayer for all the incredibly thoughtful input and revision on this content. [ 🤝 PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/handbook/collab/how-we-collaborate/)

As part of bringing this into the handbook, I removed some duplicate/outdated content from the Meetings and meeting tools page.

(I also added the "outdated" banner to an outdated page.)