### PR TITLE
remove data from Tech Portfolio scope

### DIFF
--- a/_pages/about-us/teams/tech-portfolio.md
+++ b/_pages/about-us/teams/tech-portfolio.md
@@ -5,11 +5,10 @@ navtitle: Tech Portfolio
 
 The goal of the Tech Portfolio is to oversee/manage/coordinate everything technology-related that cuts across TTS, or anything technology-related that will affect TTS from the outside: particularly security, compliance, infrastructure, and tech policy. We provide all the things that allow you to get your job done, at the highest quality level.
 
-Rather than trying to exert control over everything technology at TTS, we focus instead on protecting, streamlining, and enabling our staff and systems, and doing so in an empathetic, transparent way. The Tech Portfolio’s work applies to much more than technology; it applies to our entire operation, including how we work inside the law, how we secure our systems, how we collect data from the public, and how we spend money.
+Rather than trying to exert control over everything technology at TTS, we focus instead on protecting, streamlining, and enabling our staff and systems, and doing so in an empathetic, transparent way. The Tech Portfolio’s work applies to much more than technology; it applies to our entire operation, including how we work inside the law, how we secure our systems, and how we spend money.
 
 Tech Portfolio Vision:
 
-- Make sure we are making the most of the data we collect and create, to make for better decisions within TTS and for our partners
 - Find where we may be duplicating effort or have gaps around technology, and if those are opportunities for TTS/GSA/government-wide shared services
 - Serve as the primary liaison between [GSA IT](https://www.gsa.gov/about-us/organization/gsa-it) and TTS, ensuring high levels of service, finding compromise, and generally keeping a good relationship between the teams
 


### PR DESCRIPTION
> after some back-and-forth within the team, we've decided that data across TTS is not a major area the Tech Portfolio has bandwidth to focus on right now. we're shifting focus to be more around tools: approvals, consolidation, documentation, etc.

https://gsa-tts.slack.com/archives/CN29CUEAE/p1574175942007700