### PR TITLE
generate table of contents recursively

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,9 +53,6 @@ navigation:
   - text: About TTS
     blurb: |
       <a href="https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services">Technology Transformation Services (TTS)</a> applies modern methodologies and technologies to improve the public’s experience with government by helping agencies make their services more accessible, efficient, and effective. Below is more information on both general TTS policies and the individual offices within TTS.
-    url: about-us
-    internal: true
-    generated: true
     children:
       - children:
           - text: Mission, history, and values
@@ -73,9 +70,6 @@ navigation:
   - text: Getting started
     blurb: |
       Here's what you probably want to know in your first weeks at TTS.
-    url: welcome-to-TTS/
-    internal: true
-    generated: true
     children:
       - children:
           - text: Welcome
@@ -102,9 +96,6 @@ navigation:
   - text: Training &amp; Development
     blurb: |
       Classes, coaching and ongoing professional development
-    url: development-and-training
-    internal: true
-    generated: true
     children:
       - children:
           - text: Online Learning University (OLU)
@@ -122,9 +113,6 @@ navigation:
   - text: Travel and leave
     blurb: |
       Going somewhere? Here's what you need to know.
-    url: travel-guide-table-of-contents
-    internal: true
-    generated: true
     children:
       - children:
           - text: Leave (HR Links)
@@ -134,9 +122,6 @@ navigation:
             url: travel-guide-table-of-contents/
             internal: true
   - text: General information and resources
-    url: about-us/
-    internal: true
-    generated: true
     children:
       - children:
           - text: Who we are
@@ -332,9 +317,6 @@ navigation:
   - text: TTS Offices
     blurb: |
       We’re all one family at TTS, but each office has its own norms and practices.
-    url: tts-offices/
-    internal: true
-    generated: true
     children:
       - text: TTS Office of Operations
         children:

--- a/_config.yml
+++ b/_config.yml
@@ -9,14 +9,14 @@ github_info:
   default_branch: master
 
 exclude:
-- CONTRIBUTING.md
-- Dockerfile
-- Gemfile
-- Gemfile.lock
-- LICENSE.md
-- README.md
-- go
-- vendor
+  - CONTRIBUTING.md
+  - Dockerfile
+  - Gemfile
+  - Gemfile.lock
+  - LICENSE.md
+  - README.md
+  - go
+  - vendor
 
 styles:
   - stylesheets/screen.css
@@ -28,8 +28,7 @@ scripts:
   - javascripts/application.js
 
 defaults:
-  -
-    scope:
+  - scope:
       path: ""
       type: "pages"
     values:
@@ -48,493 +47,493 @@ search_site_handle: tts-handbook
 
 jekyll_get:
   - data: dgcommunities
-    json: 'https://digital.gov/communities/index.json'
+    json: "https://digital.gov/communities/index.json"
 
 navigation:
