### PR TITLE
Remove functional leads, update DE&I lead description

### DIFF
--- a/_pages/business-units/18f/chapters/engineering.md
+++ b/_pages/business-units/18f/chapters/engineering.md
@@ -57,7 +57,7 @@ Supervisors are selected through nominations and interviews according to team ne
 
 ### Director
 
-The Director of Engineering is responsible for the Engineering Chapter. The Director represents the chapter on the Senior Management Team of 18F, is responsible for the strategic planning of the chapter including hiring approach, capacity planning, and expanding the impact of the chapter and engineers’ work. The Director guides the work of the Engineering Practices guild (which encompasses backend, frontend, ops, and security) and the diversity, equity, and inclusion (DE&I) leads to ensure alignment with strategy and each other. The Director has as direct reports the Engineering Supervisors, and acts as mentor, coach, and guide to their work. The Director is ultimately responsible for the success of the chapter in the context of the 18F mission and organizational priorities.
+The Director of Engineering is responsible for the Engineering Chapter. The Director represents the chapter on the Senior Management Team of 18F, is responsible for the strategic planning of the chapter including hiring approach, capacity planning, and expanding the impact of the chapter and engineers’ work. The Director guides the work of the Engineering Practices guild (which encompasses backend, frontend, and data) and the diversity, equity, and inclusion (DE&I) leads to ensure alignment with strategy and each other. The Director has as direct reports the Engineering Supervisors, and acts as mentor, coach, and guide to their work. The Director is ultimately responsible for the success of the chapter in the context of the 18F mission and organizational priorities.
 
 The Director was selected through nominations and interviews. While there is no additional compensation for being a director, it’s an opportunity to help make team members’ time at 18F great.
 
@@ -144,4 +144,3 @@ Most of the Engineering team works on a mix of partner agency projects and inter
 Here are some [common tools we use]({{site.baseurl}}/#software-and-tools), how we use them, and how you can get access to them. If you can’t find the information you need in the chart below, get in touch with your design lead; they’ll be able to point you in the right direction.
 
 And one more thing: before you start using any new tool that asks for access to files/browser data, please check the [full list](https://ea.gsa.gov/#!/itstandards) of approved tools. If what you want to use isn’t there, you’ll need to ask [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure) first. New tools often create hard-to-anticipate security problems.
-

--- a/_pages/business-units/18f/chapters/engineering.md
+++ b/_pages/business-units/18f/chapters/engineering.md
@@ -57,13 +57,13 @@ Supervisors are selected through nominations and interviews according to team ne
 
 ### Director
 
-The Director of Engineering is responsible for the Engineering Chapter. The Director represents the chapter on the Senior Management Team of 18F, is responsible for the strategic planning of the chapter including hiring approach, capacity planning, and expanding the impact of the chapter and engineers’ work. The Director guides the work of the Functional Leads (backend, frontend, ops, security, diversity) to ensure alignment with strategy and each other. The Director has as direct reports the Engineering Supervisors, and acts as mentor, coach, and guide to their work. The Director is ultimately responsible for the success of the chapter in the context of the 18F mission and organizational priorities.
+The Director of Engineering is responsible for the Engineering Chapter. The Director represents the chapter on the Senior Management Team of 18F, is responsible for the strategic planning of the chapter including hiring approach, capacity planning, and expanding the impact of the chapter and engineers’ work. The Director guides the work of the Engineering Practices guild (which encompasses backend, frontend, ops, and security) and the diversity, equity, and inclusion (DE&I) leads to ensure alignment with strategy and each other. The Director has as direct reports the Engineering Supervisors, and acts as mentor, coach, and guide to their work. The Director is ultimately responsible for the success of the chapter in the context of the 18F mission and organizational priorities.
 
 The Director was selected through nominations and interviews. While there is no additional compensation for being a director, it’s an opportunity to help make team members’ time at 18F great.
 
-### Functional Leads
+### DE&I Leads
 
-Engineering also has six functional leads: backend, frontend, devops, data, security, and diversity. Collectively and separately they work to make our engineering practice better by improving documentation, project oversight, training, hiring, onboarding, and making us a diverse and inclusive organization.
+<content coming from Alex and Amy>
 
 ### Leadership and facilitators
 

--- a/_pages/business-units/18f/chapters/engineering.md
+++ b/_pages/business-units/18f/chapters/engineering.md
@@ -63,7 +63,7 @@ The Director was selected through nominations and interviews. While there is no 
 
 ### DE&I Leads
 
-<content coming from Alex and Amy>
+The DE&I Leads lead efforts to foster a diverse and inclusive environment for engineers. Their mission includes building a strong culture and setting an inclusive tone even before a new engineer comes on board. Anyone who has issues or concerns related to inclusion or equity in the 18F engineering chapter should feel empowered to reach out to the DE&I Leads. If you have access to the TTS Slack, you can reach us at @amymok and @alexsoble. You can also reach us by email at: amy.mok@gsa.gov and alex.soble@gsa.gov.
 
 ### Leadership and facilitators
 


### PR DESCRIPTION
The functional leads other than DE&I were rolled into the engineering practices guild. This PR removes those from the handbook, and expands a little on the role of DE&I leads.

cc: @alexsoble @amymok