### PR TITLE
stranded pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,10 @@ jobs:
             ! (grep -Erl "\(/|href=['\"]/" _pages && echo "ERROR: Internal links must be prefixed with {{site.baseurl}} to work correctly with Federalist Previews. Fix the above pages.")
 
       - run:
+          name: checking stranded pages
+          command: ruby stranded.rb
+
+      - run:
           name: build site
           command: bundle exec jekyll build
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,5 @@ gem 'jekyll-sass-converter', git: 'https://github.com/jekyll/jekyll-sass-convert
 
 group :development do
   gem 'html-proofer'
+  gem 'nokogiri'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ DEPENDENCIES
   jekyll
   jekyll-sass-converter!
   json
+  nokogiri
   uswds-jekyll!
 
 RUBY VERSION

--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ To run the site locally:
 
 1. Open http://localhost:4000
 
+## Checking for stranded pages
+
+"Stranded," meaning "not linked from the homepage."
+
+```sh
+docker-compose run web bundle exec jekyll build
+docker-compose run web bundle exec ruby stranded.rb
+```
+
 ## Contributing
 
 If you are interested in contributing to this repository, you can read more at [CONTRIBUTING](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -19,15 +19,6 @@ To run the site locally:
 
 1. Open http://localhost:4000
 
-## Checking for stranded pages
-
-"Stranded," meaning "not linked from the homepage."
-
-```sh
-docker-compose run web bundle exec jekyll build
-docker-compose run web bundle exec ruby stranded.rb
-```
-
 ## Contributing
 
 If you are interested in contributing to this repository, you can read more at [CONTRIBUTING](CONTRIBUTING.md).

--- a/stranded.rb
+++ b/stranded.rb
@@ -26,3 +26,4 @@ pages = rendered_pages.reject{ |pg| pg.match?(/travel|intro-to/) }.to_set
 
 stranded_pages = pages - homepage_links
 puts stranded_pages.to_a.sort
+abort if stranded_pages.any?

--- a/stranded.rb
+++ b/stranded.rb
@@ -1,0 +1,28 @@
+require "nokogiri"
+require "set"
+require "uri"
+
+def homepage_links
+  doc = File.open("_site/index.html") { |f| Nokogiri::HTML(f) }
+  links = doc.css(".layout-table-of-contents a")
+  paths = links.map { |l| l["href"] }
+  paths = paths.reject { |path| path.start_with?("http") }
+  paths.map { |path| URI::parse(path).path.gsub(/^\/|\/$/, "") }.to_set
+end
+
+def redirect?(path)
+  doc = File.open(path) { |f| Nokogiri::HTML(f) }
+  doc.css("meta[http-equiv=\"refresh\"]").any?
+end
+
+def rendered_pages
+  pages = Dir.glob("_site/*/index.html")
+  pages = pages.reject { |pg| redirect?(pg) }
+  pages.map { |pg| pg.split("/")[1] }
+end
+
+# Travel pages are deeply nested, so ignore those. Intro pages are linked from the onboarding guide.
+pages = rendered_pages.reject{ |pg| pg.match?(/travel|intro-to/) }.to_set
+
+stranded_pages = pages - homepage_links
+puts stranded_pages.to_a.sort


### PR DESCRIPTION
I was curious to know what pages were "stranded," meaning "not linked from the homepage." Wrote up a short script to do so. Here's what I got:

```
accessibility
changing-your-name
contract-file-management
fas-speaker-guide
hosting-non-government-speakers
igcap-october2016
management-reviews-of-procurement-actions
responding-to-public-disclosure-vulnerabilities
telework-agreement-new-ft
tts-office-of-acquisition-team-roles-and-responsibilities
```

Thoughts on whether this is useful or not? Should we aim for zero?