### PR TITLE
Add OTP generation to setup

### DIFF
--- a/_pages/how-we-work/tools/anyconnect.md
+++ b/_pages/how-we-work/tools/anyconnect.md
@@ -6,6 +6,7 @@ AnyConnect is a VPN client that we use to connect to GSA's intranet.
 
 ## Setup
 
+### VPN Client
 Your machine may already have AnyConnect installed. If it is, it will be under Cisco>AnyConnect in your Applications.
 
 If it is not installed, here is how you can get access:
@@ -16,6 +17,9 @@ If it is not installed, here is how you can get access:
 Your installation screen should look like this:
 
 ![AnyConnect Installation Screen]({{site.baseurl}}/images/anyconnect/1.png)
+
+### Two-Factor Authentication
+* [Install the phone app](https://preview-insite.gsa.gov/employee-resources/information-technology/do-it-yourself-self-help/telework-technology/secureauth/install-secureauth-otp-on-ios-apple) that will generate one-time passwords that you will need to connect to the VPN.
 
 ## Usage
 

--- a/_pages/how-we-work/tools/anyconnect.md
+++ b/_pages/how-we-work/tools/anyconnect.md
@@ -18,8 +18,15 @@ Your installation screen should look like this:
 
 ![AnyConnect Installation Screen]({{site.baseurl}}/images/anyconnect/1.png)
 
-### Two-Factor Authentication
-* [Install the phone app](https://preview-insite.gsa.gov/employee-resources/information-technology/do-it-yourself-self-help/telework-technology/secureauth/install-secureauth-otp-on-ios-apple) that will generate one-time passwords that you will need to connect to the VPN.
+## Logging into Cisco AnyConnect
+
+  1. Click on Launchpad (Rocket ship icon in the Dock at the bottom of your screen) 
+  2. Click on the Cisco AnyConnect Mobility Client icon to launch
+  3. Select your server in the pop-up window and click connect
+  4. Enter ENT login and password
+  5. Go to [otp.gsa.gov](http://otp.gsa.gov) and enter your ENT info to get the Tokencode
+     - You can also obtain a Tokencode by installing [SecureAuth OTP](https://preview-insite.gsa.gov/employee-resources/information-technology/do-it-yourself-self-help/telework-technology/secureauth/install-secureauth-otp-on-ios-apple)) on your phone, as described in the [Get a one-time password?]({{site.baseurl}}/distributed/#otp) handbook section
+  6. Enter the Tokencode back into thee AnyConnect pop-up screen and submit
 
 ## Usage
 


### PR DESCRIPTION
While setting up my own VPN, I got tripped up by not having the one time password client installed on my phone.  I thought the OTP that it was asking for was one of the many other passwords asked for in the setup process.  Figured it would help others doing this setup to spell out the need for the phone app here.