### PR TITLE
add url to config to have full url for sitemap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,7 +38,8 @@ collections:
   pages:
     output: true
     permalink: /:name/
-
+    
+url: "https://handbook.tts.gsa.gov"
 plugins:
   - jekyll-sitemap
 # Google Analytics & DAP tracking code for handbook


### PR DESCRIPTION
per [jekyll-sitemap](https://github.com/jekyll/jekyll-sitemap#usage) including the `url` key in the _config.yml should generate a sitemap that has the full url that can be indexed by search.gov