-- text: Table of Contents
-  internal: true
-- text: About TTS
-  blurb: |
-    <a href="https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services">Technology Transformation Services (TTS)</a> applies modern methodologies and technologies to improve the public’s experience with government by helping agencies make their services more accessible, efficient, and effective. Below is more information on both general TTS policies and the individual offices within TTS.
-  url: about-us
-  internal: true
-  generated: true
-  children:
-  - children:
-    - text: Mission, history, and values
-      url: tts-history
-      internal: true
-    - text: Diversity, equity & inclusion
-      url: diversity
-      internal: true
-    - text: Code of Conduct
-      url: code-of-conduct
-      internal: true
-    - text: Org chart
-      url: tts-org-chart
-      internal: true
-- text: Getting started
-  blurb: |
-    Here's what you probably want to know in your first weeks at TTS.
-  url: welcome-to-TTS/
-  internal: true
-  generated: true
-  children:
-  - children:
-    - text: Welcome
-      url: welcome-letter
-      internal: true
-    - text: Getting Started at TTS
-      url: getting-started
-      internal: true
-    - text: Onboarding class schedule
-      url: onboarding-schedule
-      internal: true
-    - text: Logging in &amp; Networks
-      url: how-to-log-in
-      internal: true
-    - text: Equipment
-      url: equipment
-      internal: true
-    - text: Benefits
-      url: benefits
-      internal: true
-    - text: Travel 101
-      url: travel-101
-      internal: true
-- text: Training &amp; Development
-  blurb: |
-    Classes, coaching and ongoing professional development
-  url: development-and-training
-  internal: true
-  generated: true
-  children:
-  - children:
-    - text: Online Learning University (OLU)
-      url: olu/
-      internal: true
-    - text: Conferences and events
-      url: conferences-events-training/
-      internal: true
-    - text: Coaching, mentoring and professional development
-      url: development-and-training
-      internal: true
-    - text: GitHub 101
-      url: intro-to-github/
-      internal: true
-- text: Travel and leave
-  blurb: |
-    Going somewhere? Here's what you need to know.
-  url: travel-guide-table-of-contents
-  internal: true
-  generated: true
-  children:
-  - children:
-      - text: Leave (HR Links)
-        url: leave/
-        internal: true
-      - text: Travel guide (table of contents)
-        url: travel-guide-table-of-contents/
-        internal: true
-- text: General information and resources
-  url: about-us/
-  internal: true
-  generated: true
-  children:
-  - children:
-    - text: Who we are
-      children:
-      - text: General contacts and listservs
-        url: general-contacts-and-listservs/
-        internal: true
-      - text: Working groups and guilds
-        url: working-groups-and-guilds-101/
-        internal: true
-      - text: Glossary
-        url: glossary/
-        internal: true
-      - text: Records management
-        url: records-management/
-        internal: true
-    - text: TTS locations
-      children:
-      - text: Distributed
-        url: distributed/
-        internal: true
-      - text: Chicago
-        url: chicago/
-        internal: true
-      - text: New York City
-        url: new-york-city/
-        internal: true
-      - text: San Francisco
-        url: san-francisco/
-        internal: true
-      - text: Washington, D.C.
-        url: washington-dc/
-        internal: true
-    - text: TTS platforms
-      children:
-      - text: Cloud.gov
-        url: https://cloud.gov/
-        internal: false
-      - text: Login.gov
-        url: https://login.gov/
-        internal: false
-      - text: Federalist (publishing platform)
-        url: federalist/
-        internal: true
-    - text: Tech
-      children:
-      - text: FITARA
-        url: fitara/
-        internal: true
-      - text: Requirements for passwords
-        url: password-requirements/
-        internal: true
-      - text: Security incidents
-        url: security-incidents/
-        internal: true
-      - text: Sensitive information
-        url: sensitive-information/
-        internal: true
-    - text: Employee resources
-      children:
-      - text: Benefits links and resources
-        url: benefits-links/
-        internal: true
-      - text: Emergency procedures
-        url: https://docs.google.com/document/d/11tUnOegbHajqXPwSFxGtmGakupYrLgyItz4sgxAysi8/edit
-        internal: false
-      - text: Employee assistance program
-        url: employee-assistance-program/
-        internal: true
-      - text: Employment verification
-        url: employment-verification/
-        internal: true
-      - text: Overtime and comp time
-        url: overtime-and-comp-time/
-        internal: true
-      - text: Performance management
-        url: performance-management
-        internal: true
-      - text: Purchase requests
-        url: purchase-requests/
-        internal: true
+  - text: Table of Contents
+    internal: true
+  - text: About TTS
+    blurb: |
+      <a href="https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services">Technology Transformation Services (TTS)</a> applies modern methodologies and technologies to improve the public’s experience with government by helping agencies make their services more accessible, efficient, and effective. Below is more information on both general TTS policies and the individual offices within TTS.
+    url: about-us
+    internal: true
+    generated: true
+    children:
+      - children:
+          - text: Mission, history, and values
+            url: tts-history
+            internal: true
+          - text: Diversity, equity & inclusion
+            url: diversity
+            internal: true
+          - text: Code of Conduct
+            url: code-of-conduct
+            internal: true
+          - text: Org chart
+            url: tts-org-chart
+            internal: true
+  - text: Getting started
+    blurb: |
+      Here's what you probably want to know in your first weeks at TTS.
+    url: welcome-to-TTS/
+    internal: true
+    generated: true
+    children:
+      - children:
+          - text: Welcome
+            url: welcome-letter
+            internal: true
+          - text: Getting Started at TTS
+            url: getting-started
+            internal: true
+          - text: Onboarding class schedule
+            url: onboarding-schedule
+            internal: true
+          - text: Logging in &amp; Networks
+            url: how-to-log-in
+            internal: true
+          - text: Equipment
+            url: equipment
+            internal: true
+          - text: Benefits
+            url: benefits
+            internal: true
+          - text: Travel 101
+            url: travel-101
+            internal: true
+  - text: Training &amp; Development
+    blurb: |
+      Classes, coaching and ongoing professional development
+    url: development-and-training
+    internal: true
+    generated: true
+    children:
+      - children:
+          - text: Online Learning University (OLU)
+            url: olu/
+            internal: true
+          - text: Conferences and events
+            url: conferences-events-training/
+            internal: true
+          - text: Coaching, mentoring and professional development
+            url: development-and-training
+            internal: true
+          - text: GitHub 101
+            url: intro-to-github/
+            internal: true
+  - text: Travel and leave
+    blurb: |
+      Going somewhere? Here's what you need to know.
+    url: travel-guide-table-of-contents
+    internal: true
+    generated: true
+    children:
+      - children:
+          - text: Leave (HR Links)
+            url: leave/
+            internal: true
+          - text: Travel guide (table of contents)
+            url: travel-guide-table-of-contents/
+            internal: true
+  - text: General information and resources
+    url: about-us/
+    internal: true
+    generated: true
+    children:
+      - children:
+          - text: Who we are
+            children:
+              - text: General contacts and listservs
+                url: general-contacts-and-listservs/
+                internal: true
+              - text: Working groups and guilds
+                url: working-groups-and-guilds-101/
+                internal: true
+              - text: Glossary
+                url: glossary/
+                internal: true
+              - text: Records management
+                url: records-management/
+                internal: true
+          - text: TTS locations
+            children:
+              - text: Distributed
+                url: distributed/
+                internal: true
+              - text: Chicago
+                url: chicago/
+                internal: true
+              - text: New York City
+                url: new-york-city/
+                internal: true
+              - text: San Francisco
+                url: san-francisco/
+                internal: true
+              - text: Washington, D.C.
+                url: washington-dc/
+                internal: true
+          - text: TTS platforms
+            children:
+              - text: Cloud.gov
+                url: https://cloud.gov/
+                internal: false
+              - text: Login.gov
+                url: https://login.gov/
+                internal: false
+              - text: Federalist (publishing platform)
+                url: federalist/
+                internal: true
+          - text: Tech
+            children:
+              - text: FITARA
+                url: fitara/
+                internal: true
+              - text: Requirements for passwords
+                url: password-requirements/
+                internal: true
+              - text: Security incidents
+                url: security-incidents/
+                internal: true
+              - text: Sensitive information
+                url: sensitive-information/
+                internal: true
+          - text: Employee resources
+            children:
+              - text: Benefits links and resources
+                url: benefits-links/
+                internal: true
+              - text: Emergency procedures
+                url: https://docs.google.com/document/d/11tUnOegbHajqXPwSFxGtmGakupYrLgyItz4sgxAysi8/edit
+                internal: false
+              - text: Employee assistance program
+                url: employee-assistance-program/
+                internal: true
+              - text: Employment verification
+                url: employment-verification/
+                internal: true
+              - text: Overtime and comp time
+                url: overtime-and-comp-time/
+                internal: true
+              - text: Performance management
+                url: performance-management
+                internal: true
+              - text: Purchase requests
+                url: purchase-requests/
+                internal: true
+                children:
+                  - text: Software under $10,000
+                    url: software/
+                    internal: true
+                  - text: Procurements over $10,000
+                    url: procurements-over-10000/
+                    internal: true
+              - text: Resources for Deaf and Hard of Hearing individuals
+                url: deaf-hoh/
+                internal: true
+              - text: Telework guidance
+                url: telework/
+                internal: true
+                children:
+                  - text: Virtual work and moving
+                    url: moving/
+                    internal: true
+              - text: Transit benefit
+                url: transit-benefit/
+                internal: true
+          - text: Hiring, staying, or changing jobs
+            children:
+              - text: Hiring
+                url: hiring/
+                internal: true
+              - text: TTSJobs
+                url: ttsjobs/
+                internal: true
+              - text: Term extensions
+                url: term-extensions/
+                internal: true
+              - text: Assignments and details
+                url: assignee-detail/
+                internal: true
+              - text: Promotions
+                url: promotions/
+                internal: true
+              - text: Leaving TTS
+                url: leaving-tts/
+                internal: true
+              - text: Hiring authorities
+                url: hiring-authorities/
+                internal: true
+          - text: Software and tools
+            children:
+              - text: GSA internal tools
+                url: gsa-internal-tools/
+                internal: true
+              - text: Adobe Acrobat and Creative Cloud (CC)
+                url: adobe/
+                internal: true
+              - text: Analytics
+                url: analytics/
+                internal: true
+              - text: AnyConnect (VPN client)
+                url: anyconnect/
+                internal: true
+              - text: DocuSign (digital signatures; replaced eSign)
+                url: digital-signatures/
+                internal: true
+              - text: GitHub (code repos and versioning)
+                url: github/
+                internal: true
+              - text: Gmail
+                url: gmail/
+                internal: true
+              - text: Google Calendar
+                url: google-calendar/
+                internal: true
+              - text: Google Drive
+                url: google-drive/
+                internal: true
+              - text: Google Groups
+                url: google-groups/
+                internal: true
+              - text: Google Meet (video conferencing)
+                url: google-meet/
+                internal: true
+              - text: Meetings and meeting tools
+                url: meetings-and-meeting-tools/
+                internal: true
+              - text: Microsoft Office for OS X
+                url: office/
+                internal: true
+              - text: Mural.ly (collaborative whiteboard tool)
+                url: murally/
+                internal: true
+              - text: Sketch
+                url: sketch/
+                internal: true
+              - text: Slack (chat client)
+                url: slack/
+                internal: true
+              - text: Text editors
+                url: text-editors/
+                internal: true
+              - text: Tock (time tracking)
+                url: tock/
+                internal: true
+              - text: Trello (task and project management)
+                url: trello/
+                internal: true
+              - text: VMware Fusion (hypervisor)
+                url: vmware-fusion/
+                internal: true
+              - text: VMware Horizon (virtual desktop client)
+                url: vmware-horizon/
+                internal: true
+              - text: Zoom (video conferencing)
+                url: zoom/
+                Internal: true
+  - text: TTS Offices
+    blurb: |
+      We’re all one family at TTS, but each office has its own norms and practices.
+    url: tts-offices/
+    internal: true
+    generated: true
+    children:
+      - text: TTS Office of Operations
         children:
