### PR TITLE
Moved the Internal Documentation to a more canonical place

### DIFF
--- a/_pages/about-us/teams/tech-portfolio.md
+++ b/_pages/about-us/teams/tech-portfolio.md
@@ -31,7 +31,7 @@ Things not within our scope:
 - [The Tech Portfolio Kanban board](https://github.com/orgs/18F/projects/11?fullscreen=true) - what we're working on
 - [Before You Ship](https://before-you-ship.18f.gov/) - TTS's internal documentation about security, compliance, and infrastructure
 - Maintaining the authoritative source documentation for components used across TTS  [Software-as-a-service (SaaS) ](https://docs.google.com/spreadsheets/d/12pfcEIEXaJTjIKex-3wnI89erIvgKf9B_XpGkDl6qsM/edit#gid=0), [Systems](https://docs.google.com/spreadsheets/u/1/d/1LGn9kZCphzf14V5HpBfV3aYjflu-k9GtHS5LmFvDywM/edit?usp=drive_web&ouid=114492559070606542558), and [Accounts](https://docs.google.com/spreadsheets/d/1DedSCiU9AsCAAVvAFZT0_Ii7AFIKlI-JNifzlpHNbDg/edit#gid=0) 
-- [More internal documentation](https://docs.google.com/document/d/1qIms6TcYOQ24BerQrxAFzTKAqVS6VNCpWklwTsxBmWA/edit#)
+- [More internal documentation](https://github.com/18F/tts-tech-portfolio/wiki/Documents-for-TTS-Tech-Porfolio)
 - The Technology Portfolio team is new as of July 2019, though, is the evolution of [18F/TTS Infrastructure](https://github.com/18F/Infrastructure/blob/master/README.md).
 
 

--- a/_pages/about-us/teams/tech-portfolio.md
+++ b/_pages/about-us/teams/tech-portfolio.md
@@ -32,6 +32,7 @@ Things not within our scope:
 - [Before You Ship](https://before-you-ship.18f.gov/) - TTS's internal documentation about security, compliance, and infrastructure
 - Maintaining the authoritative source documentation for components used across TTS  [Software-as-a-service (SaaS) ](https://docs.google.com/spreadsheets/d/12pfcEIEXaJTjIKex-3wnI89erIvgKf9B_XpGkDl6qsM/edit#gid=0), [Systems](https://docs.google.com/spreadsheets/u/1/d/1LGn9kZCphzf14V5HpBfV3aYjflu-k9GtHS5LmFvDywM/edit?usp=drive_web&ouid=114492559070606542558), and [Accounts](https://docs.google.com/spreadsheets/d/1DedSCiU9AsCAAVvAFZT0_Ii7AFIKlI-JNifzlpHNbDg/edit#gid=0) 
 - [More internal documentation](https://github.com/18F/tts-tech-portfolio/wiki/Documents-for-TTS-Tech-Porfolio)
+- [Read more about us](https://github.com/18F/tts-tech-portfolio/blob/master/README.md)
 - The Technology Portfolio team is new as of July 2019, though, is the evolution of [18F/TTS Infrastructure](https://github.com/18F/Infrastructure/blob/master/README.md).
 
 


### PR DESCRIPTION
Started using the wiki feature of GitHub in our Tech Portfolio repo