### PR TITLE
change vendor ID instructions to be a link instead of an email

### DIFF
--- a/_pages/travel-leave/travel-and-leave-policies/first-time-travel-get-in-concur.md
+++ b/_pages/travel-leave/travel-and-leave-policies/first-time-travel-get-in-concur.md
@@ -2,19 +2,18 @@
 title: Get access to Concur
 ---
 
-[TTS Travel Guide Table of Contents]({{site.baseurl}}/travel-guide-table-of-contents)
+[TTS Travel Guide Table of Contents]({{site.baseurl}}/travel-guide-table-of-contents) <br />
 [Next to Travel Card]({{site.baseurl}}/first-time-travel-travel-card)
 
 There are four required steps to gain access to [Concur](http://travel.gsa.gov/).
 
-1. To access [Concur](http://travel.gsa.gov/), you’ll first need to get a **“travel vendor ID”**. The easiest way to do this is to email [kc-travel.finance@gsa.gov](mailto:kc-travel.finance@gsa.gov). Your email should request your vendor ID and state that payroll banking information can be used to generate the ID.  We've drafted an [email template for you here](mailto:kc-travel.finance@gsa.gov?subject=Request%20for%20Travel%20Vendor%20ID&body=Hi.%20I%20will%20be%20traveling%20for%20work%20and%20will%20need%20a%20travel%20vendor%20ID.%20Can%20you%20please%20assign%20one%20to%20me?%20My%20payroll%20banking%20information%20can%20be%20used%20to%20generate%20this%20ID.). Just click, personalize, and send.
+1. To access [Concur](http://travel.gsa.gov/), you will need a **“travel vendor ID”**. Use the [Vendor Request Management site](https://finance.ocfo.gsa.gov/VendorRequest/co/Stepd.aspx) to request a new vendor ID.
   * In case the travel finance team is unable to locate your payroll banking information, they may request that you complete [the EFT form](https://drive.google.com/a/gsa.gov/file/d/0B0Kck5dqF_Ebb0FFZ29RR0JmVVk/view?usp=sharing) and will provide instructions on how you can send this information to them securely.
-  * While you wait for the ID number to be generated (which can take up to 1 business day), you may get started on [applying for the GSA travel card]({{site.baseurl}}/first-time-travel-travel-card).
+  * While you wait for the ID number to be generated and sent to you via email (which can take up to 1 business day), you may get started on [applying for the GSA travel card]({{site.baseurl}}/first-time-travel-travel-card).
 
 2. Take the 2019 GSA Mandatory Cyber Security and Privacy Training in [OLU](https://gsaolu.gsa.gov). This can take several hours. Follow the instructions [here]({{site.baseurl}}/olu/#help-with-olu) if you need help.
 
-3. Complete the [CGE Access Request Form](https://drive.google.com/a/gsa.gov/file/d/0B0Kck5dqF_EbM3ZRaHRqRHFWSzA/view?usp=sharing), minus the EFT enrollment form. Either an electronic or ink signature is fine. Don't forget to get your supervisor's signature as well!
-
+3. Complete the [CGE Access Request Form](https://drive.google.com/a/gsa.gov/file/d/0B0Kck5dqF_EbM3ZRaHRqRHFWSzA/view?usp=sharing), minus the EFT enrollment form. Either an electronic or ink signature is fine. Don't forget to get your supervisor's signature as well!  
 *_Not sure about a particular field? Get help by reading the_ [_FAQ below_](#frequently-asked-questions)
 
 4. Email completed CGE form to [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov). _Do not email it to cge-access-requests@gsa.gov,_ as the form specifies. Only email it to tts-travel@gsa.gov. Your account will be set up before [the next travel office hours](https://sites.google.com/a/gsa.gov/tts-office-hours/), which you can also book any time if you have questions.


### PR DESCRIPTION
As part of orientation, I followed the steps to get into Concur for travel, including requesting a travel vendor ID via email.

I heard back from kc-travel.finance@gsa.gov via eric.eilers@gsa.gov that I should use the Vendor Request Management site (https://finance.ocfo.gsa.gov/VendorRequest/co/Stepd.aspx) which "allows you to request a new vendor code or enter your individual banking information. This information is automatically sent to the vendor mailbox for processing. This site is within the GSA firewall so can only be used by GSA employees."

I confirmed with Eric that this is the case for all new employees rather than sending an email:
"Good Morning Julie,
Yes. new employees should go directly to the Vendor Request Management site. Other inquiries can be sent to this mailbox.
Thank you."

I updated the instructions. I'm not sure why private-eye isn't showing the link I added with a padlock. 