### PR TITLE
install jekyll sitemap to handleredirect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'jekyll'
 gem 'json'
 gem 'hash-joiner'
 gem 'uswds-jekyll', git: 'https://github.com/18F/uswds-jekyll', ref: 'refs/pull/182/head'
+gem "jekyll-sitemap", "~> 1.4"
 
 # workaround to support _pages collection
 # https://github.com/jekyll/jekyll-sass-converter/issues/93#issuecomment-524270623
@@ -14,3 +15,5 @@ gem 'jekyll-sass-converter', git: 'https://github.com/jekyll/jekyll-sass-convert
 group :development do
   gem 'html-proofer'
 end
+
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,8 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 1.8)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.2.0)
@@ -100,6 +102,7 @@ DEPENDENCIES
   html-proofer
   jekyll
   jekyll-sass-converter!
+  jekyll-sitemap (~> 1.4)
   json
   uswds-jekyll!
 

--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,8 @@ collections:
     output: true
     permalink: /:name/
 
+plugins:
+  - jekyll-sitemap
 # Google Analytics & DAP tracking code for handbook
 google_analytics_ua: UA-48605964-19
 dap_agency: GSA


### PR DESCRIPTION
in order to update the search.gov results with the site url migration - adding the jekyll sitemap plugin