### PR TITLE
Updating ttsjobs

### DIFF
--- a/_pages/policies/detailing-and-offboarding-policies/ttsjobs.md
+++ b/_pages/policies/detailing-and-offboarding-policies/ttsjobs.md
@@ -26,7 +26,7 @@ This page serves as a central listing for:
 - Links to USAJobs Announcements for hiring actions using the Competitive Service (Career) Merit Promotion Process
 - Links to Excepted Service job announcements posted on the TTS Join site
 
-If you’d like to be notified when new opportunities are listed on this page, please join the [#ttsjobs](https://gsa-tts.slack.com/messages/ttsjobs/) slack channel.
+If you’d like to be notified when new opportunities are listed on this page, please join the [#tts-jobs](https://gsa-tts.slack.com/messages/tts-jobs/) slack channel.
 
 ## Announcements
 
@@ -54,4 +54,4 @@ For any TTS staff interested in learning what it’s like to transition from TTS
 ### Still have questions?
 
 **Have questions about an announcement listed?** Please reach out to the Hiring PoC listed on the announcement
-**General questions** Please reach out to TTS Talent via [#ttsjobs](https://gsa-tts.slack.com/messages/ttsjobs/) or [email](mailto:tts-talentteam@gsa.gov) for information regarding hiring.
+**General questions** Please reach out to TTS Talent via [#tts-jobs](https://gsa-tts.slack.com/messages/tts-jobs/) or [email](mailto:tts-talentteam@gsa.gov) for information regarding hiring.

--- a/_pages/policies/employee-resources-policies/hiring.md
+++ b/_pages/policies/employee-resources-policies/hiring.md
@@ -50,7 +50,7 @@ The hiring action owner is responsible for developing job materials and interact
 
 Once the TTSJobs Announcement is complete, Talent will:
 
-- Add it to [#ttsjobs](https://gsa-tts.slack.com/messages/ttsjobs/) on Slack informing everyone of the new opportunity
+- Add it to [#tts-jobs](https://gsa-tts.slack.com/messages/tts-jobs/) on Slack informing everyone of the new opportunity
 - Add it to [TTSJobs Listings]({{site.baseurl}}/ttsjobs/#announcements)
 
 
@@ -89,4 +89,4 @@ For an overview of the way in which hiring actions are collected, prioritized an
 
 ### Still have questions?
 
-**General questions** Please reach out to TTS Talent via [#ttsjobs](https://gsa-tts.slack.com/messages/ttsjobs/) or [email](mailto:tts-talentteam@gsa.gov) for information regarding hiring.
+**General questions** Please reach out to TTS Talent via [#tts-jobs](https://gsa-tts.slack.com/messages/tts-jobs/) or [email](mailto:tts-talentteam@gsa.gov) for information regarding hiring.


### PR DESCRIPTION
Per a conversation in the #ttsjobs slack channel, we're updating the channel name to be #tts-jobs.  This PR updates all of the references to the slack channel in the handbook.  