### PR TITLE
updates to equipment/supply ordering process

### DIFF
--- a/_pages/getting-started/equipment.md
+++ b/_pages/getting-started/equipment.md
@@ -71,16 +71,7 @@ See the [software](../software/) page.
 
 If you are based in an office, you can check out mice, keyboards, and trackpads to assist you in your work. They are already available, so there is no need to make a purchase request. Ask in the Slack channel corresponding to your office.
 
-To get additional peripherals (chargers, dongles, etc.), [open a `Hardware` request](https://gsa.service-now.com/sp/?id=sc_cat_item&sys_id=c73f4b527897a400ce3ddff91a649434). If that link doesn't work, find it through:
-
-1. Visit the [GSA IT Service Portal](https://gsa.service-now.com/)
-1. Click `Service Catalog`
-1. Click `Equipment Services`
-1. Click `Hardware`
-
-Note that, per policy [OAS P 9900.1](https://www.gsa.gov/cdnstatic/OAS_P_9900.1_Government_Furnished_Equipment_for_Use_Outside_GSA_Agency_Worksites_%28Signed_4-8-2014%29_%28Rev._11-19-2015%29.pdf#page=2),
-
-> GSA will not provide a government furnished print output device, GSA furnished internet connection, or other equipment or services, beyond the laptop and headset...for use by employees working at locations other than GSA office workspaces.
+To get replacement/additional peripherals (chargers, dongles, etc.), open a [micropurchase request]({{site.baseurl}}/purchase-requests/).
 
 ## Equipment to accommodate disability
 

--- a/_pages/how-we-work/purchase-requests.md
+++ b/_pages/how-we-work/purchase-requests.md
@@ -30,7 +30,9 @@ If you want TTS/18F branding, you must purchase your own business cards. However
 
 ## Office supplies
 
-Anyone working in an 18F office may request a purchase of office supplies by filling out the [micropurchase request form](https://docs.google.com/forms/d/e/1FAIpQLSd-GoOE9xWWfJvdZNRP3SE7mj5ysI_RfM8brxdG8YpyJV9yKA/viewform). Once the request is placed, the designated TTS Ops team member will determine whether or not to recommend your request for approval by the TTS Director of Operations.
+1. If you have access to a GSA office, check the supply rooms for what you need.
+1. If not available, fill out the [micropurchase request form](https://docs.google.com/forms/d/e/1FAIpQLSd-GoOE9xWWfJvdZNRP3SE7mj5ysI_RfM8brxdG8YpyJV9yKA/viewform).
+1. The designated TTS Ops team member will determine whether or not to recommend your request for approval by the TTS Director of Operations.
 
 ## Domain renewals
 

--- a/_pages/how-we-work/purchase-requests.md
+++ b/_pages/how-we-work/purchase-requests.md
@@ -30,14 +30,7 @@ If you want TTS/18F branding, you must purchase your own business cards. However
 
 ## Office supplies
 
-Anyone working in an 18F office may request a purchase of office supplies by filling out the [micropurchase request form](https://docs.google.com/forms/d/e/1FAIpQLSd-GoOE9xWWfJvdZNRP3SE7mj5ysI_RfM8brxdG8YpyJV9yKA/viewform). If you have questions about office supplies, the TTS Ops team points of contact (POC) are:
-
-- Chicago - Ethan Heppner
-- DC - Matt Spencer
-- New York - Ethan Heppner
-- San Francisco - Ethan Heppner
-
-Once the request is placed, the designated TTS Ops team member will determine whether or not to recommend your request for approval by the TTS Director of Operations.
+Anyone working in an 18F office may request a purchase of office supplies by filling out the [micropurchase request form](https://docs.google.com/forms/d/e/1FAIpQLSd-GoOE9xWWfJvdZNRP3SE7mj5ysI_RfM8brxdG8YpyJV9yKA/viewform). Once the request is placed, the designated TTS Ops team member will determine whether or not to recommend your request for approval by the TTS Director of Operations.
 
 ## Domain renewals
 
@@ -72,16 +65,6 @@ Please follow the recommended steps below when ordering services under $10,000:
    - You need to avoid scope creep (adding extra work to the original agreement) that would go over the threshold.
    - If you need any assistance with negotiations, please contact the TTS Micro-Purchase PM and the OA Director.
 6. Once the quote is received, the Micropurchase PM and OA Director will review the quote and ask for more quotes, clarifications, or proceed with the purchase.
-
-**Who to contact about purchasing services**
-
-**TTS Micro-Purchase Project Manager:** Melanie Leopold [melanie.leopold@gsa.gov](mailto:melanie.leopold@gsa.gov)
-
-Slack: @melanie
-
-**TTS Office of Acquisition Director:** Esther Praske [esther.praske@gsa.gov](mailto:tts-purchasers@gsa.gov)
-
-Or find us in Slack: [#tts-oa](https://gsa-tts.slack.com/messages/tts-oa/).
 
 ## Behind the scenes
 
@@ -123,4 +106,4 @@ For issues related to automated logs not showing up as expected, reach out to GS
 
 ## Questions
 
-Any questions? Email [tts-purchasers@gsa.gov](mailto:tts-purchasers@gsa.gov) or [book office hours](https://sites.google.com/a/gsa.gov/tts-office-hours/).
+Any questions? [#micropurchase](https://gsa-tts.slack.com/messages/micropurchase/), email [tts-purchasers@gsa.gov](mailto:tts-purchasers@gsa.gov), or [book office hours](https://sites.google.com/a/gsa.gov/tts-office-hours/).


### PR DESCRIPTION
- Take names out of the Handbook, as they should go through the process rather than reaching out directly
- Encourage use of the supply rooms for office supplies, per [suggestion in Slack](https://gsa-tts.slack.com/archives/C150XFETD/p1581369637001700?thread_ts=1581369445.000400&cid=C150XFETD)
- Submit micropurchase requests for peripherals rather than going through GSA IT, per conversations with them—closes https://github.com/18F/tts-tech-portfolio/issues/247