### PR TITLE
Create "Guidance on hosting non-government speakers" page

### DIFF
--- a/_pages/policies/employee-resources-policies/hosting-non-government-speakers
+++ b/_pages/policies/employee-resources-policies/hosting-non-government-speakers
@@ -1,0 +1,45 @@
+---
+title: Guidance on hosting non-government speakers
+
+---
+
+TTS teams, [Guilds]{{site.baseurl}}/#/working-groups-and-guilds-101#existing-guilds), [Working groups]({{site.baseurl}}/#/working-groups-and-guilds-101#existing-wgs)), have the opportunity to invite individuals outside of the government to speak to our teams. Guest speakers provide a unique opportunity for federal employees to learn from industry professionals on modern practices. Hearing new perspectives provide employees not only with different points-of-view, but also with knowledge they can apply in their careers at TTS. 
+
+*Unfortunately, we can not compensate guests for their time and are currently working on ways to allocate an honorarium.*
+
+## Steps for virtual meetings
+
+If you’d like to host a non-government speaker at a guild meeting, training, workshop, or other TTS gathering, you must follow the steps and guidelines below. 
+
+1. Make a local copy of the [Outside Speaker Checklist](https://docs.google.com/document/d/1F2IEMaPgfWZY2_RvSkILNnjulY8d3XDeJagAqSkFNvo/edit?usp=sharing). 
+  -  It will help you spot any issues and the Office of General Counsel will use this document to review your event.
+  -  You will not need to turn this form in.
+2. Have each outside speaker sign a [Gratuitous Services Agreement](https://docs.google.com/document/d/11xLRGV2mka51PnuaCLMm75lVEq1uV7N0Fn19Lyw832o/edit?usp=sharing) in advance of the event. 
+  -  This is necessary because the Antideficiency Act does not permit federal agencies to accept voluntary services unless someone offering such services executes an advance written agreement that (1) states that the services are offered without expectation of payment, and (2) expressly waives any future pay claims against the government. 
+   -  You can also ask [Slackbot](https://get.slack.help/hc/en-us/articles/202026038-Slackbot-your-assistant-notepad-programmable-bot) for a link to the Gratuitous Services Agreement
+3. *Optional:* If you plan to record or take photographs of the speaker, have them fill out the [GSA Model Release Form](https://insite.gsa.gov/portal/getMediaData?mediaId=702794). 
+4. Put the signed Gratuitous Services Agreement and GSA Model Release Form (if applicable) in [the Gratuitous Services Agreement folder](https://drive.google.com/drive/folders/1UOKVVZGdI7IlAxrqcq48-HQQr8f5U6N7).
+5. Invite your speaker and let the team know on different Slack channels such as [#upcoming-in-guilds](https://gsa-tts.slack.com/messages/upcoming-in-guilds/)
+
+## In-person meeting
+
+If the event takes place in a physical location, follow steps 1-4 and check out [the Office of Administrative Services Event and Travel Approval Matrix](https://insite.gsa.gov/topics/travel-and-events/reservations-and-travel-information/event-management-conference-attendance-information?term=OAS%20Event%20and%20Travel%20Approval%20Matrix) to make sure you get the proper approvals for the event. 
+
+If it’s going to take place after hours, you will also have to coordinate with the Office of Mission Assurance and building management for any special after hours security issues.
+
+## To keep events ethical and compliant
+
+In addition to those steps, there are a couple important things to keep in mind when hosting speakers from outside government. 
+
+- We have to make sure the outside speaker is not here for a sales pitch, a discussion on what their company can do for federal agencies, or to gain access to information that could help them in a future procurement. 
+  -  For example, someone from GitHub can come talk about how their internal teams manage open source software, but they can’t talk about how GitHub is a good tool for federal agencies. 
+- TTS must be willing to provide the same access to similarly situated companies.
+- TTS cannot endorse or promote the entity that is speaking at GSA. 
+
+## Accessibility
+
+Be sure to check out the resources on the [Deaf-HOH]{{site.baseurl}}/#deaf-hoh) page to provide the most accessible telecommunications services for Deaf/HoH and speech-disabled employees.
+
+## Questions
+
+Any questions? Ask the [#training-conferences](https://gsa-tts.slack.com/messages/g-accessibility/) and/or [#outreach](https://gsa-tts.slack.com/messages/outreach/) channels on Slack.


### PR DESCRIPTION
TTS teams, guilds, and working groups often bring in external speakers but guidance is buried in emails and provided by a colleague who has termed-out and is unavailable for guidance. Outreach team unofficially offered guidance on this process, but the approvals team was unsure of (background conversation in Slack here: https://gsa-tts.slack.com/archives/C02APU5RT/p1571415750010100). I'd love to add this page under "18F team resources" so that external speakers are brought in ethically and compliantly.