-        - text: Software under $10,000
-          url: software/
-          internal: true
-        - text: Procurements over $10,000
-          url: procurements-over-10000/
-          internal: true
-      - text: Resources for Deaf and Hard of Hearing individuals
-        url: deaf-hoh/
-        internal: true
-      - text: Telework guidance
-        url: telework/
-        internal: true
+          - text: Business Operations
+            children:
+              - text: Overview of Business Operations
+                url: bizops/
+                internal: true
+              - text: Agreements
+                url: agreements/
+                internal: true
+                children:
+                  - text: State and local agreements
+                    url: state-local-agreements/
+                    internal: true
+              - text: Technology Portfolio
+                url: tech-portfolio/
+                internal: true
+          - text: Talent team
+            children:
+              - text: Talent
+                url: talent/
+                internal: true
+              - text: Federal resume guide
+                url: resume
+                internal: true
+              - text: Refer a person
+                url: https://handbook.18f.gov/talent/#referring-a-person
+                internal: false
+              - text: Internal TTS Opportunities
+                url: https://docs.google.com/spreadsheets/d/120cF2PhzbTcCfoJ8n9L3o9brn30jOcfP5LZdZy6bElk/edit#gid=0
+                internal: false
+              - text: Top Secret/Sensitive Compartmented Information (TS/SCI) Clearance
+                url: top-secret/
+                internal: true
+          - text: Outreach
+            children:
+              - text: Outreach
+                url: outreach/
+                internal: true
+              - text: Social media
+                url: social-media/
+                internal: true
+      - text: TTS Office of Acquisition
         children:
