### PR TITLE
updated phishing section with instructions from GSA IT

### DIFF
--- a/_pages/policies/tech-policies/security-incidents.md
+++ b/_pages/policies/tech-policies/security-incidents.md
@@ -13,20 +13,18 @@ See GSA’s Insite: [Report IT Security Incidents or Suspicious Activity](https:
 If you detect any unusual or suspicious activity on your computer, DO NOT turn off your computer. By turning off the computer, valuable evidence may be lost. For questions about GSA’s Incident Response Program, contact the GSA Incident Response (IR) Team at [gsa-ir@gsa.gov](mailto:gsa-ir@gsa.gov).
 
 ## Reporting phishing emails
-If you receive a phishing email, follow these steps to report to GSA IT:
+If you receive a phishing email, follow these steps:
 
 1. Do not click any links in the email. Do not delete it yet. You may mark it as spam.
-1. If you can, click the `Show Original` option in the "triangle" menu associated with the email. This will open a new window with the Original Message above and the raw text of the email below.
-1. Click on the `Download Original` link halfway down the page and it will save text of the email to your hard drive.
-1. Forward the email to itservicedesk@gsa.gov. As long as you haven't clicked on link or downloaded the file, you may stop here.
-1. After receiving your notification to GSA, IT will create a ticket and may contact you for more information. If you were unable to retrieve the raw headers above, IT may need to access your computer to view the email.
-1. After GSA IR confirms that they have all they need to investigate, mark the email as a phishing email by selecting the `Report phishing` option in the same "triangle" menu associated with the email.
+1. Follow the ["To report a suspicious email" directions](https://insite.gsa.gov/topics/information-technology/do-it-yourself-self-help/google-g-suite-apps/email-with-gmail/phishing-emails-and-scams) on insite.
+1. This should instruct you in how to use the Cofense tool (the little fish icon that should be on the right) to report the phish.
+1. GSA IT will triage and let you know what they need you to do, if anything.
 
 ## Reporting phishing incidents
 If you also clicked on a link in a phishing email, follow these steps to report to GSA IR:
 
 1. If you haven't already, follow the steps above for reporting phishing emails, and then continue to the next step.
-1. Forward the phishing email to gsa-ir@gsa.gov and devops@gsa.gov and attach the original text you downloaded. Please include *Security Incident* in the subject line, along with a brief description of the issue (Ex. Clicked on link in phishing email).
+1. Send an email to  itservicedesk@gsa.gov and devops@gsa.gov. Please include *Security Incident* in the subject line, along with a brief description of the issue (Ex. Clicked on link in phishing email).
 1. Report the phishing email in the [#incident-response](https://gsa-tts.slack.com/messages/incident-response) Slack channel.
 
 ## Reporting other incidents

--- a/_pages/policies/tech-policies/security-incidents.md
+++ b/_pages/policies/tech-policies/security-incidents.md
@@ -13,7 +13,7 @@ See GSA’s Insite: [Report IT Security Incidents or Suspicious Activity](https:
 If you detect any unusual or suspicious activity on your computer, DO NOT turn off your computer. By turning off the computer, valuable evidence may be lost. For questions about GSA’s Incident Response Program, contact the GSA Incident Response (IR) Team at [gsa-ir@gsa.gov](mailto:gsa-ir@gsa.gov).
 
 ## Reporting phishing emails
-If you receive a phishing email, follow these steps:
+If you receive a suspicious email, follow these steps:
 
 1. Do not click any links in the email. Do not delete it yet. You may mark it as spam.
 1. Follow the ["To report a suspicious email" directions](https://insite.gsa.gov/topics/information-technology/do-it-yourself-self-help/google-g-suite-apps/email-with-gmail/phishing-emails-and-scams) on insite.

--- a/_pages/policies/tech-policies/security-incidents.md
+++ b/_pages/policies/tech-policies/security-incidents.md
@@ -16,7 +16,7 @@ If you detect any unusual or suspicious activity on your computer, DO NOT turn o
 If you receive a suspicious email, follow these steps:
 
 1. Do not click any links in the email. Do not delete it yet. You may mark it as spam.
-1. Follow the ["To report a suspicious email" directions](https://insite.gsa.gov/topics/information-technology/do-it-yourself-self-help/google-g-suite-apps/email-with-gmail/phishing-emails-and-scams) on insite.
+1. Follow the ["To report a suspicious email" directions](https://insite.gsa.gov/topics/information-technology/do-it-yourself-self-help/google-g-suite-apps/email-with-gmail/phishing-emails-and-scams#Report%20suspicious%20emails) on the [Phishing Emails and Scams InSite page](https://insite.gsa.gov/topics/information-technology/do-it-yourself-self-help/google-g-suite-apps/email-with-gmail/phishing-emails-and-scams#Report%20suspicious%20emails).
 1. This should instruct you in how to use the Cofense tool (the little fish icon that should be on the right) to report the phish.
 1. GSA IT will triage and let you know what they need you to do, if anything.
 


### PR DESCRIPTION
I reported a Phish, and they told me that I was doing it wrong, and that I should be using Cofense, and gave me a URL.  I have attempted to bring that update in here.

I would love it if we could remove the incident-response channel stuff too, because they seem to want to be the canonical responders, but it seems like that sort of change would need to be approved by the TTS infrastructure group.
