### PR TITLE
add policy around name-brand peripherals

### DIFF
--- a/_pages/getting-started/equipment.md
+++ b/_pages/getting-started/equipment.md
@@ -73,6 +73,8 @@ If you are based in an office, you can check out mice, keyboards, and trackpads 
 
 To get replacement/additional peripherals (chargers, dongles, etc.), open a [micropurchase request]({{site.baseurl}}/purchase-requests/).
 
+**TTS policy: Anything connected to a GSA device must be a name brand.** If you're not sure, ask [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure).
+
 ## Equipment to accommodate disability
 
 GSA provides equipment to accommodate an injury or disability under these conditions:


### PR DESCRIPTION
Checking with Pranjali if GSA has a policy around this already, but putting this in as a placeholder in the meantime.