### PR TITLE
discontinue offering Office for Mac 2016

### DIFF
--- a/_pages/how-we-work/tools/office.md
+++ b/_pages/how-we-work/tools/office.md
@@ -4,26 +4,8 @@ title: Microsoft Office
 
 At GSA, [Google Docs/Sheets/Slides]({{site.baseurl}}/google-drive/) is our preferred tool for documents/spreadsheets/presentations, since it has built-in records retention, collaboration, sharing, importing and exporting of Office files, etc.
 
-In normal day-to-day operations, you will probably never need Microsoft Office. However, if you should encounter an edge case such as a large spreadsheet that won't load well in Google Sheets, Microsoft Office for Mac 2016 can be requested.
+In normal day-to-day operations, you will probably never need Microsoft Office. However, if you should encounter an edge case such as a large spreadsheet that won't load well in Google Sheets, you can use Microsoft Office through [VMWare Horizon]({{site.baseurl}}/vmware-horizon/).
 
-## Requesting a license
-
-To request a Microsoft Office license for your Mac, please **send an email to <tts-software@gsa.gov> with a short explanation of why you need Office rather than using G Suite**.
-
-You should receive a reply from the SaaS Manager after your access to an Office license has been granted, as well as an email from Microsoft. When you receive the latter, wait up to two hours: it takes that long for your license access to be granted to your new account. Then, follow these instructions, as the ones in the email lack some details.
-
-1.  Go to the [Microsoft Volume Licensing Service Center](https://www.microsoft.com/Licensing/servicecenter/).
-1.  Click the Sign In button.
-    - If the sign in page is sending you in a loop, switch to Safari.
-1.  Select the second option "Sign in with your Microsoft account".
-    - Do not choose to "Sign in with a work account", it will not let you sign in.
-    - If it does not allow you to sign in, you will need to click on "No account? Create one!"
-1.  Log in or create an account with your GSA email and navigate to "Downloads and Keys".
-1.  Click on "Download" for "Office 2016 for Mac Standard".
-1.  Click the link under step 1, or to use a download manager click the "Continue" button.
-
-**If you sign into your account and it says that you do not have a license**, there is one more step you must take to complete the installation. When you download Microsoft Office, there is an entire wall of text and hidden in that wall of text are instructions related to installing the [Serializer package](https://drive.google.com/file/d/1oOvxzADPTrDo8yV6roOjNwTBmKFoWz0H/view?usp=sharing). Follow those instructions to install the Serializer package and your download is complete!
-
-**If you cannot find Microsoft Office on your computer after you download:** Click on each link separately for Microsoft Word, Excel, Powerpoint, and they will download individually. You will have to sign in or create an account each time you download. This should install the applications you need on your computer.
+_TTS/GSA used to offer Office for Mac 2016, but given the overhead in installing and managing licenses, this was discontinued in November 2019._
 
 If you have any questions, please ask #infrastructure.

--- a/_pages/how-we-work/tools/office.md
+++ b/_pages/how-we-work/tools/office.md
@@ -6,6 +6,6 @@ At GSA, [Google Docs/Sheets/Slides]({{site.baseurl}}/google-drive/) is our prefe
 
 In normal day-to-day operations, you will probably never need Microsoft Office. However, if you should encounter an edge case such as a large spreadsheet that won't load well in Google Sheets, you can use Microsoft Office through [VMWare Horizon]({{site.baseurl}}/vmware-horizon/).
 
-_TTS/GSA used to offer Office for Mac 2016, but given the overhead in installing and managing licenses, this was discontinued in November 2019._
+_TTS/GSA used to offer Office for Mac 2016, but given the overhead in installing and managing licenses and being [previously denied by the IT Standards process](https://ea.gsa.gov/#!/itstandards/1032), this was discontinued in November 2019._
 
 If you have any questions, please ask #infrastructure.


### PR DESCRIPTION
Closes https://github.com/18F/tts-tech-portfolio/issues/151.

Right now, managing Office for Mac 2016 licenses and troubleshooting installations is a big hassle and for the Tech Portfolio. Given the small number of edge cases that really need Office specifically, this is not a good use of time. Horizon offers a newer/supported version of Office, no setup required, which is better for both us and users. The only downside is it's not local, and thus can't be used offline.

Anyone with an existing license can continue using it, though that may change. Barring any strong objections, I will be directing outstanding Office requests to Horizon starting now.

Thanks for everyone's understanding!