-        - text: Virtual work and moving
-          url: moving/
-          internal: true
-      - text: Transit benefit
-        url: transit-benefit/
-        internal: true
-    - text: Hiring, staying, or changing jobs
-      children:
-      - text: Hiring
-        url: hiring/
-        internal: true
-      - text: TTSJobs
-        url: ttsjobs/
-        internal: true
-      - text: Term extensions
-        url: term-extensions/
-        internal: true
-      - text: Assignments and details
-        url: assignee-detail/
-        internal: true
-      - text: Promotions
-        url: promotions/
-        internal: true
-      - text: Leaving TTS
-        url: leaving-tts/
-        internal: true
-      - text: Hiring authorities
-        url: hiring-authorities/
-        internal: true
-    - text: Software and tools
-      children:
-        - text: GSA internal tools
-          url: gsa-internal-tools/
-          internal: true
-        - text: Adobe Acrobat and Creative Cloud (CC)
-          url: adobe/
-          internal: true
-        - text: Analytics
-          url: analytics/
-          internal: true
-        - text: AnyConnect (VPN client)
-          url: anyconnect/
-          internal: true
-        - text: DocuSign (digital signatures; replaced eSign)
-          url: digital-signatures/
-          internal: true
-        - text: GitHub (code repos and versioning)
-          url: github/
-          internal: true
-        - text: Gmail
-          url: gmail/
-          internal: true
-        - text: Google Calendar
-          url: google-calendar/
-          internal: true
-        - text: Google Drive
-          url: google-drive/
-          internal: true
-        - text: Google Groups
-          url: google-groups/
-          internal: true
-        - text: Google Meet (video conferencing)
-          url: google-meet/
-          internal: true
-        - text: Meetings and meeting tools
-          url: meetings-and-meeting-tools/
-          internal: true
-        - text: Microsoft Office for OS X
-          url: office/
-          internal: true
-        - text: Mural.ly (collaborative whiteboard tool)
-          url: murally/
-          internal: true
-        - text: Sketch
-          url: sketch/
-          internal: true
-        - text: Slack (chat client)
-          url: slack/
-          internal: true
-        - text: Text editors
-          url: text-editors/
-          internal: true
-        - text: Tock (time tracking)
-          url: tock/
-          internal: true
-        - text: Trello (task and project management)
-          url: trello/
-          internal: true
-        - text: VMware Fusion (hypervisor)
-          url: vmware-fusion/
-          internal: true
-        - text: VMware Horizon (virtual desktop client)
-          url: vmware-horizon/
-          internal: true
-        - text: Zoom (video conferencing)
-          url: zoom/
-          Internal: true
-- text: TTS Offices
-  blurb: |
-    We’re all one family at TTS, but each office has its own norms and practices.
-  url: tts-offices/
-  internal: true
-  generated: true
-  children:
-  - text: TTS Office of Operations
-    children:
-    - text: Business Operations
-      children:
-      - text: Overview of Business Operations
-        url: bizops/
-        internal: true
-      - text: Agreements
-        url: agreements/
-        internal: true
+          - text: Overview of OA
+            url: oa/
+            internal: true
+          - text: OA Operational Guidance
+            url: acquisition/
+            internal: true
+      - text: 18F
         children:
