### PR TITLE
restart server when _config.yml is changed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,6 @@ WORKDIR /app
 COPY Gemfile* ./
 RUN bundle install
 
-CMD bundle exec jekyll serve --host 0.0.0.0 --incremental
+CMD bundle exec \
+  rerun --pattern _config.yml -- \
+  jekyll serve --host 0.0.0.0 --incremental

--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ gem 'jekyll-sitemap'
 
 group :development do
   gem 'html-proofer'
+  gem 'rerun'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,8 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rerun (0.13.0)
+      listen (~> 3.0)
     rouge (3.16.0)
     safe_yaml (1.0.5)
     sassc (2.2.1)
@@ -101,6 +103,7 @@ DEPENDENCIES
   jekyll!
   jekyll-sitemap
   json
+  rerun
   uswds-jekyll!
 
 RUBY VERSION

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3"
 services:
   web:
     build: .
+    tty: true
     ports:
       - "4000:4000"
     volumes:


### PR DESCRIPTION
Noticed this issue watching someone else edit: edits to `_config.yml` don't get picked up by `jekyll serve`, which is confusing to users. This change makes the server restart on `_config.yml` changes automatically.