### PR TITLE
Fix link in "#returning-from-leave"

### DIFF
--- a/_pages/policies/travel-and-leave-policies/leave.md
+++ b/_pages/policies/travel-and-leave-policies/leave.md
@@ -77,7 +77,7 @@ Before taking leave, be sure to:
 - Mark your out of office time on your calendar and any applicable team or project calendars. Remember to set the permissions of the event to "public" so that people can see it's OOO time, rather than just seeing "busy."
 - Tell team members or partners via Slack or email, and make sure work is covered
 - Set up an email autoresponder as appropriate. This should include both when you’ll be back and a point of contact/team email for while you’re out. For example: `I am out of the office on Wednesday January 2nd and will respond to your request when I return on Thursday the 3rd. If you need immediate assistance please email 18F-PartnerSolutions@gsa.gov and your request will be directed to the appropriate party.`
-- Consider reminding yourself to update your status on return. You can tell Slackbot `/remind me to “Update my OOO reminder per https://handbook.18f.gov/leave/#retuning-from-leave” on [date you return]`
+- Consider reminding yourself to update your status on return. You can tell Slackbot `/remind me to “Update my OOO reminder per https://handbook.18f.gov/leave/#returning-from-leave” on [date you return]`
 
 - 18F team members should also:
     - Submit [correct Tock entries]({{site.baseurl}}/tock/#tocking-for-out-of-office-time)


### PR DESCRIPTION
Prior spelling of "retuning" was entirely my fault.