-        - text: State and local agreements
-          url: state-local-agreements/
-          internal: true
-      - text: Technology Portfolio
-        url: tech-portfolio/
-        internal: true
-    - text: Talent team
-      children:
-      - text: Talent
-        url: talent/
-        internal: true
-      - text: Federal resume guide
-        url: resume
-        internal: true
-      - text: Refer a person
-        url: https://handbook.18f.gov/talent/#referring-a-person
-        internal: false
-      - text: Internal TTS Opportunities
-        url: https://docs.google.com/spreadsheets/d/120cF2PhzbTcCfoJ8n9L3o9brn30jOcfP5LZdZy6bElk/edit#gid=0
-        internal: false
-      - text: Top Secret/Sensitive Compartmented Information (TS/SCI) Clearance
-        url: top-secret/
-        internal: true
-    - text: Outreach
-      children:
-      - text: Outreach
-        url: outreach/
-        internal: true
-      - text: Social media
-        url: social-media/
-        internal: true
-  - text: TTS Office of Acquisition
-    children:
-    - text: Overview of OA
-      url: oa/
-      internal: true
-    - text: OA Operational Guidance
-      url: acquisition/
-      internal: true
-  - text: 18F
-    children:
-    - text: About 18F
-      children:
-      - text: 18F history and values
-        url: history-and-values/
-        internal: true
-      - text: 18F org chart
-        url: https://docs.google.com/presentation/d/189TanLPSFF9MWvNr6VdfUvhBAWBSXeoCSGD2ZXRDm3s/edit#slide=id.g54b7f7db38_18_0
-        internal: false
-    - text: How we work
-      children:
-      - text: Time tracking and billing
-        url: tock/#time-tracking-and-billing
-        internal: false
-      - text: How we staff projects
-        url: staffing-projects/
-        internal: true
-      - text: One-on-ones
-        url: one-on-ones/
-        internal: true
-      - text: Out of office expectations
-        url: leave/#leave-checklist
-        internal: false
-      - text: Performance Plan (FY19)
-        url: 18f-performance-plan/
-        internal: true
-      - text: Open source policy
-        url: https://github.com/18F/open-source-policy/blob/master/policy.md
-        internal: false
-    - text: 18F projects
-      children:
-      - text: Consulting with partners
-        url: how-we-relate-to-partners/
-        internal: true
-      - text: Working with partners
-        url: how-we-collaborate/
-        internal: true
-      - text: Sharing calendars with partners
-        url: sharedcalendars/
-        internal: true
-      - text: Leading projects
-        url: leading-projects/
-        internal: true
-      - text: Working on an acquisition engagement
-        url: working-on-an-acquisition-engagement/
-        internal: true
+          - text: About 18F
+            children:
+              - text: 18F history and values
+                url: history-and-values/
+                internal: true
+              - text: 18F org chart
+                url: https://docs.google.com/presentation/d/189TanLPSFF9MWvNr6VdfUvhBAWBSXeoCSGD2ZXRDm3s/edit#slide=id.g54b7f7db38_18_0
+                internal: false
+          - text: How we work
+            children:
+              - text: Time tracking and billing
+                url: tock/#time-tracking-and-billing
+                internal: false
+              - text: How we staff projects
+                url: staffing-projects/
+                internal: true
+              - text: One-on-ones
+                url: one-on-ones/
+                internal: true
+              - text: Out of office expectations
+                url: leave/#leave-checklist
+                internal: false
+              - text: Performance Plan (FY19)
+                url: 18f-performance-plan/
+                internal: true
+              - text: Open source policy
+                url: https://github.com/18F/open-source-policy/blob/master/policy.md
+                internal: false
+          - text: 18F projects
+            children:
+              - text: Consulting with partners
+                url: how-we-relate-to-partners/
+                internal: true
+              - text: Working with partners
+                url: how-we-collaborate/
+                internal: true
+              - text: Sharing calendars with partners
+                url: sharedcalendars/
+                internal: true
+              - text: Leading projects
+                url: leading-projects/
+                internal: true
+              - text: Working on an acquisition engagement
+                url: working-on-an-acquisition-engagement/
+                internal: true
+                children:
+                  - text: Acquisition engagement types
+                    url: acquisition-engagement-types/
+                    internal: true
+                  - text: Acquisition engagement glossary
+                    url: working-on-an-acquisition-engagement/#acquisition-glossary
+                    internal: true
+          - text: 18F chapters
+            children:
+              - text: Account management
+                url: account-manager/
+                internal: true
+                children:
+                  - text: Account management policy
+                    url: client-accounts/
+                    internal: true
+              - text: Acquisition
+                url: acqstack/
+                internal: true
+              - text: Design
+                url: design/
+                internal: true
+              - text: Engineering
+                url: engineering/
+                internal: true
+              - text: Product
+                url: product/
+                internal: true
+              - text: Strategy
+                url: strategy/
+                internal: true
+          - text: 18F labs
+            children:
+              - text: Writing Lab
+                url: writing-lab/
+                internal: true
+              - text: Design Lab
+                url: https://github.com/18F/design-lab
+                internal: false
+              - text: Dev Lab
+                url: https://gsa-tts.slack.com/messages/CDE5DU7QC/
+                internal: false
+          - text: 18F team resources
+            children:
+              - text: Before you ship
+                url: https://before-you-ship.18f.gov/infrastructure/aws/
+                internal: false
+              - text: Blogging
+                url: blogging/
+                internal: true
+              - text: Doing research at 18F
+                url: research-guidelines/
+                internal: true
+              - text: Accessing DoD Systems
+                url: accessing-dod-systems/
+                internal: true
+      - text: Office of Products and Programs (OPP)
         children:
-        - text: Acquisition engagement types
-          url: acquisition-engagement-types/
-          internal: true
-        - text: Acquisition engagement glossary
-          url: working-on-an-acquisition-engagement/#acquisition-glossary
-          internal: true
-    - text: 18F chapters
-      children:
-      - text: Account management
-        url: account-manager/
-        internal: true
+          - text: About OPP
+            children:
+              - text: Overview of OPP
+                url: office-of-products-and-programs/
+                internal: true
+              - text: OPP history
+                url: opp-history/
+                internal: true
+              - text: OPP org chart
+                url: opp-org-chart/
+                internal: true
+          - text: Portfolios
+            children:
+              - text: Data
+                url: https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services/office-of-products-and-programs#DSP
+                internal: false
+              - text: Innovation
+                url: https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services/office-of-products-and-programs#IP
+                internal: false
+              - text: Public Experience
+                url: https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services/office-of-products-and-programs#CEP
+                internal: false
+              - text: Smarter IT
+                url: https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services/office-of-products-and-programs#SmarterITDelivery
+                internal: false
+              - text: Secure Cloud
+                url: https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services/office-of-products-and-programs#SecureCloud
+                internal: false
+              - text: 10x
+                url: https://10x.gsa.gov
+                internal: false
+      - text: Centers of Excellence (CoE)
         children:
