### PR TITLE
Removed GSA Telework Policy [outdated]

### DIFF
--- a/_pages/policies/employee-resources-policies/telework.md
+++ b/_pages/policies/employee-resources-policies/telework.md
@@ -11,6 +11,7 @@ A core belief of TTS is, “Work is what we do, not where we are.”  The goal o
 
 ## GSA Telework links
 
+* [GSA Workforce Mobility and Telework Policy](https://www.gsa.gov/directives-library/gsa-workforce-mobility-and-telework-policy-60401a-hrm-0)
 * [How to Create a Telework Agreement in HR Links (PDF)](https://corporateapps.gsa.gov/wordpress/wp-content/uploads/2018/11/Job-Aid_Telework-for-Employees_FINALv2.pdf)
 * For new hires in FT telework roles, [a simplified guide to submit your Telework Agreement in HR Links]({{site.baseurl}}/telework-agreement-new-ft/).
 

--- a/_pages/policies/employee-resources-policies/telework.md
+++ b/_pages/policies/employee-resources-policies/telework.md
@@ -11,7 +11,7 @@ A core belief of TTS is, “Work is what we do, not where we are.”  The goal o
 
 ## GSA Telework links
 
-* [GSA Workforce Mobility and Telework Policy](https://www.gsa.gov/directives-library/gsa-workforce-mobility-and-telework-policy-60401a-hrm-0)
+* [GSA's Workforce Mobility and Telework Policy](https://www.gsa.gov/directives-library/gsa-workforce-mobility-and-telework-policy-60401a-hrm-0)
 * [How to Create a Telework Agreement in HR Links (PDF)](https://corporateapps.gsa.gov/wordpress/wp-content/uploads/2018/11/Job-Aid_Telework-for-Employees_FINALv2.pdf)
 * For new hires in FT telework roles, [a simplified guide to submit your Telework Agreement in HR Links]({{site.baseurl}}/telework-agreement-new-ft/).
 

--- a/_pages/policies/employee-resources-policies/telework.md
+++ b/_pages/policies/employee-resources-policies/telework.md
@@ -11,7 +11,6 @@ A core belief of TTS is, “Work is what we do, not where we are.”  The goal o
 
 ## GSA Telework links
 
-* [GSA’s Telework Policy](https://insite.gsa.gov/portal/content/523510)
 * [How to Create a Telework Agreement in HR Links (PDF)](https://corporateapps.gsa.gov/wordpress/wp-content/uploads/2018/11/Job-Aid_Telework-for-Employees_FINALv2.pdf)
 * For new hires in FT telework roles, [a simplified guide to submit your Telework Agreement in HR Links]({{site.baseurl}}/telework-agreement-new-ft/).
 


### PR DESCRIPTION
Removed hyperlinked GSA Telework policy from bullets - https://insite.gsa.gov/directives-library/gsa-mobility-and-telework-policy-60401a-hco

Because the policy is no longer active.
"This directive has been cancelled by GSA Order, HRM 6040.1A, dated June 29, 2018."