### PR TITLE
Add info about finding your term-out date

### DIFF
--- a/_pages/general/hiring/leaving-tts.md
+++ b/_pages/general/hiring/leaving-tts.md
@@ -19,7 +19,7 @@ Send an official email to your supervisor and [leavingTTS@gsa.gov](mailto:leavin
 
 Please include the following information:
 
-- your **termination date** (the last day of your term or the last official day that you've selected), which should be at least two weeks out.
+- your **termination date** (the last day of your term or the last official day that you've selected), which should be at least two weeks out. (You can find the last day of your term in [eOPF](https://eopf.opm.gov/gsa/) by finding the most recent SF-50 with type `EXC APPT NTE` or `EXT OF APPT NTE` and looking at box 5-B.)
 - your **home address**. This will ensure that GSA HR enters the correct information on your final SF-50 so that you can receive all of your documents on time and to the correct address.
 - your **personal email** so that if, or when, you wish to request your FERS refund contributions HR can correspond with you after your departure with status/updates on this request.
 


### PR DESCRIPTION
Term employees can find their term-out date from finding the relevant SF-50 in eOPF. When we first start a term, we get an SF-50 with type `EXC APPT NTE` that includes our original term-out date. If we extend our term, we get a new SF-50 with type `EXT OF APPT NTE` with the new term-out date. In both cases, the date is in box 5-B.

This PR adds instructions to the handbook for folks who aren't 100% sure of their exact term-out date but need it.