-        - text: Account management policy
-          url: client-accounts/
-          internal: true
-      - text: Acquisition
-        url: acqstack/
-        internal: true
-      - text: Design
-        url: design/
-        internal: true
-      - text: Engineering
-        url: engineering/
-        internal: true
-      - text: Product
-        url: product/
-        internal: true
-      - text: Strategy
-        url: strategy/
-        internal: true
-    - text: 18F labs
-      children:
-      - text: Writing Lab
-        url: writing-lab/
-        internal: true
-      - text: Design Lab
-        url: https://github.com/18F/design-lab
-        internal: false
-      - text: Dev Lab
-        url: https://gsa-tts.slack.com/messages/CDE5DU7QC/
-        internal: false
-    - text: 18F team resources
-      children:
-      - text: Before you ship
-        url: https://before-you-ship.18f.gov/infrastructure/aws/
-        internal: false
-      - text: Blogging
-        url: blogging/
-        internal: true
-      - text: Doing research at 18F
-        url: research-guidelines/
-        internal: true
-      - text: Accessing DoD Systems
-        url: accessing-dod-systems/
-        internal: true
-  - text: Office of Products and Programs (OPP)
-    children:
-    - text: About OPP
-      children:
-      - text: Overview of OPP
-        url: office-of-products-and-programs/
-        internal: true
-      - text: OPP history
-        url: opp-history/
-        internal: true
-      - text: OPP org chart
-        url: opp-org-chart/
-        internal: true
-    - text: Portfolios
-      children:
-      - text: Data
-        url: https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services/office-of-products-and-programs#DSP
-        internal: false
-      - text: Innovation
-        url: https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services/office-of-products-and-programs#IP
-        internal: false
-      - text: Public Experience
-        url: https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services/office-of-products-and-programs#CEP
-        internal: false
-      - text: Smarter IT
-        url: https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services/office-of-products-and-programs#SmarterITDelivery
-        internal: false
-      - text: Secure Cloud
-        url: https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services/office-of-products-and-programs#SecureCloud
-        internal: false
-      - text: 10x
-        url: https://10x.gsa.gov
-        internal: false
-  - text: Centers of Excellence (CoE)
-    children:
-    - text: Overview of CoE
-      url: centers-of-excellence/
-      internal: true
-    - text: CoE Website
-      url: https://coe.gsa.gov/
-      internal: false
-  - text: Presidential Innovation Fellows (PIF)
-    children:
-    - text: PIF Website
-      url: https://presidentialinnovationfellows.gov/
-      internal: false
+          - text: Overview of CoE
+            url: centers-of-excellence/
+            internal: true
+          - text: CoE Website
+            url: https://coe.gsa.gov/
+            internal: false
+      - text: Presidential Innovation Fellows (PIF)
+        children:
+          - text: PIF Website
+            url: https://presidentialinnovationfellows.gov/
+            internal: false

--- a/_config.yml
+++ b/_config.yml
@@ -50,8 +50,6 @@ jekyll_get:
     json: "https://digital.gov/communities/index.json"
 
 navigation:
-  - text: Table of Contents
-    internal: true
   - text: About TTS
     blurb: |
       <a href="https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services">Technology Transformation Services (TTS)</a> applies modern methodologies and technologies to improve the public’s experience with government by helping agencies make their services more accessible, efficient, and effective. Below is more information on both general TTS policies and the individual offices within TTS.

--- a/_includes/nav-item.html
+++ b/_includes/nav-item.html
@@ -1,5 +1,0 @@
-    <li id="{{ include.child.text | slugify }}" class="{{ include.child.text | slugify }}">
-        <a href="{% if include.child.internal %}{{site.baseurl}}/{% endif %}{{ include.child.url }}">
-          {{ include.child.text }}
-        </a>
-    </li>

--- a/_includes/nav-link.html
+++ b/_includes/nav-link.html
@@ -1,7 +1,5 @@
-{% if child.url %}
-<a href="{% if child.internal %}{{site.baseurl}}/{% endif %}{{ child.url }}">
-{% endif %}
-  {{ child.text }}
-{% if child.url %}
-</a>
-{% endif %}
+{% if include.child.url %}<a
+  href="{% if include.child.internal %}{{site.baseurl}}/{% endif %}{{ include.child.url }}"
+>{% endif %}
+  {{ include.child.text }}
+{% if include.child.url %}</a>{% endif %}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,18 +1,18 @@
 <ol>
   {% for item in include.nav %}
-    {% if item.children %}
-      <h{{ include.level }}>
-        {% include nav-link.html child=item %}
-      </h{{ include.level }}>
-      <p>
-        {{ item.blurb }}
-      </p>
-      {% assign next_level = include.level | plus: 1 %}
-      {% include nav.html level=next_level nav=item.children %}
-    {% else %}
-      <li>
-        {% include nav-link.html child=item %}
-      </li>
-    {% endif %}
+    <li>
+      {% if item.children %}
+        <h{{ include.level }}>
+          {% include nav-link.html child=item %}
+        </h{{ include.level }}>
+        {% if item.blurb %}
+          <p>{{ item.blurb }}</p>
+        {% endif %}
+        {% assign next_level = include.level | plus: 1 %}
+        {% include nav.html level=next_level nav=item.children %}
+      {% else %}
+          {% include nav-link.html child=item %}
+      {% endif %}
+    </li>
   {% endfor %}
 </ol>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,0 +1,15 @@
+<ol>
+  {% for item in include.nav %}
+    {% if item.children %}
+      <h{{ include.level }}>
+        {% include nav-link.html child=item %}
+      </h{{ include.level }}>
+      {% assign next_level = include.level | plus: 1 %}
+      {% include nav.html level=next_level nav=item.children %}
+    {% else %}
+      <li>
+        {% include nav-link.html child=item %}
+      </li>
+    {% endif %}
+  {% endfor %}
+</ol>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -4,6 +4,9 @@
       <h{{ include.level }}>
         {% include nav-link.html child=item %}
       </h{{ include.level }}>
+      <p>
+        {{ item.blurb }}
+      </p>
       {% assign next_level = include.level | plus: 1 %}
       {% include nav.html level=next_level nav=item.children %}
     {% else %}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,7 +2,7 @@
   {% for item in include.nav %}
     <li>
       {% if item.children %}
-        <h{{ include.level }}>
+        <h{{ include.level }} id="{{ item.text | slugify }}">
           {% include nav-link.html child=item %}
         </h{{ include.level }}>
         {% if item.blurb %}

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -1,70 +1,11 @@
 ---
 title: TTS Handbook
-permalink: '/'
+permalink: "/"
 ---
+
 <p>{{ site.description }}</p>
 <div class="layout-table-of-contents">
   <div class="wrapper">
