### PR TITLE
change suggested order of travel courses

### DIFF
--- a/_pages/policies/travel-and-leave-policies/first-time-travel-travel-card.md
+++ b/_pages/policies/travel-and-leave-policies/first-time-travel-travel-card.md
@@ -19,10 +19,10 @@ _Est. time: 60 minutes_
 1. Head over to GSA's [OLU](https://gsaolu.gsa.gov).
 2. Click on the Home button, and then choose "Learning" from the dropdown.
 3. Below, look for a "Find Learning" search box.
-4. Search for "travel card".
-5. Select "GSA Travel Card Training", and then Start course.
-6. Once completed there is a second training to take. Return to the "Find Learning" search box and search for "travel training".
-7. Select "Temporary Duty (TDY) Travel Training", and then Start course.
+4. Search for "travel training".
+5. Select "Temporary Duty (TDY) Travel Training", and then Start course.
+6. Once completed there is a second training to take. Return to the "Find Learning" search box and search for "travel card".
+7. Select "GSA Travel Card Training", and then Start course.
 8. Once completed, download your certificates of completion for both trainings by returning to the "Learning" page and clicking on the "View All" button under "Learning History". You should see your completed travel card and TDY trainings on the list, and there will be an icon to generate a print preview, which you can save, at the right.
 9. For ease of processing later on, save your certificates as “Your Name travel card training” and “Your Name TDY training”.
 


### PR DESCRIPTION
I just did the two required travel courses on OLU. I did them in the order instructed on this page but in retrospect, reversing the order makes more sense because there are terms explained in the travel training that are referenced without explanation in the travel card training. The change reverses the order.