### PR TITLE
Add VS Code to the list of code editors

### DIFF
--- a/_pages/how-we-work/tools/text-editors.md
+++ b/_pages/how-we-work/tools/text-editors.md
@@ -12,7 +12,7 @@ We use text editors to write documentation in [Markdown](https://github.com/adam
 * [Emacs](https://www.gnu.org/software/emacs/): Installed on OS X and Linux
   by default. Also available on OS X via [Homebrew](http://brew.sh/)
 * [Atom](https://atom.io/)
-* [Visual Studio Code](https://code.visualstudio.com/): VS Code is very extensible with lots plugins. One great plugin for pairing is [Live Share](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare), which supports live editing of the same file, sharing a terminal session, port forwarding to the host's computer, and even audio.
+* [Visual Studio Code](https://code.visualstudio.com/): VS Code is very extensible with lots plugins.
 * [Sublime Text](http://www.sublimetext.com/): This is a paid app, but we have [licenses]({{site.baseurl}}/software/#get-access-to-software-we-already-have). If you use Sublime, you may wish to customize your packages. Feel free to ask others about their recommended packages. Notable mentions in past Slack discussions include:
     - Color Highlighter (turns color codes into the actual color)
     - DocBlockr (generates clean comment blocks based on active language)

--- a/_pages/how-we-work/tools/text-editors.md
+++ b/_pages/how-we-work/tools/text-editors.md
@@ -12,6 +12,7 @@ We use text editors to write documentation in [Markdown](https://github.com/adam
 * [Emacs](https://www.gnu.org/software/emacs/): Installed on OS X and Linux
   by default. Also available on OS X via [Homebrew](http://brew.sh/)
 * [Atom](https://atom.io/)
+* [Visual Studio Code](https://code.visualstudio.com/): VS Code is very extensible with lots plugins. One great plugin for pairing is [Live Share](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare), which supports live editing of the same file, sharing a terminal session, port forwarding to the host's computer, and even audio.
 * [Sublime Text](http://www.sublimetext.com/): This is a paid app, but we have [licenses]({{site.baseurl}}/software/#get-access-to-software-we-already-have). If you use Sublime, you may wish to customize your packages. Feel free to ask others about their recommended packages. Notable mentions in past Slack discussions include:
     - Color Highlighter (turns color codes into the actual color)
     - DocBlockr (generates clean comment blocks based on active language)


### PR DESCRIPTION
A sizable chunk of 18F devs are using VS Code now, so it makes sense for that to be listed alongside other editors in the handbook! I also added a note about the Live Share plugin because it's so useful for things like code pairing and review.