-
-    <ol>
-    {% for nav in site.navigation %}
-    {% if nav.url == nil %}{% continue %}{% endif %}
-      <li>
-        <h1 id="{{ nav.url | remove:"/" }}">{{ nav.text }}</h1>
-        {% if nav.blurb %}<p>{{ nav.blurb }}</p>{% endif %}
-
-        {% unless nav.children == nil %}
-        {% for child in nav.children %}
-          <h2 id="{{ child.text | slugify }}">
-            {% include nav-link.html %}
-          </h2>
-          {% if child.children.size > 0 %}
-          <ol class="toc-nav-children toc-nav-children-level-3">
-          {% for child in child.children %}
-            {% if child.children.size > 0 %}
-            <ol class="toc-nav-children-level-4">
-            <h3 id="{{ child.text | slugify }}">
-              {% include nav-link.html %}
-            </h3>
-            {% for child in child.children %}
-              {% if child.children.size > 0 %}
-                <li id="{{ child.text | slugify }}">
-                  {% include nav-link.html %}
-
-                  <ol class="toc-nav-children-level-5">
-                  {% for child in child.children %}
-                    {% if child.children.size > 0 %}
-                      <h5 id="{{ child.text | slugify }}">
-                        {% include nav-link.html %}
-                      <h4 id="{{ child.text | slugify }}">
-                        {% include nav-link.html %}	                        
-                      </h4>
-                      <ol class="toc-nav-children-level-6">
-                      {% for child in child.children %}
-                        {% include nav-item.html child=child %}
-                      {% endfor %}
-                      </ol>
-                    {% else %}
-                      {% include nav-item.html child=child %}
-                    {% endif %}
-                  {% endfor %}
-                  </ol>
-                </li>
-              {% else %}
-                {% include nav-item.html child=child %}
-              {% endif %}
-            {% endfor %}
-            </ol>
-            {% else %}
-              {% include nav-item.html child=child %}
-            {% endif %}
-          {% endfor %}
-          </ol>
-          {% endif %}
-        {% endfor %}
-        {% endunless %}
-      </li>
-    {% endfor %}
-    </ol>
+    {% include nav.html level=1 nav=site.navigation %}
   </div>
 </div>

--- a/_sass/toc.scss
+++ b/_sass/toc.scss
@@ -24,23 +24,32 @@
   }
 }
 
-.layout-table-of-contents .wrapper ol ol ol ol ol {
-  margin: 0;
-  padding-left: 1rem;
-}
-
 .layout-table-of-contents .wrapper ol li {
   font-weight: normal;
   margin-bottom: 2px;
 }
 
