### PR TITLE
Fixes typo, adds punctuation, and adds descriptive links

### DIFF
--- a/_pages/travel-leave/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
+++ b/_pages/travel-leave/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
@@ -1,5 +1,5 @@
 ---
-title: Get set up to travel for TTS _before_ GSA onboarding
+title: Get set up to travel for TTS <em>before</em> GSA onboarding
 ---
 
 [TTS Travel Guide Table of Contents]({{site.baseurl}}/travel-guide-table-of-contents) <br>
@@ -15,15 +15,15 @@ If you're traveling for TTS during your first two weeks (normally for orientatio
 
    _Note if you haven't started and don't have your GSA email address yet_:
 
-   Your access to the EFT form linked above may be restricted, so you should have received it as an attachment in your welcome email-- feel free to reach out to [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov) if you never got it. The EFT form is needed so that the reimbursement for your hotels, meals, and other expenses can be reimbursed (GSA only pays for your flight or Amtrak tickets upfront).
+Your access to the EFT form linked above may be restricted, so you should have received it as an attachment in your welcome email-- feel free to reach out to [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov) if you never got it. The EFT form is needed so that the reimbursement for your hotels, meals, and other expenses can be reimbursed (GSA only pays for your flight or Amtrak tickets upfront).
 
-2. Once you recieve your employee ID (should be in the format _E000xxxxx_), forward it to [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov), along with your **Full Name** as it appears on ID and **Phone Number** as per TSA requirements.
+2. Once you receive your employee ID (should be in the format _E000xxxxx_), forward it to [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov), along with your **Full Name** as it appears on ID and **Phone Number** as per TSA requirements.
 
 3. **Book travel**: A member of the TTS travel team will reach out to you within two business days once you’ve sent in the above information, confirming that you've been set up in the Concur system. You may then call AdTrav at (877) 472-6716 to make your reservations at your convenience.
 
    Email tts-travel@gsa.gov once you've finalized your reservations and they will approve your itinerary. Make sure this is done during business hours-- no later than 3:30 PM ET!
 
