### PR TITLE
Horizon VDI - > Citrix VDI

### DIFF
--- a/_pages/software-tools/vmware-horizon.md
+++ b/_pages/software-tools/vmware-horizon.md
@@ -1,5 +1,6 @@
 ---
 title: VMWare Horizon
+outdated: true
 ---
 
 **VMWare Horizon is being replaced by Citrix VDI.** See [instructions for using Citrix](https://insite.gsa.gov/employee-resources/information-technology/do-it-yourself-self-help/telework-technology/citrix/citrix-and-citrix-workspace).


### PR DESCRIPTION
An email went out on 2/6/20 from GSA IT Alert subject: Retirement of Horizon VDI and moving to new Citrix VDI Environment went out describing that the Citrix VDI environment is finished being configured and they are now preparing to retire and shutodwn the Horizon VDI. 

Due: before 2/21/2020