-@media screen and (min-width: 711.11px) {
-  .layout-table-of-contents .wrapper > ol > li > ol > li > ol {
+// third-level nav
+.layout-table-of-contents .wrapper > ol > li > ol > li > ol {
+  @media screen and (min-width: 711.11px) {
     column-count: 2;
 
     li {
       page-break-inside: avoid;
       break-inside: avoid-column;
+    }
+  }
+
+  // fourth-level nav
+  > li {
+    > ol {
+      margin: 0.6em 0 1.7em 0;
+    }
+
+    // fifth+ level nav
+    ol ol {
+      margin: 0;
+      padding-left: 1rem;
     }
   }
 }
@@ -76,6 +85,7 @@
 
   ol h4 {
     margin: 0;
+    font-family: inherit;
     font-size: 17px;
     font-weight: normal;
   }

--- a/_sass/toc.scss
+++ b/_sass/toc.scss
@@ -42,7 +42,8 @@
     margin: 0 0 0.5em;
   }
 
-  h4 {
+  h4,
+  h5 {
     margin: 0;
     font-family: inherit;
     font-size: 17px;

--- a/_sass/toc.scss
+++ b/_sass/toc.scss
@@ -18,47 +18,15 @@
     margin-bottom: 1em;
   }
 
-  .wrapper ol li.toc-nav-child-with-children {
-    font-weight: 600;
-    padding-top: 1em;
-  }
-
-  .wrapper ol li.toc-nav-child-with-children > ol {
-    padding-top: 0.6em;
-  }
-
   .wrapper ol {
     // left-align
     padding-left: 0;
   }
 }
 
-.toc-nav-children-level-2 {
-  padding-top: 1em;
-}
-
-.toc-nav-children-level-3 {
-  margin: 0;
-  padding-top: 0.6em;
-}
-
-.toc-nav-children-level-4 {
-  margin: 0;
-  padding-top: 0.6em;
-  padding-bottom: 1em;
-}
-
-.toc-nav-children-level-5 {
+.layout-table-of-contents .wrapper ol ol ol ol ol {
   margin: 0;
   padding-left: 1rem;
-}
-
-.toc-nav-children-level-6 {
-  padding-left: 1.5rem;
-}
-
-.layout-table-of-contents .wrapper ol li.policies {
-  padding-bottom: 1em;
 }
 
 .layout-table-of-contents .wrapper ol li {
@@ -67,10 +35,10 @@
 }
 
 @media screen and (min-width: 711.11px) {
-  .layout-table-of-contents .wrapper > ol > ol > ol {
+  .layout-table-of-contents .wrapper > ol > li > ol > li > ol {
     column-count: 2;
 
-    > ol {
+    li {
       page-break-inside: avoid;
       break-inside: avoid-column;
     }
@@ -88,7 +56,7 @@
     color: #202020;
   }
 
-  ol h1:first-of-type {
+  ol li:first-of-type h1 {
     border-top: none;
     margin-top: 0;
   }

--- a/_sass/toc.scss
+++ b/_sass/toc.scss
@@ -3,10 +3,6 @@
     list-style-type: none;
   }
 
-  .wrapper {
-    max-width: 640px;
-  }
-
   p,
   li {
     line-height: 1.33em;
@@ -18,44 +14,7 @@
     margin-bottom: 1em;
   }
 
-  .wrapper ol {
-    // left-align
-    padding-left: 0;
-  }
-}
-
-.layout-table-of-contents .wrapper ol li {
-  font-weight: normal;
-  margin-bottom: 2px;
-}
-
-// third-level nav
-.layout-table-of-contents .wrapper > ol > li > ol > li > ol {
-  @media screen and (min-width: 711.11px) {
-    column-count: 2;
-
-    li {
-      page-break-inside: avoid;
-      break-inside: avoid-column;
-    }
-  }
-
-  // fourth-level nav
-  > li {
-    > ol {
-      margin: 0.6em 0 1.7em 0;
-    }
-
-    // fifth+ level nav
-    ol ol {
-      margin: 0;
-      padding-left: 1rem;
-    }
-  }
-}
-
-.layout-table-of-contents {
-  ol h1 {
+  h1 {
     font-size: 28px;
     font-weight: 600;
     padding-top: 1em;
@@ -65,28 +24,67 @@
     color: #202020;
   }
 
-  ol li:first-of-type h1 {
+  li:first-of-type h1 {
     border-top: none;
     margin-top: 0;
   }
 
-  ol h2 {
+  h2 {
     font-size: 24px;
     font-weight: 600;
     margin-top: 1em;
     color: #046b99;
   }
 
-  ol h3 {
+  h3 {
     font-size: 20px;
     font-weight: 600;
     margin: 0 0 0.5em;
   }
 
-  ol h4 {
+  h4 {
     margin: 0;
     font-family: inherit;
     font-size: 17px;
     font-weight: normal;
+  }
+
+  .wrapper {
+    max-width: 640px;
+
+    ol {
+      // left-align
+      padding-left: 0;
+
+      li {
+        font-weight: normal;
+        margin-bottom: 2px;
+      }
+    }
+
+    // third-level nav
+    > ol > li > ol > li > ol {
+      @media screen and (min-width: 711.11px) {
+        column-count: 2;
+
+        li {
+          page-break-inside: avoid;
+          break-inside: avoid-column;
+        }
+      }
+
+      // fourth-level nav
+      > li {
+        > ol {
+          margin: 0.6em 0 1.7em 0;
+        }
+
+        // fifth+ level nav
+        ol ol {
+          margin: 0;
+          padding-left: 1rem;
+        }
+      }
+    }
   }
 }

--- a/_sass/toc.scss
+++ b/_sass/toc.scss
@@ -63,7 +63,7 @@
     }
 
     // third-level nav
-    > ol > li > ol > li > ol {
+    h2 + ol {
       @media screen and (min-width: 711.11px) {
         column-count: 2;
 
@@ -72,18 +72,17 @@
           break-inside: avoid-column;
         }
       }
+    }
 
-      // fourth-level nav
-      > li {
-        > ol {
-          margin: 0.6em 0 1.7em 0;
-        }
+    // fourth-level nav
+    h3 + ol {
+      margin: 0.6em 0 1.7em 0;
 
-        // fifth+ level nav
-        ol ol {
-          margin: 0;
-          padding-left: 1rem;
-        }
+      // fifth+ level nav
+      ol {
+        // indent
+        margin: 0;
+        padding-left: 1rem;
       }
     }
   }

--- a/_sass/toc.scss
+++ b/_sass/toc.scss
@@ -7,19 +7,6 @@
     max-width: 640px;
   }
 
-  @keyframes highlight {
-    0% {
-      background: #fff0be;
-    }
-    100% {
-      background: none;
-    }
-  }
-
-  *:target {
-    animation: highlight 2s;
-  }
-
   p,
   li {
     line-height: 1.33em;
@@ -40,9 +27,7 @@
     padding-top: 0.6em;
   }
 
-  .wrapper > ol,
-  .toc-nav-children-level-3,
-  .toc-nav-children-level-4 {
+  .wrapper ol {
     // left-align
     padding-left: 0;
   }
@@ -61,9 +46,6 @@
   margin: 0;
   padding-top: 0.6em;
   padding-bottom: 1em;
-  -webkit-column-break-inside: avoid;
-  page-break-inside: avoid;
-  break-inside: avoid-column;
 }
 
 .toc-nav-children-level-5 {
@@ -85,14 +67,13 @@
 }
 
 @media screen and (min-width: 711.11px) {
-  .toc-nav-children {
-    -webkit-column-count: 2;
-    -moz-column-count: 2;
+  .layout-table-of-contents .wrapper > ol > ol > ol {
     column-count: 2;
-  }
 
-  .toc-nav-child-with-children {
-    column-span: all;
+    > ol {
+      page-break-inside: avoid;
+      break-inside: avoid-column;
+    }
   }
 }
 
@@ -107,7 +88,7 @@
     color: #202020;
   }
 
-  ol li:first-of-type h1 {
+  ol h1:first-of-type {
     border-top: none;
     margin-top: 0;
   }


### PR DESCRIPTION
Depends on #1722.

Was having a bit of fun playing around with Jekyll here. https://github.com/18F/handbook/pull/1652 adds another level of navigation, which was breaking some styles. Rather than have it fixed, this pull request changes the generation and styles to handle an arbitrary number of navigation levels (regardless of whether that's desirable or not), using less hard-coding.

To test: Check the preview and ensure the homepage looks and behaves similar to the live site.