### PR TITLE
Fix a Top Secret typo.

### DIFF
--- a/_pages/policies/business-and-ops-policies/top-secret.md
+++ b/_pages/policies/business-and-ops-policies/top-secret.md
@@ -7,7 +7,7 @@ tags:
 - security
 ---
 
-Most TTS employees has a Public Trust (Moderate Risk - Level 5) clearance. However, for certain projects, clients need TTS employees to have a higher type of clearance so that they are able to view certain documents.  This is the process for TTS employees to request this clearance.
+Most TTS employees have a Public Trust (Moderate Risk - Level 5) clearance. However, for certain projects, clients need TTS employees to have a higher type of clearance so that they are able to view certain documents.  This is the process for TTS employees to request this clearance.
 
 [See Wikipedia for a list of different types of security clearances](https://en.wikipedia.org/wiki/List_of_U.S._security_clearance_terms).
 


### PR DESCRIPTION
Intentionally burying the lead. 😄 

`has -> have` on the _Top Secret / Sensitive Compartmented Information (TS/SCI) Clearance_ page.