### PR TITLE
adds a page that points to the staffing repo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -395,6 +395,9 @@ navigation:
       - text: Time tracking and billing
         url: tock/#time-tracking-and-billing
         internal: false
+      - text: How we staff projects
+        url: staffing-projects/
+        internal: true
     - text: 18F chapters
       children:
       - text: Custom Partner Solutions

--- a/_pages/how-we-work/staffing-projects.md
+++ b/_pages/how-we-work/staffing-projects.md
@@ -1,0 +1,6 @@
+---
+title: How We Staff Projects
+---
+
+18F partner projects and 10x projects are staffed using a process outlined in the [staffing repo](https://github.com/18F/staffing).
+The staffing repo README details specific processes for staffing new projects, changing staffing on in-flight projects, and making "microrequests" (requests that are for fewer than eight total hours of work per week overall). 


### PR DESCRIPTION
Resolves issue #1354 

Just aiming to improve the discoverability of the staffing repo.