-   Until you can get a GSA travel card (read more about this [here]({{site.baseurl}}/first-time-travel-travel-card)), you will unfortunately have to pay for your lodging and all other travel expenses other than air or rail upfront. But with a valid receipt, you will get reimbursed (generally 6-10 business days after expenses are submitted).  Just make sure to stay at a hotel with rates under the government maximum (also known as the per diem rate). You can look up what that is [here](http://www.gsa.gov/portal/category/100120).
+   Until you can get a GSA travel card (read more about this [here]({{site.baseurl}}/first-time-travel-travel-card)), you will unfortunately have to pay for your lodging and all other travel expenses other than air or rail upfront. But with a valid receipt, you will get reimbursed (generally 6-10 business days after expenses are submitted). Just make sure to stay at a hotel with rates under the government maximum (also known as the per diem rate). [You can look up per diem rates here](http://www.gsa.gov/portal/category/100120).
 
 4. **Receive tickets**: E-tickets will be sent to the email address that you provided. Once a reservation is made, you will get a “pending” itinerary, which will be finalized, depending on the airline, no later than 72 hours before departure.
 
@@ -35,7 +35,7 @@ If you're traveling for TTS during your first two weeks (normally for orientatio
 
    You can apply to be reimbursed for your travel expenses as soon as your return from your trip and have full access to Concur. Once you have completed the IT Security Awareness and Privacy Act trainings in [GSA's Online University (OLU)](https://gsaolu.gsa.gov/), you can apply for access to Concur by completing the [CGE Access Request Form](https://drive.google.com/a/gsa.gov/file/d/0B0Kck5dqF_EbM3ZRaHRqRHFWSzA/view?usp=sharing) and sending it to [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov).
 
-   Once you get access, you can follow [these instructions for how to complete a voucher]({{site.baseurl}}/travel-guide-3-reimbursement). Feel free to book travel office hours [here](https://sites.google.com/a/gsa.gov/tts-office-hours/) any time should you need any assistance.
+   Once you get access, you can follow [these instructions for how to complete a voucher]({{site.baseurl}}/travel-guide-3-reimbursement). Feel free to [book travel office hours here](https://sites.google.com/a/gsa.gov/tts-office-hours/) any time should you need any assistance.
 
 ### What happens if my flight gets cancelled?
 
@@ -45,4 +45,4 @@ If you are traveling to orientation and are worried that you will miss it becaus
 
 While the Talent and Travel Teams won't be available until Monday if your cancellation occurs over the weekend, please feel comfortable rebooking your travel either though the airline or via Ad-Trav, and rest assured that you will be in good hands when you arrive at TTS.
 
-*Got questions? Ask [#travel](https://gsa-tts.slack.com/messages/travel)*, [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov), or book office hours [here](https://sites.google.com/a/gsa.gov/tts-office-hours/)
+*Got questions? Ask [#travel](https://gsa-tts.slack.com/messages/travel)*, [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov), or [book office hours here](https://sites.google.com/a/gsa.gov/tts-office-hours/).

--- a/_pages/travel-leave/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
+++ b/_pages/travel-leave/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
@@ -23,7 +23,7 @@ Your access to the EFT form linked above may be restricted, so you should have r
 
    Email tts-travel@gsa.gov once you've finalized your reservations and they will approve your itinerary. Make sure this is done during business hours-- no later than 3:30 PM ET!
 
-   Until you can get a GSA travel card (read more about this [here]({{site.baseurl}}/first-time-travel-travel-card)), you will unfortunately have to pay for your lodging and all other travel expenses other than air or rail upfront. But with a valid receipt, you will get reimbursed (generally 6-10 business days after expenses are submitted). Just make sure to stay at a hotel with rates under the government maximum (also known as the per diem rate). [You can look up per diem rates here](http://www.gsa.gov/portal/category/100120).
+ Until you can get a GSA travel card (read more about the travel card here]({{site.baseurl}}/first-time-travel-travel-card)), you will unfortunately have to pay for your lodging and all other travel expenses other than air or rail upfront. But with a valid receipt, you will get reimbursed (generally 6-10 business days after expenses are submitted). Just make sure to stay at a hotel with rates under the government maximum (also known as the per diem rate). [You can look up per diem rates here](http://www.gsa.gov/portal/category/100120).
 
 4. **Receive tickets**: E-tickets will be sent to the email address that you provided. Once a reservation is made, you will get a “pending” itinerary, which will be finalized, depending on the airline, no later than 72 hours before departure.
 

--- a/_pages/travel-leave/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
+++ b/_pages/travel-leave/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
@@ -23,7 +23,7 @@ Your access to the EFT form linked above may be restricted, so you should have r
 
    Email tts-travel@gsa.gov once you've finalized your reservations and they will approve your itinerary. Make sure this is done during business hours-- no later than 3:30 PM ET!
 
- Until you can get a GSA travel card (read more about the travel card here]({{site.baseurl}}/first-time-travel-travel-card)), you will unfortunately have to pay for your lodging and all other travel expenses other than air or rail upfront. But with a valid receipt, you will get reimbursed (generally 6-10 business days after expenses are submitted). Just make sure to stay at a hotel with rates under the government maximum (also known as the per diem rate). [You can look up per diem rates here](http://www.gsa.gov/portal/category/100120).
+ Until you can [get a GSA travel card]({{site.baseurl}}/first-time-travel-travel-card), you will unfortunately have to pay for your lodging and all other travel expenses other than air or rail upfront. But with a valid receipt, you will get reimbursed (generally 6-10 business days after expenses are submitted). Just make sure to stay at a hotel with rates under the government maximum (also known as the per diem rate). [You can look up per diem rates here](http://www.gsa.gov/portal/category/100120).
 
 4. **Receive tickets**: E-tickets will be sent to the email address that you provided. Once a reservation is made, you will get a “pending” itinerary, which will be finalized, depending on the airline, no later than 72 hours before departure.
 


### PR DESCRIPTION
As I was reading this, I noticed some potential improvements:

- Uses `html` instead of markdown for emphasis in title to attempt fix output (the `_before_` underscores are on the page)
- Fixes typo
- Adds punctuation to last sentence
- Adds text to "here" links to make more descriptive for accessibility