### PR TITLE
Remove reference to Zoom Scheduling calendar

### DIFF
--- a/_pages/how-we-work/tools/zoom.md
+++ b/_pages/how-we-work/tools/zoom.md
@@ -54,7 +54,7 @@ These meetings do not need to be scheduled in advance and you may hold as many a
 Let the Zoom Admins know as far in advance as possible in [#admins-zoom](https://gsa-tts.slack.com/messages/admins-zoom).
 Currently 18F only has two Pro licenses that allow for meetings longer than 40 minutes. What 
 this means to you is that longer meetings need to be scheduled and are generally a "first come, 
-first served" scenario. Zoom meetings are tracked on a Google Calendar called "Zoom Scheduling." We have one large meeting extension for meetings with over 100 participants. You must have a pro account to have the large meeting extension.
+first served" scenario. We have one large meeting extension for meetings with over 100 participants. You must have a pro account to have the large meeting extension.
 
 Before your scheduled meeting, the Zoom Admins will promote your account to Pro Status. If there are multiple 
 meetings scheduled that day, your account will be promoted as soon as the Pro account is available. The Zoom Admins will try to schedule 15 minutes before the requested time to allow you ample set up time.


### PR DESCRIPTION
We couldn't track this calendar down in onboarding.  I suspect this is an obsolete reference.