### PR TITLE
update diversity at TTS page

### DIFF
--- a/_pages/about-us/diversity.md
+++ b/_pages/about-us/diversity.md
@@ -1,60 +1,75 @@
 ---
-title: Diversity At TTS
-navtitle: Diversity At TTS
+title: Diversity, Equity, and Inclusion at TTS
+navtitle: Diversity, Equity, and Inclusion at TTS
 ---
 
-TTS believes that diversity matters and is vital to a successful organization.
-TTS is committed to promoting an inclusive environment where all individuals
-are empowered to succeed.
+A diverse organization creates a spectrum of solutions and ideas, and helps us challenge status quo thinking. Inside TTS, the work of diversity, equity, and inclusion (DEI or DE&I) is a collective effort: every employee makes a difference.
 
-## Documentation
+The TTS Diversity Guild has collaboratively drafted this handbook page to outline how we approach DEI in TTS. We believe that diversity is vital to a successful organization and that it is crucial to reflect the diversity of the public we serve. We also recognize that [a diverse workforce is not enough](https://www.opm.gov/policy-data-oversight/diversity-and-inclusion/). We are committed to promoting an inclusive environment where all individuals feel like they can bring their whole selves, their uniqueness is valued, and they are an integral part of [TTS’s mission](https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services) to improve the public’s experience with the government.
 
-The foundation for the Diversity Guild's work is the
-[TTS Code of Conduct]({{site.baseurl}}/code-of-conduct/).
+## Code of Conduct 
 
-We understand that diversity and inclusion may be hard to talk about. In order
-to solve that we created the
-[Diversity Talking Points]({{site.baseurl}}/pdfs/diversity-talking-points.pdf)
-[with notes]({{site.baseurl}}/pdfs/diversity-talking-points-with-notes.pdf).
+The foundation for the Diversity Guild’s work is based on the [TTS Code of Conduct]({{site.baseurl}}/code-of-conduct/).
+ 
+We strive to create a community where everyone feels empowered to speak up. However, we recognize that there are always power dynamics at play and that each of us has personal preferences when discussing sensitive information. If you would like to discuss an issue without disclosing your name, [please use this anonymous form](https://docs.google.com/forms/d/1xIaxaHD957MtfDwHy7Ec_Xf4C4VXbOy_bpwWL7f6e94/edit?ts=5d52ff9b).
+
+## Resources
+
+We actively work to eliminate bigotry and subtle forms of disrespect (e.g. [microaggressions](https://en.wikipedia.org/wiki/Microaggression), microinvalidations,  etc.) from our workplace. We also understand that in order to address [unconscious bias](https://diversity.ucsf.edu/resources/unconscious-bias) you have to start somewhere. Below are resources for anyone to learn more about diversity and inclusion principles and best-practices.
+
+- [18F Inclusive Language Guide](https://content-guide.18f.gov/inclusive-language/) - principles, resources, and suggestions for writing and talking about diverse groups of people.
+- Preference, Tradition, or Requirement? [“Here’s EY’s Simple But Effective Strategy For Increasing Diversity”](http://fortune.com/2017/02/10/ey-simple-effective-diversity-inclusiveness-strategy/) - Is something a preference, tradition, or requirement? This article covers how Ernst and Young used the “PTR” framework to hire a more diverse workforce. It can be used widely to critically assess all aspects of a work culture.
+- [One on One Meeting Framework](https://docs.google.com/document/d/1GAhgY2y1usPhU7UN-w08ZDNXFTC6aWBKFBYRRxgjvWk/edit) - This GSA resource - though not explicitly written with a diversity and inclusion lens - contains useful guidelines that supervisors can use to provide equitable feedback experiences with each employee on a regular basis.
+- [Management Tools list from The Management Center](http://www.managementcenter.org/tools/) - includes resources on delegation, roles & goals, performance problems, managing up, and much more. They include equity and inclusion considerations in their tools.
+- Got a question for #g-diversity? [This is an anonymous form for questions or issues regarding diversity, equity, and inclusion](https://docs.google.com/forms/d/1xIaxaHD957MtfDwHy7Ec_Xf4C4VXbOy_bpwWL7f6e94/edit?ts=5d52ff9b).
+
+## Approach
+
+We believe there are four sources of inclusiveness at every organization, and we work to align our organization to these principles.
+
+**1. Organizational level: Practices and activities that contribute to, or detract from, an inclusive organization.**
+  -  Formal communications (mission statement, strategy, annual reports, etc.) reflect a commitment to diversity, equity and inclusion.
+  -  Diversity, equity, and inclusion are part of the core values of senior leadership and are treated as priorities.
+  -  There are transparent and equitable processes around interviews, hiring, promotions, salaries, training approvals, and evaluations. Additionally, there are systems in place to regularly re-examine and remove any potential bias in these processes.
+  -  There are clearly communicated ways to support individual employees, including mentorship, development plans, and advancement opportunities.
+  -  There is accountability and action when issues arise. 
+
+**2. Management: The support you receive from your managers - this includes program managers, leads, and/or supervisors.**
+  -  Your manager is reliable, ethical, and transparent.
+  -  Your manager includes you in discussions, and you feel like an invaluable member of the team. 
+  -  Your manager models the importance of creating strong, supportive teams.
+  -  Your manager acknowledges the power dynamics that are created with managerial titles does their best to make interactions more fair and balanced.
+  -  Your manager creates an environment that feels safe for you to bring your whole self to work and upholds strong expectations that everyone else does the same.
+  -  Your manager serves as an advocate and supports you in your professional growth. 
+  -  Your manager has challenging conversations when needed, and approaches them with respect and empathy.
+  -  Leveraging Diversity is a new metric for evaluating supervisors across GSA. It will go into effect FY20.
+
+**3. Work-group level: Day-to-day interpersonal relationships and the team climate.**
+  -  Your coworkers treat you as an insider to decision-making, respect your opinions, value you, and emphasize that you belong on the team.
+  -  Your uniqueness is celebrated, and you do not feel the need to assimilate in order to fit in.
+  -  You are treated as a valued participant to interpersonal and group learning.
+
+**4. Individual level: The contributions you make that affect inclusion and awareness of diversity.**
+  -  You share decision-making and power with your colleagues.
+  -  You take the time to build relationships with colleagues on a personal level
+  -  You are mindful of your actions and words and take responsibility for the impact they have on others.
+  -  You put in the work to educate yourself around subjects you are unfamiliar with before asking someone to educate you.
+  -  You acknowledge your privilege and balance listening and supporting colleagues. 
+  -  You are an ally and use your voice to advocate for those who are overlooked or interrupted.  
+  -  You practice empathy and approach situations with curiosity rather than defensiveness — you try to understand where someone else is coming from.
+  -  You recognize that it’s ok to disagree with others, but practice respectful discourse.
+  -  You treat yourself with kindness. Mistakes happen; you apologize and grow from them. 
+
 
 ## Diversity Guild
 
-The Diversity [Guild]({{site.baseurl}}/working-groups-and-guilds-101/) strives to make TTS a great place to work for people of all backgrounds; to foster diversity of all kinds; and to create a culture where people feel safe, work joyfully, and communicate openly. It aims to do this all while providing great services for the American people.
+The Diversity [Guild]({{site.baseurl}}/working-groups-and-guilds-101/) is a formal, on-going way for employees to share experiences, resources, and learn from one another via weekly meetings and [#g-diversity](https://gsa-tts.slack.com/messages/g-diversity/ Slack channel))🔒. 
 
-### Leadership
-
-The Diversity Guild is led by [Cordelia Yu](https://gsa-tts.slack.com/messages/@bcordeliayu) and [Deb Baptiste](https://gsa-tts.slack.com/messages/@debbaptiste).
-
-### Communication
-
-Find us in Slack:
-
-- [#g-diversity](https://gsa-tts.slack.com/messages/g-diversity/)
-- [#wg-code-of-conduct](https://gsa-tts.slack.com/messages/wg-code-of-conduct/)
-
-_It's important that the responsibility of answering questions around diversity and inclusion doesn't fall on one or two people. Our Slack channel is open space in which our colleagues (who genuinely want to do the right thing) can ask hard questions of one another. It allows us to collectively place the responsibility of diversity and inclusion on multiple people rather than any one person._
-
-### Philosophy
-
-The Diversity Guild is a space for learning. If you make a mistake---and we all do---a key component of diversity is that we have a culture of mindfulness and trying to do better. Remaining open to feedback, learning about why an action was offensive, and then apologizing is the kind of environment we look to cultivate.
-
-The guild realizes that building an inclusive environment is tough, but it's far from impossible. We base our work on actionable items and deliverables which are reflected in our [Outcomes and Key Results (OKRs)](https://docs.google.com/a/gsa.gov/document/d/1bXXVpGE0OGFTJHQklo4k7-M83dA4RQqvN5qIGklzh1g/edit?usp=sharing). These OKRs are discussed and decided every quarter.
-
-### Tracking progress on Trello
-
-The Diversity Guild tracks its progress on Trello. If you're interested in joining, reach out to the channel and they'll share the Trello board with you. Currently, the group's board is set up like this:
-
-- **Ideas to discuss.** These will be discussed at the next scheduled meeting, unless there's a plan to push these forward more quickly.
-- **Backlog.** Things that need to happen soon and are ready for action to be taken. _Anyone_ can lead any one of these items. Assign yourself and move it over to...
-- **Current(ly being worked on).** These are things in progress. If you would like to join one, add yourself.
-- **Completed.** These items are completed and need feedback or review.
-- **Done.** Things that are fully completed — we will celebrate them during our next meeting!
 
 ### How to get involved
 
-Not only does the Diversity Guild a space for learning, it also promotes the belief in sharing what you've learned. The group is developing a Diversity Guide that has the goal of providing insight on how TTS integrates diversity principles at every point: from recruitment, interviewing, and onboarding to retention, such as professional development and benefits.
+Not only does the Diversity Guild provide a space for learning, it also promotes the belief in sharing what you’ve learned. The group also tries to provide insight on how TTS currently integrates DEI and could better integrate DEI principles at every point: from recruitment, interviewing, and onboarding, all the way to terming out, leaving the organization, or even returning to TTS.
 
-If you're interested in getting involved:
-
-- **Join our channel.** Head on over to [#g-diversity](https://gsa-tts.slack.com/messages/g-diversity/).
-- **Join our meetings.** We meet monthly, the fourth Friday of the month. We also have open coworking sessions every Friday. The meetings currently show up on the 18F Working Groups and Guilds calendar. If you would like to be added to the invites directly, please [message Cordelia Yu](https://gsa-tts.slack.com/messages/@bcordeliayu).
+- Join our Slack channel, [#g-diversity](https://gsa-tts.slack.com/messages/g-diversity/). 
+  -  Read the [Guidelines for the #G-Diversity Channel](https://docs.google.com/document/d/1IP0GERswH8t5nQxH0VyYPidj5TrkNtfJEmaPz3_y-go/edit)
+- Come to our meetings. We meet weekly, every Friday at 12:30-1pm EST. We also have open coworking sessions every Friday at 1pm EST, or the option to extend meeting topics to one hour. The meetings currently show up on the [TTS Working Groups and Guilds Calendar](https://www.google.com/calendar/embed?src=gsa.gov_o1aqcv28k1f0nmca5bkch8los4%40group.calendar.google.com)🔒 If you would like to be added to the invites directly, please [message Austin Hernandez](https://gsa-tts.slack.com/messages/@austinhernandez)🔒.


### PR DESCRIPTION
The TTS Diversity Guild has collaboratively drafted this handbook page to outline how we approach Diversity, Equity, and Inclusion in TTS. It has gone through internal approval and members of the content design team have read it over, as well.