### PR TITLE
Github Desktop is approved

### DIFF
--- a/_pages/how-we-work/tools/github.md
+++ b/_pages/how-we-work/tools/github.md
@@ -10,7 +10,7 @@ GSA IT has staff that manage GSA's GitHub org. See more information about that i
 
 ## <a id="setup">Setup</a>
 
-GitHub is a web application, so there's no installation necessary. Due to security restrictions, the GitHub Desktop app is ***not*** currently approved for use at GSA.
+GitHub is a web application, and you may be able to do all of your work within the [github.com](https://github.com) website. Optionally, you may also install the GitHub [desktop application](https://desktop.github.com/).
 
 If you don&rsquo;t have a GitHub account, you must use your work email (rather than your personal email) to [sign up](https://github.com/join), as this helps us with [records retention]({{site.baseurl}}/records-management) and identification. If you do have a GitHub account, please [add your work email to your profile](https://github.com/settings/emails) as your primary email.
 


### PR DESCRIPTION
Update documentation to indicate that you can install GitHub Desktop if you wish.  Per GEAR and Ron, this has been approved.