### PR TITLE
remove unnecessary anchor tags

### DIFF
--- a/_pages/about-us/diversity.md
+++ b/_pages/about-us/diversity.md
@@ -7,7 +7,7 @@ TTS believes that diversity matters and is vital to a successful organization.
 TTS is committed to promoting an inclusive environment where all individuals
 are empowered to succeed.
 
-## <a id="documentation">Documentation</a>
+## Documentation
 
 The foundation for the Diversity Guild's work is the
 [TTS Code of Conduct]({{site.baseurl}}/code-of-conduct/).
@@ -17,15 +17,15 @@ to solve that we created the
 [Diversity Talking Points]({{site.baseurl}}/pdfs/diversity-talking-points.pdf)
 [with notes]({{site.baseurl}}/pdfs/diversity-talking-points-with-notes.pdf).
 
-## <a id="diversity-guild">Diversity Guild</a>
+## Diversity Guild
 
 The Diversity [Guild]({{site.baseurl}}/working-groups-and-guilds-101/) strives to make TTS a great place to work for people of all backgrounds; to foster diversity of all kinds; and to create a culture where people feel safe, work joyfully, and communicate openly. It aims to do this all while providing great services for the American people.
 
-### <a id="leadership">Leadership</a>
+### Leadership
 
 The Diversity Guild is led by [Cordelia Yu](https://gsa-tts.slack.com/messages/@bcordeliayu) and [Deb Baptiste](https://gsa-tts.slack.com/messages/@debbaptiste).
 
-### <a id="communication">Communication</a>
+### Communication
 
 Find us in Slack:
 
@@ -34,14 +34,14 @@ Find us in Slack:
 
 _It&rsquo;s important that the responsibility of answering questions around diversity and inclusion doesn&rsquo;t fall on one or two people. Our Slack channel is open space in which our colleagues (who genuinely want to do the right thing) can ask hard questions of one another. It allows us to collectively place the responsibility of diversity and inclusion on multiple people rather than any one person._
 
-### <a id="philosophy">Philosophy</a>
+### Philosophy
 
 The Diversity Guild is a space for learning. If you make a mistake &mdash; and we all do &mdash; a key component of diversity is that we have a culture of mindfulness and trying to do better. Remaining open to feedback, learning about why an action was offensive, and then apologizing is the kind of environment we look to cultivate.
 
 The guild realizes that building an inclusive environment is tough, but it&rsquo;s far from impossible. We base our work on actionable items and deliverables which are reflected in our [Outcomes and Key Results (OKRs)](https://docs.google.com/a/gsa.gov/document/d/1bXXVpGE0OGFTJHQklo4k7-M83dA4RQqvN5qIGklzh1g/edit?usp=sharing). These OKRs are discussed and decided every quarter.
 
 
-### <a id="trello">Tracking progress on Trello</a>
+### Tracking progress on Trello
 
 The Diversity Guild tracks its progress on Trello. If you&rsquo;re interested in joining, reach out to the channel and they&rsquo;ll share the Trello board with you. Currently, the group's board is set up like this:
 
@@ -52,7 +52,7 @@ The Diversity Guild tracks its progress on Trello. If you&rsquo;re interested in
 - **Done.** Things that are fully completed — we will celebrate them during our next meeting!
 
 
-### <a id="how-to-get-involved">How to get involved</a>
+### How to get involved
 
 Not only does the Diversity Guild a space for learning, it also promotes the belief in sharing what you've learned. The group is developing a Diversity Guide that has the goal of providing insight on how TTS integrates diversity principles at every point: from recruitment, interviewing, and onboarding to retention, such as professional development and benefits.
 

--- a/_pages/about-us/offices/distributed.md
+++ b/_pages/about-us/offices/distributed.md
@@ -36,9 +36,9 @@ title: Distributed
 
 _Before you do anything, read our [best practices for making distributed teams work](https://18f.gsa.gov/2015/10/15/best-practices-for-distributed-teams/)._
 
-## <a id="how-do-i">How do I&hellip;</a>
+## How do I&hellip;
 
-### <a id="set-up-my-computer">Set up my computer?</a>
+### Set up my computer?
 
 TTS employees receive a MacBook and an iPhone from GSA, though you may not receive your work phone on your first day.
 
@@ -46,39 +46,39 @@ On your first day at work you should configure things so that your two-factor au
 
 See the [Equipment page]({{site.baseurl}}/equipment/#phone) for more about how to set up 2FA so you can receive GSA 2FA codes on your cell phone.
 
-### <a id="otp">Get a one-time password?</a>
+### Get a one-time password?
 
 To get a one time password (OTP, required for logging in to some systems), you can either:
 
 * Setup a [SecureAuth client application](https://www.secureauth.com/support/downloads/client-applications) by following [these instructions]({{site.baseurl}}/pdfs/setting_up_otp_for_remote_access.pdf).
 * Visit [otp.gsa.gov](https://otp.gsa.gov).
 
-### <a id="listen-to-all-hands">Listen to and participate in the weekly Tuesday all-hands meeting?</a>
+### Listen to and participate in the weekly Tuesday all-hands meeting?
 
 We use a videocall for our all-hands meetings. Instructions are in the calendar event details.
 
-### <a id="visit-another-gsa-building">Visit another GSA building?</a>
+### Visit another GSA building?
 
 Your badge should work in other GSA buildings. <a href="https://gsa-tts.slack.com/messages/@kathryn/">Kathryn Connolly</a> can submit paperwork to get permission for you to enter the NYC, Chicago, or D.C. buildings, which will take a few days. After you receive an email confirmation, visit the security office in that new building to activate your card.
 
-### <a id="connect-to-gsa">Connect to the GSA network remotely?</a>
+### Connect to the GSA network remotely?
 
 See [Networks]({{site.baseurl}}/networks) for details.
 
-### <a id="get-my-laptop-repaired">Get my laptop repaired?</a>
+### Get my laptop repaired?
 
 First, go to [#teamops](https://gsa-tts.slack.com/messages/teamops/) for advice. They will likely either ask you to take it to an Apple Store (TTS will pay for the repairs), or ship it back to TTS (we&rsquo;ll ship you a new laptop).
 
-### <a id="tether">Tether to my GSA phone?</a>
+### Tether to my GSA phone?
 
 Apple&rsquo;s instructions [are here](https://support.apple.com/en-us/HT204023).
 
-### <a id="supplies">What supplies do distributed employees receive?</a>
+### What supplies do distributed employees receive?
 
 GSA provides remote workers with a laptop and phone but does not provide monitors, desk chairs, or office products.
 
 
-### <a id="advice">What advice do your distributed colleagues have?</a>
+### What advice do your distributed colleagues have?
 
 From Peter Karman and Becky Sweger:
 

--- a/_pages/about-us/teams/design.md
+++ b/_pages/about-us/teams/design.md
@@ -14,7 +14,7 @@ The Design team at 18F includes content, user experience, front end, and visual 
 - **Interaction design and front end development.** We work with people to wireframe and prototype simple, beautiful, usable interactions.
 - **Visual design.** We help people more clearly communicate through visualizations and illustrations as well as solid graphic design knowhow.
 
-## <a id="documentation">Documentation</a>
+## Documentation
 
 - [Experience Design capabilities](https://docs.google.com/presentation/d/1aOeq5SsLSMhskchlJRtSLQ28OcIzAQgkanyDZy7bPiU/edit)
 - [18F Visual Identity Guide](https://brand.18f.gov/)
@@ -23,7 +23,7 @@ The Design team at 18F includes content, user experience, front end, and visual 
 - [Design Methods](https://methods.18f.gov/)
 - [Design Wiki](https://github.com/18F/Design-Wiki)
 
-### <a id="suggested-reading">Suggested reading</a>
+### Suggested reading
 
 - [18F Partnership Playbook](https://pages.18f.gov/partnership-playbook/)
 - [Lean Product Design Guide](https://pages.18f.gov/lean-product-design/)
@@ -54,11 +54,11 @@ Welcome to the 18F Design team — we’re happy you’re here! We’ve compiled
 
 You might not have much assigned work during your first two weeks here. That’s okay and expected. If you’ve gotten all the government onboarding items done and a project _still_ hasn’t landed, the design team has a list of internal projects that aren’t funded but that will help us all work better together. Talk to your design lead (more on that, below) to get more information about these internal projects and how you can get involved.
 
-## <a id="who-we-are">Who we are</a>
+## Who we are
 
 The Design team at 18F includes content, user experience, front-end, and visual designers. We are researchers, editors, prototypers, illustrators, and wordsmiths. We come from a variety of backgrounds, including government, non-profits, consultancies, corporations, and academia.
 
-### <a id="structure">Structure</a>
+### Structure
 
 As per the [org chart](https://docs.google.com/presentation/d/189TanLPSFF9MWvNr6VdfUvhBAWBSXeoCSGD2ZXRDm3s/edit?usp=sharing), 18F Design is itself composed of the content design, user experience (UX) design + frontend design, and visual design teams. Members of the Design team are active participants in the content, frontend, and research [guilds]({{site.baseurl}}/working-groups-and-guilds-101).
 
@@ -66,7 +66,7 @@ As these teams have grown in size, we’ve introduced **leads** and **supervisor
 
 Members of the Design team are also assigned to **critique groups.** These groups meet regularly (barring more urgent project activities) to discuss work in progress and help the Design team maintain its storytelling and presentation skills. Critique groups also have leaders, and their groupings change periodically. These rotations are announced ahead of time, and if you're interested in taking a turn as a critique lead, you can raise your hand as a candidate at that time.
 
-## <a id="what-we-do">What we do</a>
+## What we do
 
 18F Design provides design as a service to the rest of the organization, including:
 
@@ -76,9 +76,9 @@ Members of the Design team are also assigned to **critique groups.** These group
 - **Interaction design and frontend development.** We work with people to develop prototypes and wireframes, discover and implement new technologies to produce simple, beautiful, usable, interactions.
 - **Visual design.** We help people more clearly communicate through visualizations and illustrations as well as solid graphic design knowhow.
 
-## <a id="how-we-work">How we work</a>
+## How we work
 
-### <a id="rituals">Rituals</a>
+### Rituals
 
 Most of the design team works on a mix of partner-agency projects and internal initiatives. As you’d guess, everyone’s weeks look a little different. That said, there are recurring weekly meetings and commitments we all have on our calendars.
 
@@ -86,13 +86,13 @@ Most of the design team works on a mix of partner-agency projects and internal i
 - **Once a week:** meet with your lead. Once a week, you’ll have a short check-in with your Design lead at a time that’s convenient for both of you. The purpose of this meeting is both administrative and personal. It’s how the team leadership keeps on top of project timelines and activities to coordinate resourcing. It’s also a time to talk through any project concerns, figure out how to wrangle the federal bureaucracy, and talk about how to make 18F work better for you.
 - **Once a week:** meet with your critique group. Once a week, you’ll meet with your critique group to talk about creative questions and share work. Critique teams decide internally how often and how long they want to meet.
 
-### <a id="communication-channels">Communication channels</a>
+### Communication channels
 
 - **Mailing lists**
   - 18F-xd@gsa.gov is a Google group for all members of the design chapter. Your supervisor is responsible for adding you to this list — no need to worry about registering.
   - Other mailing lists are listed [here]({{site.baseurl}}/general-contacts-and-listservs/#listservs).
 
-### <a id="tools">Tools</a>
+### Tools
 
 Here are some common tools we use, how we use them, and how you can get access to them. If you can’t find the information you need in the chart below, get in touch with your design lead; they’ll be able to point you in the right direction.
 
@@ -125,7 +125,7 @@ Every project and team has a different mix of project management tools based on 
 - **Google Drive / Docs / Slides:** This is our primary tool for documents of various sorts.
 - **Microsoft Office:** We use this rarely and only for collaboration with those partner agencies who rely on it. [Follow the instructions](https://docs.google.com/document/d/1ca1Ka0R9XBaxRhpagGUKPgVzO589_bx89GWMogQintM/edit?usp=sharing) to get a license if your project work requires it.
 
-### <a id="assets">Assets</a>
+### Assets
 
 We default to free and open-source assets, unless there is a very, very good reason to do otherwise (and you’d better be prepared to defend that reason). Luckily, there are a lot of great resources for us to choose from.
 

--- a/_pages/about-us/teams/engineering.md
+++ b/_pages/about-us/teams/engineering.md
@@ -102,7 +102,7 @@ Are you already a member of 18F and interested in moving into the Engineering Ch
 3. You'll have a meeting with someone from Engineering leadership to review the expectations of being in Engineering, review the appropriate performance profile, and talk about a development plan to improve software skills, if appropriate.
 4. Your current Supervisor, your new Engineering Supervisor, and yourself will agree on a transition date.
 
-## <a id="rituals">Rituals</a>
+## Rituals
 
 Most of the Engineering team works on a mix of partner agency projects and internal initiatives. As you’d guess, everyone’s weeks look a little different. That said, there are recurring weekly meetings and commitments we all have on our calendars.
 

--- a/_pages/how-we-work/equipment.md
+++ b/_pages/how-we-work/equipment.md
@@ -96,7 +96,7 @@ To purchase this type of equipment, go to <https://requests.18f.gov/> and attach
 
 For issues with any GSA-provided hardware (such as laptops or phones), contact the GSA IT Service Desk.
 
-## <a id="stolen-or-lost">Lost or stolen equipment</a>
+## Lost or stolen equipment
 
 If TTS-issued equipment is lost or stolen, follow these mandatory steps.  Employees must follow the GSA procedures for lost or stolen equipment or missing PIV cards, and alert TTS in [#equipment](https://gsa-tts.slack.com/messages/equipment):
 

--- a/_pages/how-we-work/tools/anyconnect.md
+++ b/_pages/how-we-work/tools/anyconnect.md
@@ -25,7 +25,7 @@ Your installation screen should look like this:
   3. Select your server in the pop-up window and click connect
   4. Enter ENT login and password
   5. Go to [otp.gsa.gov](http://otp.gsa.gov) and enter your ENT info to get the Tokencode
-     - You can also obtain a Tokencode by installing [SecureAuth OTP](https://preview-insite.gsa.gov/employee-resources/information-technology/do-it-yourself-self-help/telework-technology/secureauth/install-secureauth-otp-on-ios-apple)) on your phone, as described in the [Get a one-time password?]({{site.baseurl}}/distributed/#otp) handbook section
+     - You can also obtain a Tokencode by installing [SecureAuth OTP](https://preview-insite.gsa.gov/employee-resources/information-technology/do-it-yourself-self-help/telework-technology/secureauth/install-secureauth-otp-on-ios-apple)) on your phone, as described in the [Get a one-time password?]({{site.baseurl}}/distributed/#get-a-one-time-password) handbook section
   6. Enter the Tokencode back into thee AnyConnect pop-up screen and submit
 
 ## Usage

--- a/_pages/how-we-work/tools/github.md
+++ b/_pages/how-we-work/tools/github.md
@@ -8,7 +8,7 @@ GitHub is a closed-source platform for [open-source](https://github.com/18F/open
 
 GSA IT has staff that manage GSA's GitHub org. See more information about that in [the GSA GitHub documentation](https://github.com/GSA/GitHub-Administration#requesting-access-to-the-gsa-organization).
 
-## <a id="setup">Setup</a>
+## Setup
 
 GitHub is a web application, and you may be able to do all of your work within the [github.com](https://github.com) website. Optionally, you may also install the GitHub [desktop application](https://desktop.github.com/).
 

--- a/_pages/how-we-work/tools/google-analytics.md
+++ b/_pages/how-we-work/tools/google-analytics.md
@@ -14,6 +14,6 @@ We use Google Analytics to track traffic and search queries on TTS projects.
 
 * Repo: [analytics standards](https://github.com/18F/analytics-standards)
 
-## <a id="setup">Setup</a>
+## Setup
 
 Because Google Analytics is a web application, there’s no installation necessary. Request access in [#g-analytics](https://gsa-tts.slack.com/messages/g-analytics/). Access is granted within a day or so.

--- a/_pages/how-we-work/tools/google-meet.md
+++ b/_pages/how-we-work/tools/google-meet.md
@@ -25,7 +25,7 @@ You can change your avatar across Google Apps even though Google+ profile editin
  4. Update your profile photo.
  5. Click **Set as profile photo**.
 
-## <a id="setup">Tips</a>
+## Tips
 
 - You can [add a Meet]({{site.baseurl}}/google-calendar/#tips) to Google Calendar invites.
 - All Google Meet meetings include telephone dial-in instructions by default. If someone is unable to join using their computer, you can have them dial in or you can call their phone from the Meet.

--- a/_pages/how-we-work/tools/vmware-horizon.md
+++ b/_pages/how-we-work/tools/vmware-horizon.md
@@ -23,7 +23,7 @@ New employees should have a GSA VMware myView/Horizon account, but if not:
   3. Use ENT info for initial VMware Horizon login-in screen
   4. Go to [otp.gsa.gov](http://otp.gsa.gov) and enter your ENT info to get the Tokencode
      - You can also obtain a Tokencode by installing SecureAuth OTP on your
-       phone, as described in the [Get a one-time password?]({{site.baseurl}}/distributed/#otp)
+       phone, as described in the [Get a one-time password?]({{site.baseurl}}/distributed/#get-a-one-time-password)
        handbook section
   5. Enter the Tokencode back into VMware Horizon login-in screen
 

--- a/_pages/retired-content/intro-to-open-source.md
+++ b/_pages/retired-content/intro-to-open-source.md
@@ -27,19 +27,19 @@ Everything we as a team do should be public and available for collaboration. An 
 
 There are also several [listservs and communities]({{site.baseurl}}/general-contacts-and-listservs/#listservs) that facilitate working with others within the government.
 
-### Would any personally identifiable information (PII) live in open source software? 
+### Would any personally identifiable information (PII) live in open source software?
 
 Open source software has no direct relationship to PII or the Privacy Act. PII is data. "Open source software" refers to the release of code. Data can be managed entirely separately from code, and generally is. Additionally, "open source" is an entirely separate concept from "open data".
 
 For example, whitehouse.gov is powered by an open source system named Drupal. Drupal publishes their software as open source for anyone to use, but this software doesn't contain any of the content or data that users of Drupal might put into it when publishing a website. Another example is WordPress, an open source blogging platform that also powers digitalgov.gov.
 
-## <a id="github-use">GitHub usage at agencies</a>
+## GitHub usage at agencies
 
 1. Every agency is allowed to create a GitHub org, based on OMB 10-23 and the addendum to GitHub's terms of service that GSA coordinated with them to add section 17 at [GitHub's terms of service](https://help.github.com/articles/github-terms-of-service/).
 
 1. Many agencies already have - here's [a list](https://government.github.com/community/#us-federal) of many of them.
 
-1. Any government employee can create an account for themselves.  This was recently [reinforced](https://github.com/project-open-data/project-open-data.github.io/issues/346#issuecomment-169140589) by OMB's Office of the Federal CIO. 
+1. Any government employee can create an account for themselves.  This was recently [reinforced](https://github.com/project-open-data/project-open-data.github.io/issues/346#issuecomment-169140589) by OMB's Office of the Federal CIO.
 
 ---
 

--- a/_pages/welcome-to-TTS/classes/accessibility.md
+++ b/_pages/welcome-to-TTS/classes/accessibility.md
@@ -4,11 +4,11 @@ title: Accessibility
 
 The federal government is accountable for making all of its products 508 compliant, which means everything we make (or buy) needs to be accessible to all users, regardless of their abilities or disabilities. This usually means making sure our products can be used with screen readers and alternate input devices, and that they’re logically easy to follow.
 
-## <a id="leadership">Leadership</a>
+## Leadership
 
-[Nikki Lee](https://gsa-tts.slack.com/messages/@nkkl) and [David Stenger](https://gsa-tts.slack.com/messages/@davidstenger) lead the [accessibility guild](https://github.com/18F/accessibility). 
+[Nikki Lee](https://gsa-tts.slack.com/messages/@nkkl) and [David Stenger](https://gsa-tts.slack.com/messages/@davidstenger) lead the [accessibility guild](https://github.com/18F/accessibility).
 
-## <a id="communication">Communication</a>
+## Communication
 
 ### Slack room
 
@@ -23,11 +23,11 @@ The federal government is accountable for making all of its products 508 complia
 - [Accessibility Guide](https://pages.18f.gov/accessibility/)
 - [Working Groups and Guilds]({{site.baseurl}}/working-groups-and-guilds-101)
 
-## <a id="training">Training</a>
+## Training
 
 TTS hosts monthly training sessions to help you learn how to build accessible products. The class is required for all developers, who must attend the class at least once (but can attend as many times as they like). Folks from other teams are encouraged to attend as well. Find the class schedule on the [Working Groups and Guilds calendar](https://www.google.com/calendar/embed?src=gsa.gov_o1aqcv28k1f0nmca5bkch8los4%40group.calendar.google.com&ctz=America/New_York).
 
-## <a id="making-a-project-accessibile">Making a project accessible</a>
+## Making a project accessible
 
 The easiest way to make a project accessible is to think about accessibility from the start. Retrofitting accessibility is very costly. As you might expect, certain libraries and tools are not great for accessibility — for example, Bootstrap&rsquo;s color scheme and some of its form elements are not accessible by default. These are things that should be taken into consideration at the start of a project, before you've dedicated substantial time and energy to it.
 

--- a/_pages/welcome-to-TTS/classes/gsa-internal-tools.md
+++ b/_pages/welcome-to-TTS/classes/gsa-internal-tools.md
@@ -8,7 +8,7 @@ _This post provides information on how to work with GSA&rsquo;s web tools and yo
 
 If you have any questions, please ping [#teamops](https://gsa-tts.slack.com/archives/teamops) or [#it-issues](https://gsa-tts.slack.com/archives/it-issues).
 
-## <a id="gsa-tools">GSA tools</a>
+## GSA tools
 
 Most of GSA&rsquo;s internal tools are accessible via our Agency&rsquo;s intranet [Insite](http://insite.gsa.gov). You must be on the VPN to connect if you work remotely. [Instructions for connecting are here]({{site.baseurl}}/networks/). Here&rsquo;s an overview of what you can access (you can click the names in this table to scroll down the page):
 
@@ -57,14 +57,13 @@ Most of GSA&rsquo;s internal tools are accessible via our Agency&rsquo;s intrane
   </tbody>
 </table>
 
-
 ### Browser requirements
 
-Please note that while many of these websites work fine in Chrome or Firefox, you *must* use Safari or Internet Explorer to access Online University.
+Please note that while many of these websites work fine in Chrome or Firefox, you _must_ use Safari or Internet Explorer to access Online University.
 
 Let&rsquo;s cover each of these tools in a bit more detail.
 
-## <a id="bookit">BookIt!</a>
+## BookIt!
 
 [BookIt!](https://bookit.gsa.gov/mobile/auth/spnego/spnegoLogin.jsp) is what you'll use to reserve a desk or a meeting room within a GSA building.
 
@@ -88,7 +87,7 @@ Here are some tips for employees that frequent an office:
   <li>Some employees have expressed difficulty in logging into BookIT! If you&rsquo;re having difficulty, try bookmarking <a href="https://bookit.gsa.gov/mobile/auth/spnego/spnegoLogin.jsp">the BookIT! login page</a>. It should immediately ask for your ENT password. In DC, you can also email <a href="mailto:1800ftenantsupport@gsa.gov">1800tenantsupport@gsa.gov</a> and ask to be added to the 18F org they should be able to add you to the list in a day.</li>
  </ul>
 
-## <a id="employee-express">Employee Express</a>
+## Employee Express
 
 [Employee Express](https://www.employeeexpress.gov/) is used to view your paystub, change your withholdings, change your health insurance plan, and change your address.
 
@@ -105,29 +104,29 @@ If they ask for your health insurance code, you can see that in CHRIS under `GSA
 
 See [Benefits]({{site.baseurl}}/benefits) for more details about Employee Express.
 
-## <a id="hr-links">HR Links</a>
+## HR Links
 
 <a href="https://corporateapps.gsa.gov/hr-links/">HR Links</a> is what you'll use to [request and document leave]({{site.baseurl}}/leave/) (sick, annual, bereavement, and more) as well as access your personnel file (your salary, your GS level, your supervisor, your past performance rating(s), and information about health insurance plan).
 
 You must [be on the VPN](https://docs.google.com/document/d/1nBNXt6Ov4KWmpz6y9rgKw93mxZucVsoYC4PFABTeIA4/edit#heading=h.bbs2uvvcjvcg) to connect to HR Links, if you're working remotely.
 
-## <a id="it-service-desk">IT Service Desk</a>
+## IT Service Desk
 
 If you have any issues with a GSA-maintained system or website, you'll need to contact the IT service desk. Their chat feature is the most convenient way to get in touch with them. To contact the IT Service Desk via chat, visit the [GSA IT Service Desk](https://gsa.service-now.com/GSA_Self-Service/). Go to `Get Help → Contact the Service Desk → Live Chat` (Under the &ldquo;GSA IT Service Desk&rdquo; heading). If you need to submit a ticket, please choose Patrick Bateman from the Supervisor dropdown (most easily findable by typing `patrick.bateman`). He'll respond to any supervisor signoffs quickly.
 
 If you need to reset your ENT password, you can let your password expire and then change it through the Mac popup window. This will not cause you any issues. And if you're on a Mac and change your ENT password, once you log out and log back in, make sure you're on the GSA-wireless network (_not_ GSA-guest) so that you can re-authenticate.
 
-## <a id="meeting-space">Meeting Space</a>
+## Meeting Space
 
 <a href="https://meet.gsa.gov/">Meeting Space</a> is the service you'll use to create your own conference call line, as opposed to our usual video calls in <a href="https://meet.google.com/">Google Hangouts Meet</a>. Hangouts Meet allow up to 99 participants plus a host: Meeting Space is usually only needed if you'll go beyond that number or your participants can't use Hangouts Meet. Here&rsquo;s how to create a Meeting Space call line:
 
-1. Log in. Click `My Profile → My Audio Profiles`. 
+1. Log in. Click `My Profile → My Audio Profiles`.
 2. On the left hand side click `Intercall Audio Profile` to select it.
 3. The right hand side of the screen will display the Intercall Audio Profile information that includes the conference code, leader pin, and conference phone number information. It'll look greyed out, but that's okay unless you want to edit it &mdash; for example, to change the PIN &mdash; if so, the edit button is at top right of that panel.
 
 `My Audio Profile` is the only place that you will find the PIN needed to start any audio call outside of the meeting room.
 
-That's it: your conference number is permanent! Yours to keep, forever. And when you need to use your conference number, you *do not* need to schedule a meeting in Meeting Space. You just dial in with the leader code, and the number will be active for others using the participant code. 
+That's it: your conference number is permanent! Yours to keep, forever. And when you need to use your conference number, you _do not_ need to schedule a meeting in Meeting Space. You just dial in with the leader code, and the number will be active for others using the participant code.
 
 If you'd already set this up pre-February 2019, you may need to update it. Please reference the topical IT Insider email from February 2019 for instructions.
 
@@ -140,4 +139,3 @@ Access to general office supplies varies based on your location — see our [off
 For software requests, see [Software](../software/).
 
 If you need office supplies that aren’t available in your office, software, or need to make any other request for TTS to purchase, read on [here]({{site.baseurl}}/purchase-requests) for what to do next.
-

--- a/_pages/welcome-to-TTS/classes/intro-to-18f-infrastructure.md
+++ b/_pages/welcome-to-TTS/classes/intro-to-18f-infrastructure.md
@@ -3,6 +3,7 @@ title: Intro to 18F Infrastructure
 navtitle: Infrastructure
 outdated: true
 ---
+
 This page provides an overview of the Infrastructure team, important compliance topics, and technology best practices at TTS. As a part of TTS Classes, you will review [this document](https://docs.google.com/document/d/1iQP1S_PbJyOaeTlPEpD9oxal3kgA0bb2YNYbN56fJSk/edit#) and then complete this [confirmation survey](https://goo.gl/forms/VP4Ci9Ed3r6UxG6H3).
 
 ### TL;DR
@@ -19,11 +20,11 @@ This page provides an overview of the Infrastructure team, important compliance 
 
 ## About Infrastructure
 
-### <a id="obeying-the-law">Obeying the law</a>
+### Obeying the law
 
-Rule #1 is if you don't see us doing something already, and you can't find express authorization to do it, please ask first. We promise to get you an answer quickly. For example, if there is software or hardware you need that you don't have or don't know how to get, hop into [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure/) and ask. 
+Rule #1 is if you don't see us doing something already, and you can't find express authorization to do it, please ask first. We promise to get you an answer quickly. For example, if there is software or hardware you need that you don't have or don't know how to get, hop into [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure/) and ask.
 
-### <a id="security">Security</a>
+### Security
 
 You've probably heard about the [Office of Personnel Management (OPM) data breach](https://en.wikipedia.org/wiki/Office_of_Personnel_Management_data_breach), and you probably know about the NSA. Everyone at TTS is responsible for our organization's security and ensuring that the private data of the public is safe.
 
@@ -31,7 +32,7 @@ The most important part of your job is security. 18F has its own [security stand
 
 Take care when connecting applications to each other. While such connections can provide workflow conveniences, they also open us up to security violations. Often times this is an OAuth integration. Before connecting applications together, for example enabling a Slack-to-Google Docs plugin, please consult us in [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure/).
 
-### <a id="the-public-interest">The public interest</a>
+### The public interest
 
 As a federal employee, you yourself have practically no right to privacy in connection with your work. Anything you say or do - in an email, a phone call, a private GitHub repo, a Slack direct message, etc - can be monitored, recorded, and turned into a Federal record. If you don't want the government to know something, use a personal device or service. If you're using TTS, GSA, or Gov-wide provided anything (software, tools, devices, etc), you are actively consenting to being monitored.
 
@@ -41,9 +42,9 @@ That isn't to say that TTS can't solicit public input. We absolutely can. We can
 
 This brings us to Rule #3: You cannot spend a single penny, or create the expectation for a single penny to be spent, without prior authorization. Anything involving money must trace back to approvals. You can find out all about purchase approvals on the [Purchase Requests]({{site.baseurl}}/purchase-requests/) page.
 
-### <a id="infrastructure-rules">Infrastructure rules</a>
+### Infrastructure rules
 
-There are some things that you might have been used to doing outside of government that you cannot do now. 
+There are some things that you might have been used to doing outside of government that you cannot do now.
 
 You cannot use or deploy to whatever third party tool you want without asking in [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure/).
 
@@ -59,7 +60,7 @@ The three rules of Infrastructure are:
 
 ### I create a Chrome profile on my work laptop that is my personal account, and so far have only used it to: (1) use my Google Play Music account (2) check email one time to get my GitHub 18F invitation (3) access my LastPass account for my GitHub password. How much of my personal information has been made available to you (or anyone else who can see my account stuff) by doing this?
 
-Consider maintaining two separate Chrome profiles (18F and Personal) and segregate sessions, extensions, data, etc that way. In general, most HTTPS connections ensure that no one in the Gov, including the network owners, has access to those packets. At GSA, that's true, at least for 18F-issued laptops. That is not true for employees on all Gov networks. Those agencies give their employees work computers specially configured to allow intercepting and MITM of all internet activity, whether it's HTTP or HTTPS. 
+Consider maintaining two separate Chrome profiles (18F and Personal) and segregate sessions, extensions, data, etc that way. In general, most HTTPS connections ensure that no one in the Gov, including the network owners, has access to those packets. At GSA, that's true, at least for 18F-issued laptops. That is not true for employees on all Gov networks. Those agencies give their employees work computers specially configured to allow intercepting and MITM of all internet activity, whether it's HTTP or HTTPS.
 
 ### I'm using my private GitHub account right now to access the 18f repo. Should I change that now?
 

--- a/_pages/welcome-to-TTS/classes/meetings-and-meeting-tools.md
+++ b/_pages/welcome-to-TTS/classes/meetings-and-meeting-tools.md
@@ -4,7 +4,7 @@ title: Meetings and meeting tools
 
 Here, you'll find a list of tools folks at TTS use to schedule meetings, along with information about some specific meetings at TTS.
 
-## <a id="meetings-tools">Meeting tools</a>
+## Meeting tools
 
 Here are some of the tools TTS uses to facilitate meetings:
 
@@ -14,25 +14,24 @@ Here are some of the tools TTS uses to facilitate meetings:
 - [Meeting Space]({{site.baseurl}}/gsa-internal-tools/#meeting-space) (for conference lines)
 - Adobe Connect
 
-## <a id="general-meetings">General meetings</a>
+## General meetings
 
-### <a id="gsa-policy">Compliance with GSA policies</a>
+### Compliance with GSA policies
 
-Our agency maintains a formal meeting, conference, and event policy which may be found [here](http://www.gsa.gov/portal/mediaId/205471/fileName/OAS_57851_Conference_and_Event_Management_(Signed_on_January_28__2015).action). The most applicable part of this policy for TTS is the approval requirement for internal meetings that _require the travel of more than six employees or will cost more than $10,000._ For these meetings, approval of both the Commissioner of the Technology Transformation Service and the Deputy Administrator of GSA via the [Salesforce Event Tracker](https://gsa.my.salesforce.com/a1b/o) system. For further information and help getting your request submitted, go to the [#training-conferences](https://gsa-tts.slack.com/messages/training-conferences) Slack channel.
+Our agency maintains a formal meeting, conference, and event policy which may be found [here](<http://www.gsa.gov/portal/mediaId/205471/fileName/OAS_57851_Conference_and_Event_Management_(Signed_on_January_28__2015).action>). The most applicable part of this policy for TTS is the approval requirement for internal meetings that _require the travel of more than six employees or will cost more than \$10,000._ For these meetings, approval of both the Commissioner of the Technology Transformation Service and the Deputy Administrator of GSA via the [Salesforce Event Tracker](https://gsa.my.salesforce.com/a1b/o) system. For further information and help getting your request submitted, go to the [#training-conferences](https://gsa-tts.slack.com/messages/training-conferences) Slack channel.
 
-### <a id="townhalls">TTS Townhalls</a>
+### TTS Townhalls
 
 You'll hear well in advance about any upcoming townhalls, which should give you ample time to plan (and rearrange your schedule, if necessary). Conversations during Townhall meetings take place in the Slack channel [#townhall](https://gsa-tts.slack.com/messages/townhall).
 
-### <a id="location-specific">Location-specific meetings</a>
+### Location-specific meetings
 
 Individual offices have rituals that you might want to take part in. Check in your local office Slack channel for more information!
 
-### <a id="working-group">Guilds and working groups</a>
+### Guilds and working groups
 
 [Working groups and guilds]({{site.baseurl}}/working-groups-and-guilds-101) shape culture, frameworks, and discipline best practices across TTS. You don't have to become a permanent member of a working group to attend meetings.
 
-### <a id="opp-all-hands">OPP All Hands</a>
+### OPP All Hands
 
 OPP All Hands are a monthly, 1.5 hour opportunity for OPPers to hear updates from leadership, share kudos, welcome new teammates, learn about new initiatives within the team and across the division, and hear news and updates from existing programs. They typically take place on the third Tuesday of the month at 1 pm EST.
-

--- a/_pages/welcome-to-TTS/classes/olu.md
+++ b/_pages/welcome-to-TTS/classes/olu.md
@@ -1,39 +1,38 @@
 ---
 title: Online Learning University
 tags:
-- classes
-- training
-- mandatory
+  - classes
+  - training
+  - mandatory
 ---
 
 The GSA [Online University (OLU)](https://gsaolu.gsa.gov/) is the home for mandatory trainings, as well as a repository of recommended and optional training opportunities, for GSA employees.
 
-## <a id="online-university">Online University (OLU) classes</a>
+## Online University (OLU) classes
 
 Required classes will be assigned in OLU and pushed individually to the OLU home page of TTS employees under **My Learning Assignments**.
 
 Time spent taking OLU trainings should be coded as `969 - GSA-mandated Non-Billable Work` in [Tock]({{site.baseurl}}/tock).
 
-*GSA OLU training material sometimes has trouble with certain browsers. We recommend using [VmWare Horizon]({{site.baseurl}}/vmware-horizon) and Internet Explorer or, on Mac, Safari, to ensure successful course completion and documentation.*
+_GSA OLU training material sometimes has trouble with certain browsers. We recommend using [VmWare Horizon]({{site.baseurl}}/vmware-horizon) and Internet Explorer or, on Mac, Safari, to ensure successful course completion and documentation._
 
 ### Mandatory annual trainings for all employees
 
-* Annual Ethics Training
-* Controlled Unclassified Information
-* COOP Awareness Training
-* 2019 GSA Mandatory Cyber Security and Privacy Training
-* Employee Accountability for GSA Personal Property
-* Insider Threat Awareness & Reporting
-* Occupational Health and Safety
-* Plain Language
-* What is Record Management?
-* Telework Training (required for all telework-eligible employees, which is most people)
+- Annual Ethics Training
+- Controlled Unclassified Information
+- COOP Awareness Training
+- 2019 GSA Mandatory Cyber Security and Privacy Training
+- Employee Accountability for GSA Personal Property
+- Insider Threat Awareness & Reporting
+- Occupational Health and Safety
+- Plain Language
+- What is Record Management?
+- Telework Training (required for all telework-eligible employees, which is most people)
 
 [You can see a full list of all GSA mandatory employee and supervisor trainings on Insite.](https://insite.gsa.gov/employee-resources/training-and-development/mandatory-training)
-
 
 ## Help with OLU
 
 For help with OLU once you've logged in, including getting confirmation of classes taken, click on the **Learning** dropdown at the top of the window and then select **Live Support 24/7**.
 
-*Note that there could be a lag time of about four days between completing courses in OLU and having those courses reflected in your profile.*
+_Note that there could be a lag time of about four days between completing courses in OLU and having those courses reflected in your profile._

--- a/_pages/welcome-to-TTS/classes/working-groups-and-guilds-101.md
+++ b/_pages/welcome-to-TTS/classes/working-groups-and-guilds-101.md
@@ -7,7 +7,7 @@ Working groups and guilds are self-organized groups that improve practices, host
 
 The [TTS Policy and Procedure for Internal Project Review](https://docs.google.com/document/d/1HHDXdiNvLdCFiEPjLwZaV-lhnwWeeq90MZMYAxbkHAM) exempts working groups and guilds from review, but client work generally takes priority over guild or working group projects.
 
-## <a id="key-concepts">Key concepts</a>
+## Key concepts
 
 **Working groups** are self-organized. They spin up or down depending on our organizational needs.
 

--- a/_pages/welcome-to-TTS/classes/writing-lab.md
+++ b/_pages/welcome-to-TTS/classes/writing-lab.md
@@ -5,7 +5,7 @@ navtitle: Writing Lab
 
 The Writing Lab team knows that writing is hard: It can be time consuming and stress inducing, and can sometimes seem like a blocker to a project that’s humming along. That's why the Writing Lab came into being. The Lab is a virtual writing center where you can get personalized help from members of the 18F editorial team. (And, if you’re a writerly type yourself, you can join the Lab team and volunteer to help other folks with their writing and editing projects!)
 
-## <a id="leadership">Leadership</a>
+## Leadership
 
 The 18F Writing Lab is run by members of 18F’s editorial team, which includes members of the Content Guild, the Experience Design Content team (folks who work primarily on partner projects), and the Outreach team (folks who focus on internal and external 18F communication and evangelism).
 
@@ -13,7 +13,7 @@ All Lab members volunteer their services and base their contributions on their a
 
 The team’s collective experience is vast. Lab members hail from backgrounds in journalism, instructional design, creative writing, public media, and more. Whether you’re thinking about creating site copy or a conference presentation, someone from the Lab has the expertise to scrub in and help.
 
-## <a id="communication">Communication</a>
+## Communication
 
 Find us in Slack:
 
@@ -22,7 +22,7 @@ Find us in Slack:
 
 ## Frequently asked questions
 
-### <a id="portfolio-of-services">What kind of help can the Writing Lab offer?</a>
+### What kind of help can the Writing Lab offer?
 
 TL;DR If you have words and would like help, let us know!
 
@@ -48,27 +48,27 @@ Our role is limited to improving the overall quality of content — its readabil
 
 The Writing Lab is designed for short engagements. If you need more than 10 hours of content help, please visit [#staffing-resourcing](https://gsa-tts.slack.com/messages/staffing-resourcing) to ask for guidance on getting somebody assigned to your project.
 
-### <a id="asking-for-help">How do I ask for help?</a>
+### How do I ask for help?
 
 Standard practice is to file an issue in our [GitHub repo](https://github.com/18F/writing-lab). If you don’t feel comfortable filing an issue, reach out to us on our Slack channel, [#writing-lab](https://gsa-tts.slack.com/archives/writing-lab). Provide us with the basic details of your project and we’ll create an issue for you (and tag you in it). Lab members will reach out to schedule a 15-30 minute consult with you and make edits and specific comments in Google Docs. They may also discuss larger questions in comments on the GitHub issue. Whenever possible, Lab members try to pick up and close issues within a week.
 
-This is a lot to digest, so we’ve created this [Writing Lab One Sheet](https://docs.google.com/document/d/1pyP501N6L-mJStTUIhsZ9UQoxy7quzoKND9iibS51ls/edit) for you to keep. 
+This is a lot to digest, so we’ve created this [Writing Lab One Sheet](https://docs.google.com/document/d/1pyP501N6L-mJStTUIhsZ9UQoxy7quzoKND9iibS51ls/edit) for you to keep.
 
-### <a id="If-your-issue-isn't-picked-up">What should I do if my issue isn't picked up?</a>
+### What should I do if my issue isn't picked up?
 
 Lab members assign themselves to issues as they can. Each core Lab member is cleared to spend three hours per week on the Lab, so our ability to pick up and close issues is based on the number of issues coming in and the workload of other projects.
 
 If your issue isn’t assigned to someone within three days of you filing it, please ping the team in [#writing-lab](https://gsa-tts.slack.com/archives/writing-lab) or leave a comment on the issue. If your content has a hard deadline, please note that in the issue. Add the urgent label if it needs to be completed in the next two days.
 
-### <a id="Share-feedback">How do I share feedback?</a>
+### How do I share feedback?
 
 We’re always looking for ways to improve the Lab workflow, the quality of our services, and your experience as a customer. If you have any ideas or questions, please [complete our feedback survey](https://goo.gl/1eSVio) or reach out to the team on Slack in [#writing-lab](https://gsa-tts.slack.com/archives/writing-lab).
 
-### <a id="previous-projects">What has the Writing Lab worked on in the past?</a>
+### What has the Writing Lab worked on in the past?
 
 Feel free to peruse the [issues associated with the Writing Lab repository](https://github.com/18F/writing-lab/issues). Also, if you haven’t had a chance to check out the [18F Content Guide](https://pages.18f.gov/content-guide/) yet, that’s a great place to go to familiarize yourself with our style.
 
-### <a id="additional-resources">Additional Resources</a>
+### Additional Resources
 
 Here’s a list of the Lab staff’s favorite resources. Are we missing something? If so, add it to the list.
 
@@ -76,7 +76,7 @@ Here’s a list of the Lab staff’s favorite resources. Are we missing somethin
 - [18F Blogging Guide](https://handbook.18f.gov/blogging/): Your guide to writing, editing, and publishing posts for the 18F blog
 - [The Writing Lab’s performance profile guide](https://docs.google.com/document/d/1z6oyBG43c-5PkK9rAvWeK_bI0ojQqZIJCt8VcmsW53U/edit): An informal guide for editing performance profiles
 
-## <a id="Guidelines">Guidelines for submitting an issue</a>
+## Guidelines for submitting an issue
 
 ### Writing a good issue title
 
@@ -113,7 +113,7 @@ This narrow focus will help you decide a number of things. Because your audience
 
 If you’re sending a staff-wide email to 18F, your user story might be:
 
-_“As an 18F staff member, I want to know what our new README guidelines are, so that I can make sure my repo is up to date.”
+\_“As an 18F staff member, I want to know what our new README guidelines are, so that I can make sure my repo is up to date.”
 
 Using this framework, you can be more informal since you’re writing to your colleagues, and you can use jargon that is known to the 18F team.
 
@@ -124,4 +124,3 @@ If your Lab request is for a billable project, please list the Tock project name
 If your request is for a non billable project, please also list the Tock project name. If there is no Tock project name associated with this piece of content, then the Lab will bill it to writing-lab in Tock.
 
 Either way, the Lab member who assists you will provide you with regular billing updates so you can keep track of how much time they have spent on your issue and how that may affect your project budget.
-


### PR DESCRIPTION
Kramdown (the thing that turns Markdown to HTML in Jekyll) does this by default, so they just add confusion.