### PR TITLE
remove the step of filing a GitHub issue for security incidents

### DIFF
--- a/_pages/policies/tech-policies/responding-to-public-disclosure-vulnerabilities.md
+++ b/_pages/policies/tech-policies/responding-to-public-disclosure-vulnerabilities.md
@@ -3,46 +3,43 @@ title: Public disclosures of vulnerabilities
 ---
 
 When someone in the public alerts you to a potential vulnerability in our systems, you need to act quickly. There are four steps in this process:
-1. [Triage the vulnerability](#triage-the-vulnerability)
-2. [File an issue](#file-an-issue)
-3. [Respond to reporter](#reply-to-the-reporter)
-4. [Remediate](#remediate)
 
+1. [Triage the vulnerability](#triage-the-vulnerability)
+1. [File an issue](#file-an-issue)
+1. [Respond to reporter](#reply-to-the-reporter)
+1. [Remediate](#remediate)
 
 ## Triage the vulnerability
 
-In order to respond quickly to reports submitted by the public (aka reporter), the TTS Tech Portfolio will monitor incoming reports and initiate response accordingly. This role has been designated **first responder** and monitors reports received from the public via emails to [`tts-vulnerability-reports@gsa.gov`](mailto:tts-vulnerability-reports@gsa.gov),  [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform) or the Vulnerability Disclosure platform. 
+In order to respond quickly to reports submitted by the public (aka reporter), the TTS Tech Portfolio will monitor incoming reports and initiate response accordingly. This role has been designated **first responder** and monitors reports received from the public via emails to [`tts-vulnerability-reports@gsa.gov`](mailto:tts-vulnerability-reports@gsa.gov), [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform) or the Vulnerability Disclosure platform.
 
 The first responder will then provide a _brief_ overview of the issue in [#vuln-disclosure](https://gsa-tts.slack.com/messages/vuln-disclosure/) and @ (mention) all appropriate personnel. At this point, potential impact must be determined quickly to ensure appropriate steps are taken to remediate the reported issue.
 
-Scores of `low`, `medium`, `high` and `critical` are based on the [CVSS 3.0](https://www.first.org/cvss/specification-document) scoring. 
+Scores of `low`, `medium`, `high` and `critical` are based on the [CVSS 3.0](https://www.first.org/cvss/specification-document) scoring.
 
 Each metric above receives a single score on potential impact from the following list:
 
-| Rating	| CVSS Score|
-| ---	| ---|
-None |	0.0 |
-Low |	0.1 - 3.9 |
-Medium |	4.0 - 6.9 |
-High |	7.0 - 8.9 |
-Critical |	9.0 - 10.0 |
-
+| Rating   | CVSS Score |
+| -------- | ---------- |
+| None     | 0.0        |
+| Low      | 0.1 - 3.9  |
+| Medium   | 4.0 - 6.9  |
+| High     | 7.0 - 8.9  |
+| Critical | 9.0 - 10.0 |
 
 A score of `none` means that the report falls outside of scope, or is negligible, or doesn't contain enough information. If the report is `none`, [jump to the response step](#reply-to-the-reporter).
 
-
 ## Determine an incident
-In the case of an **incident**, the responder has determined the vulnerability has _already_ impacted system confidentiality, integrity, or availability. The responder immediately follows the [security incident process](../security-incidents/).
 
+In the case of an **incident**, the responder has determined the vulnerability has _already_ impacted system confidentiality, integrity, or availability. The responder immediately follows the [security incident process](../security-incidents/).
 
 If the first responder is unable to make a determination of risk severity, the responder should immediately post in the [#incident-response](https://gsa-tts.slack.com/messages/incident-response) Slack channel and seek counsel from other responders, as well as @-ing the lead of the affected product or service.
 
 ## File an issue
 
-For vulnerabilities categorized as **low**, an Issue should be created in the corresponding GitHub repo or project management tool for the affected system by the product or service team.  
+For vulnerabilities categorized as **low**, an Issue should be created in the corresponding GitHub repo or project management tool for the affected system by the product or service team.
 
-For vulnerabilities of **medium** or **high** issue must be filed in the private repository. If the issue is also an **incident**, it must be filed [security incident repository](https://github.com/18F/security-incidents/issues). 
-
+For vulnerabilities of **medium** or **high** issue must be filed in the private repository. If the issue is also an **incident**, it must be filed [security incident repository](https://github.com/18F/security-incidents/issues).
 
 The first responder is responsible for following up GitHub issue to assure they are satisfied that the issue has been resolved (whether remediated or marked `wont fix` or `false positive`).
 
@@ -54,59 +51,46 @@ Regardless of where the issue is filed, the first responder should advise the Fi
 
 If the report impact is `none`, send the appropriate message:
 
-* **Not in scope:** "Thanks for contacting us. However, this report falls outside of our scope as described at https://18f.gsa.gov/vulnerability-disclosure-policy/. [_Add additional details as helpful._]"
-* **No impact:** "Thanks for sending us this report. However, we have determined that the impact of this issue is not significant. Please feel free to provide additional information that indicates the issue is of higher severity, and we'll be happy to re-evaluate it."
-* **Not enough information:** "Thanks for sending us this report. However, it does not contain enough information for us to reproduce the issue and evaluate its severity. If you can send us additional information, we'll be happy to evaluate the issue."
+- **Not in scope:** "Thanks for contacting us. However, this report falls outside of our scope as described at https://18f.gsa.gov/vulnerability-disclosure-policy/. [_Add additional details as helpful._]"
+- **No impact:** "Thanks for sending us this report. However, we have determined that the impact of this issue is not significant. Please feel free to provide additional information that indicates the issue is of higher severity, and we'll be happy to re-evaluate it."
+- **Not enough information:** "Thanks for sending us this report. However, it does not contain enough information for us to reproduce the issue and evaluate its severity. If you can send us additional information, we'll be happy to evaluate the issue."
 
 Otherwise, after filing the issue as described above:
 
 1. Quickly send an acknowledgement.
-2. Loop in any relevant program staff on the acknowledgement response, so they have a direct line of communication.
-
+1. Loop in any relevant program staff on the acknowledgement response, so they have a direct line of communication.
 
 The acknowledgement text could be something like:
 
 > Thanks for sending us this report. We're taking action internally to evaluate and reproduce this report. I'm connecting you with the relevant technical staff so that you can communicate directly as needed.
-> 
+>
 > As a reminder, our policy, which can be read at https://18f.gsa.gov/vulnerability-disclosure-policy/, asks for 90 days from the date you sent your report before you disclose this report publicly.
 
-Remember to **CC this email** to any relevant program staff or TTS Tech Portfolio leads. 
-
+Remember to **CC this email** to any relevant program staff or TTS Tech Portfolio leads.
 
 ## Remediate
 
 Valid vulnerabilities need to be resolved in the following timeline:
 
-| Risk Value      | Corrective Action Deadline                                                                                                                              |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Critical        | For Internet-accessible IP addresses: within 15 calendar days of initial detection. 
-|  |For all other assets: within 30 calendar days of initial detection. |
-| High            | Within 30 calendar days of initial detection                                                                                                            |
-| Moderate/Medium | Within 90 days of initial detection                                                                                                                     |
-| Low             | No specific deadline unless defined by the GSA OCISO                                                                                                    |
+| Risk Value      | Corrective Action Deadline                                                          |
+| --------------- | ----------------------------------------------------------------------------------- |
+| Critical        | For Internet-accessible IP addresses: within 15 calendar days of initial detection. |
+|                 | For all other assets: within 30 calendar days of initial detection.                 |
+| High            | Within 30 calendar days of initial detection                                        |
+| Moderate/Medium | Within 90 days of initial detection                                                 |
+| Low             | No specific deadline unless defined by the GSA OCISO                                |
 
 Source: [GSA Vulnerability Management Process guide](https://insite.gsa.gov/topics/information-technology/security-and-privacy/it-security/it-security-procedural-guides), Appendix B. These values will also appear in the [RA-5(d)](https://nvd.nist.gov/800-53/Rev4/control/RA-5#Rev4Statements) control of your System Security Plan (SSP).
 
 ### Reports for non-TTS Systems
 
-If you know the alert applies to a system TTS doesn't have responsibility over, please either submit the report to [US-CERT](https://vulcoord.cert.org/VulReport/) if there is helpful context you can add to it, or direct the public contact to submit the report to [US-CERT](https://vulcoord.cert.org/VulReport/) themselves. 
+If you know the alert applies to a system TTS doesn't have responsibility over, please either submit the report to [US-CERT](https://vulcoord.cert.org/VulReport/) if there is helpful context you can add to it, or direct the public contact to submit the report to [US-CERT](https://vulcoord.cert.org/VulReport/) themselves.
 
-### For systems owned by partner agencies or 3rd-party vendors
-
-Notifications to partner agencies  should do the following:
+Notifications to partner agencies should do the following:
 
 1. Find a POC
-
-   i. Using the list of [security contacts](https://github.com/GSA/data/blob/master/dotgov-domains/current-full.csv)
-  
-   ii. Reach out through professional network
-1. Describe the potential harm
-1. Recommend a course of action
-
-
-### For systems owned by partner agencies or 3rd-party vendors
-Notifications to vendors should do the following:
-
-1. Look for security@[vendor.com] or VDP form
+   1. Look for security@[vendor.com] or VDP form
+   1. Using the list of [security contacts](https://github.com/GSA/data/blob/master/dotgov-domains/current-full.csv)
+   1. Reach out through professional network
 1. Describe the potential harm
 1. Recommend a course of action

--- a/_pages/policies/tech-policies/responding-to-public-disclosure-vulnerabilities.md
+++ b/_pages/policies/tech-policies/responding-to-public-disclosure-vulnerabilities.md
@@ -5,7 +5,6 @@ title: Public disclosures of vulnerabilities
 When someone in the public alerts you to a potential vulnerability in our systems, you need to act quickly. There are four steps in this process:
 
 1. [Triage the vulnerability](#triage-the-vulnerability)
-1. [File an issue](#file-an-issue)
 1. [Respond to reporter](#reply-to-the-reporter)
 1. [Remediate](#remediate)
 
@@ -35,18 +34,6 @@ In the case of an **incident**, the responder has determined the vulnerability h
 
 If the first responder is unable to make a determination of risk severity, the responder should immediately post in the [#incident-response](https://gsa-tts.slack.com/messages/incident-response) Slack channel and seek counsel from other responders, as well as @-ing the lead of the affected product or service.
 
-## File an issue
-
-For vulnerabilities categorized as **low**, an Issue should be created in the corresponding GitHub repo or project management tool for the affected system by the product or service team.
-
-For vulnerabilities of **medium** or **high** issue must be filed in the private repository. If the issue is also an **incident**, it must be filed [security incident repository](https://github.com/18F/security-incidents/issues).
-
-The first responder is responsible for following up GitHub issue to assure they are satisfied that the issue has been resolved (whether remediated or marked `wont fix` or `false positive`).
-
-The [TTS Tech Portfolio](https://docs.google.com/presentation/d/10Qfq1AaQh74q76Pik99kQedvshLBo0qLWZGsH-nrV0w/edit#slide=id.g70cae5b8a6_0_16) should be included in all issues for tracking purposes.
-
-Regardless of where the issue is filed, the first responder should advise the First Responder/TTS Tech Portfolio on next steps.
-
 ## Reply to the reporter
 
 If the report impact is `none`, send the appropriate message:
@@ -55,7 +42,7 @@ If the report impact is `none`, send the appropriate message:
 - **No impact:** "Thanks for sending us this report. However, we have determined that the impact of this issue is not significant. Please feel free to provide additional information that indicates the issue is of higher severity, and we'll be happy to re-evaluate it."
 - **Not enough information:** "Thanks for sending us this report. However, it does not contain enough information for us to reproduce the issue and evaluate its severity. If you can send us additional information, we'll be happy to evaluate the issue."
 
-Otherwise, after filing the issue as described above:
+Then:
 
 1. Quickly send an acknowledgement.
 1. Loop in any relevant program staff on the acknowledgement response, so they have a direct line of communication.

--- a/_pages/policies/tech-policies/security-incidents.md
+++ b/_pages/policies/tech-policies/security-incidents.md
@@ -8,7 +8,7 @@ Something went "bump" in the night (or the day)? This document explains what to 
 
 An “incident” or “information security incident” is a violation - or an imminent threat of violation - of information security or privacy policies, acceptable use policies, or standard security practices.
 
-If you detect any unusual or suspicious activity on your computer, DO NOT turn off your computer. By turning off the computer, valuable evidence may be lost. If you observe or suspect prohibited material or programs on GSA systems, or inappropriate use of GSA systems, report it immediately to the [GSA IT Service Desk] <a href="mailto:itservicedesk@gsa.gov?subject=Security Incident">
+If you detect any unusual or suspicious activity on your computer, DO NOT turn off your computer. By turning off the computer, valuable evidence may be lost. If you observe or suspect prohibited material or programs on GSA systems, or inappropriate use of GSA systems, report it immediately to the <a href="mailto:itservicedesk@gsa.gov?subject=Security Incident">GSA IT Service Desk</a>.
 
 It is critical that you notify GSA IT within 1 hour of suspected incident and provide all available information to assist the response team with triage. If email is unavailable, [contact them another way](https://insite.gsa.gov/employee-resources/information-technology).
 
@@ -94,8 +94,7 @@ The soundness/fitness of purpose of our systems or information. So if a backup w
 
 - Incident? Report in the [#incident-response](https://gsa-tts.slack.com/messages/incident-response) Slack channel
 - Questions? Ask in the [#g-security-compliance](https://gsa-tts.slack.com/messages/g-security-compliance) Slack channel
-- You can use this link to quickly
-  <a href="mailto:itservicedesk@gsa.gov?subject=Incident:&cc=gsa-ir@gsa.gov;devops@gsa.gov"> send an email to IT Service Desk, GSA IR Team & TTS Tech Portfolio </a> at the same time.
+- You can use this link to <a href="mailto:itservicedesk@gsa.gov?subject=Incident:&cc=gsa-ir@gsa.gov;devops@gsa.gov">quickly send an email to IT Service Desk, GSA IR Team & TTS Tech Portfolio</a> at the same time.
 - cloud.gov: [cloud.gov support team](mailto:cloud-gov-support@gsa.gov) or [#cg-incidents](https://gsa-tts.slack.com/messages/incident-response) Slack channel
 - cloud.gov: [#login-incidents](https://gsa-tts.slack.com/messages/incident-response) Slack channel
 - Need to find the Information System Security Officer (ISSO) or Information System Security Manager (ISSM) for a specific system? See the [directory of contacts for GSA systems](https://ea.gsa.gov/#!/FISMA_POC). (You'll need to be on the GSA network or VPN to access the directory.)

--- a/_pages/policies/tech-policies/security-incidents.md
+++ b/_pages/policies/tech-policies/security-incidents.md
@@ -12,7 +12,7 @@ If you detect any unusual or suspicious activity on your computer, DO NOT turn o
 
 It is critical that you notify GSA IT within 1 hour of suspected incident and provide all available information to assist the response team with triage. If email is unavailable, [contact them another way](https://insite.gsa.gov/employee-resources/information-technology).
 
-Potentially sensitive data must never be shared in Slack, GitHub, or transmitted via email. Include the hyperlink to the [GSA Google Drive](#setting-up-my-drive-for-sensitive-information-sharing) folder in the top summary of the GitHub Issue. At this time, GSA Google Drive is the only approved method of secure data transmission during an active incident
+Potentially sensitive data must never be shared in Slack, GitHub, or transmitted via email. At this time, GSA Google Drive is the only approved method of secure data transmission during an active incident.
 
 If **_classified information_** is part of the incident, do not attach the information to your report. Wait for instructions from the GSA Incident Response (IR) team. If you do not receive a timely acknowledgement of your report, you can phone the IR team via the numbers listed in Section 3.1.1 of the [GSA IT Security Procedural Guide](https://insite.gsa.gov/portal/getMediaData?mediaId=558637).
 
@@ -40,8 +40,7 @@ To report a security incident, follow _all_ of the steps below:
 Please note that incidents need to be reported within one hour of being identified. This isn't "within an hour of happening" but "within one hour of you becoming aware of the incident." The idea is to make sure we're promptly looping in the right people. So, as soon as you're aware of a problem, follow the above steps.
 
 1. Send an email to itservicedesk@gsa.gov, gsa-ir@gsa.gov, and devops@gsa.gov within 1 hour of identifying an incident. Please include _Security Incident_ in the subject line, along with a brief description of the incident (Ex. security token committed to repo).
-   - When emailing GSA's Incident Response (IR) team, please include as many details as possible, including relevant URLs, repos, and a link to related GitHub issue (if applicable).
-1. Open a [GitHub issue in the security-incidents repository](https://github.com/18F/security-incidents/issues/new), tracking the status of these steps. This will automatically populate the [#incident-response](https://gsa-tts.slack.com/messages/incident-response) Slack channel that is monitored by the TTS Tech Portfolio.
+   - Include as many details as possible, including relevant URLs (like repositories).
    - Do not delete any potential evidence or modify the evidence without instruction from the GSA's Incident Response (IR) team.
 1. Check the system's specific Incident Response Plan
    - For [cloud.gov](https://cloud.gov/) platform operations/security, start [following the additional checklist here](https://cloud.gov/docs/ops/security-ir-checklist/).

--- a/_pages/policies/tech-policies/security-incidents.md
+++ b/_pages/policies/tech-policies/security-incidents.md
@@ -6,23 +6,22 @@ Something went "bump" in the night (or the day)? This document explains what to 
 
 ## You must report IT security incidents or suspicious activity
 
-An “incident” or “information security incident” is a violation - or an imminent threat of violation - of information security or privacy policies, acceptable use policies, or standard security practices.  
+An “incident” or “information security incident” is a violation - or an imminent threat of violation - of information security or privacy policies, acceptable use policies, or standard security practices.
 
-If you detect any unusual or suspicious activity on your computer, DO NOT turn off your computer. By turning off the computer, valuable evidence may be lost. If you observe or suspect prohibited material or programs on GSA systems, or inappropriate use of GSA systems, report it immediately to the [GSA IT Service Desk] <a href="mailto:itservicedesk@gsa.gov?subject=Security Incident"> 
+If you detect any unusual or suspicious activity on your computer, DO NOT turn off your computer. By turning off the computer, valuable evidence may be lost. If you observe or suspect prohibited material or programs on GSA systems, or inappropriate use of GSA systems, report it immediately to the [GSA IT Service Desk] <a href="mailto:itservicedesk@gsa.gov?subject=Security Incident">
 
+It is critical that you notify GSA IT within 1 hour of suspected incident and provide all available information to assist the response team with triage. If email is unavailable, [contact them another way](https://insite.gsa.gov/employee-resources/information-technology).
 
- It is critical that you notify GSA IT within 1 hour of suspected incident and provide all available information to assist the response team with triage. If email is unavailable, [contact them another way](https://insite.gsa.gov/employee-resources/information-technology). 
+Potentially sensitive data must never be shared in Slack, GitHub, or transmitted via email. Include the hyperlink to the [GSA Google Drive](#setting-up-my-drive-for-sensitive-information-sharing) folder in the top summary of the GitHub Issue. At this time, GSA Google Drive is the only approved method of secure data transmission during an active incident
 
- Potentially sensitive data must never be shared in Slack, GitHub, or transmitted via email. Include the hyperlink to the [GSA Google Drive](#setting-up-my-drive-for-sensitive-information-sharing) folder in the top summary of the GitHub Issue. At this time, GSA Google Drive is the only approved method of secure data transmission during an active incident
- 
- If **_classified information_** is part of the incident, do not attach the information to your report. Wait for instructions from the GSA Incident Response (IR) team. If you do not receive a timely acknowledgement of your report, you can phone the IR team via the numbers listed in Section 3.1.1 of the [GSA IT Security Procedural Guide](https://insite.gsa.gov/portal/getMediaData?mediaId=558637).
+If **_classified information_** is part of the incident, do not attach the information to your report. Wait for instructions from the GSA Incident Response (IR) team. If you do not receive a timely acknowledgement of your report, you can phone the IR team via the numbers listed in Section 3.1.1 of the [GSA IT Security Procedural Guide](https://insite.gsa.gov/portal/getMediaData?mediaId=558637).
 
- Remember: it's totally OK — and encouraged — to fail towards the side of reporting something. Organizations with healthy incident reporting systems see a lot of false alarms, and a lot of low severity reports. This is good, because it indicates that people feel comfortable reporting day-to-day issues. The more we do it, the better we'll get at it. And this is ultimately the goal, because then when something really serious happens, we'll be practiced at handling it smoothly and efficiently.
+Remember: it's totally OK — and encouraged — to fail towards the side of reporting something. Organizations with healthy incident reporting systems see a lot of false alarms, and a lot of low severity reports. This is good, because it indicates that people feel comfortable reporting day-to-day issues. The more we do it, the better we'll get at it. And this is ultimately the goal, because then when something really serious happens, we'll be practiced at handling it smoothly and efficiently.
 
- For questions about GSA’s Incident Response Program, contact the GSA Incident Response (IR) Team at [gsa-ir@gsa.gov](mailto:gsa-ir@gsa.gov).
-
+For questions about GSA’s Incident Response Program, contact the GSA Incident Response (IR) Team at [gsa-ir@gsa.gov](mailto:gsa-ir@gsa.gov).
 
 ## Reporting [Phishing](https://insite.gsa.gov/topics/information-technology/do-it-yourself-self-help/google-g-suite-apps/email-with-gmail/phishing-emails-and-scams?term=phishing)
+
 If you receive a suspicious email, follow these steps:
 
 1. Do not click any links in the email. Do not delete it yet. You may mark it as spam.
@@ -32,54 +31,41 @@ If you receive a suspicious email, follow these steps:
 
 If you also clicked on a link in a phishing email, follow these steps to report to GSA's Incident Response (IR) team:
 
-1. Send an email to  itservicedesk@gsa.gov and devops@gsa.gov. Please include *Security Incident* in the subject line, along with a brief description of the issue (Ex. Clicked on link in phishing email).
+1. Send an email to itservicedesk@gsa.gov and devops@gsa.gov. Please include _Security Incident_ in the subject line, along with a brief description of the issue (Ex. Clicked on link in phishing email).
 
 ## Reporting other incidents
-To report a security incident, follow *all* of the steps below:
 
+To report a security incident, follow _all_ of the steps below:
 
 Please note that incidents need to be reported within one hour of being identified. This isn't "within an hour of happening" but "within one hour of you becoming aware of the incident." The idea is to make sure we're promptly looping in the right people. So, as soon as you're aware of a problem, follow the above steps.
 
-1. Send an email to itservicedesk@gsa.gov, gsa-ir@gsa.gov, and devops@gsa.gov within 1 hour of identifying an incident. Please include *Security Incident* in the subject line, along with a brief description of the incident (Ex. security token committed to repo). 
-    - When emailing GSA's Incident Response (IR) team, please include as many details as possible, including relevant URLs, repos, and a link to related GitHub issue (if applicable). 
-
-
-1. Open a [GitHub issue in the security-incidents repository](https://github.com/18F/security-incidents/issues/new), tracking the status of these steps. This will automatically populate the [#incident-response](https://gsa-tts.slack.com/messages/incident-response) Slack channel that is monitored by the TTS Tech Portfolio. 
-
-       Do not delete any potential evidence or modify the evidence without instruction from the GSA's Incident Response (IR) team.
-
-
+1. Send an email to itservicedesk@gsa.gov, gsa-ir@gsa.gov, and devops@gsa.gov within 1 hour of identifying an incident. Please include _Security Incident_ in the subject line, along with a brief description of the incident (Ex. security token committed to repo).
+   - When emailing GSA's Incident Response (IR) team, please include as many details as possible, including relevant URLs, repos, and a link to related GitHub issue (if applicable).
+1. Open a [GitHub issue in the security-incidents repository](https://github.com/18F/security-incidents/issues/new), tracking the status of these steps. This will automatically populate the [#incident-response](https://gsa-tts.slack.com/messages/incident-response) Slack channel that is monitored by the TTS Tech Portfolio.
+   - Do not delete any potential evidence or modify the evidence without instruction from the GSA's Incident Response (IR) team.
 1. Check the system's specific Incident Response Plan
-    -   For [cloud.gov](https://cloud.gov/) platform operations/security, start [following the additional checklist here](https://cloud.gov/docs/ops/security-ir-checklist/).
-    -  Fo
-
-1. Following notification to GSA, the GSA's Incident Response (IR) team will contact you requesting more information. 
-
-      - Examples of questions that will be asked are
-         1) What systems do these secrets allow access to?
-         2) How long were the secrets available on the exposed system?
-         3) Were these secrets publicly available? If not, how many people had access to the secrets and what were their roles on the project?
-         4) How quickly can/were the secrets rotated?
-         5) Has the message - or file - containing the secrets been deleted (and removed from archive) in the exposed system?
-
-
-
+   - For [cloud.gov](https://cloud.gov/) platform operations/security, start [following the additional checklist here](https://cloud.gov/docs/ops/security-ir-checklist/).
+1. Following notification to GSA, the GSA's Incident Response (IR) team will contact you requesting more information. Example questions that will be asked:
+   1. What systems do these secrets allow access to?
+   2. How long were the secrets available on the exposed system?
+   3. Were these secrets publicly available? If not, how many people had access to the secrets and what were their roles on the project?
+   4. How quickly can/were the secrets rotated?
+   5. Has the message - or file - containing the secrets been deleted (and removed from archive) in the exposed system?
 
 ## What is an incident?
 
-First: it's always OK to err on the side of reporting! [TTS](http://www.gsa.gov/portal/category/25729)'s and GSA's incident response teams are good at their job, and they are totally used to false alarms. You'll never get in trouble for pinging them about something that turns out not to be an issue! Indeed, *you'll never get in trouble for pinging IR at all*. The most effective security early warning system is attentive staff, so report early and report often!
+First: it's always OK to err on the side of reporting! [TTS](http://www.gsa.gov/portal/category/25729)'s and GSA's incident response teams are good at their job, and they are totally used to false alarms. You'll never get in trouble for pinging them about something that turns out not to be an issue! Indeed, _you'll never get in trouble for pinging IR at all_. The most effective security early warning system is attentive staff, so report early and report often!
 
 **What is an incident?** An occurrence that actually or potentially jeopardizes the [confidentiality](#confidentiality), [integrity](#integrity), or [availability](#availability) of an information system or the information the system processes, stores, or transmits or that constitutes a violation or imminent threat of violation of security policies, security procedures, or acceptable use policies.
 
-
 See GSA’s Insite: [Report IT Security Incidents or Suspicious Activity](https://insite.gsa.gov/topics/information-technology/security-and-privacy/it-security/report-it-security-incidents-and-suspicious-activity-immediately) if you need help determining whether something counts as an incident.
-
 
 ## For responders
 
 Responders to an incident (as defined above) are entitled to take steps to remediate the immediate problem without worrying about whether or not the work is billable for up to eight person-hours of work per incident. Fix the problem, and then worry about how we will account for your time.
 
 ### TTS tailored examples of incidents
+
 - Putting sensitive data in a public Slack channel
 - Exposing a secret token in a GitHub repository
 
@@ -88,17 +74,21 @@ Responders to an incident (as defined above) are entitled to take steps to remed
 If an incident involved exposing environment variables or private configuration data, consider [adding a rule](https://github.com/18F/laptop#git-seekret) to the Git Seekrets installation to prevent further incidents across TTS.
 
 ### Setting up My Drive for sensitive information sharing
+
 Ensure you’re creating the folder as part of **My Drive** and not within a pre-existing folder. Use this GSA Google Drive folder for any potentially sensitive data and/or files. Add static files, Google Docs, or Google Sheets as appropriate, and add a comment to any information you think is critical to the investigation.
 
 ## Glossary
 
-### Availability 
+### Availability
+
 Means the availability of the services we provide. If an app goes down or something we expect to be running stops running, those are availability issues. This only refers to production systems (it's fine if your demo app crashes), and only to unexpected downtime. If you decide to shut something down temporarily for maintenance — go for it, not an incident.
 
 ### Confidentiality
+
 think: secrets. Personal information (PII) — names, phone numbers, social security numbers, etc — is one kind of secret, but so are your passwords, service credentials, internal non-public documents, etc. Any time you suspect that confidential information may have been leaked outside TTS, you should open an incident.
 
-- ### Integrity
+### Integrity
+
 The soundness/fitness of purpose of our systems or information. So if a backup was lost, or an app stopped logging for a while, or some documents got deleted, those are integrity issues. Sometimes these can indicate deeper incidents (like an attacker deleting logs to cover their tracks), so it's important to report these.
 
 ## Contacts
@@ -106,7 +96,7 @@ The soundness/fitness of purpose of our systems or information. So if a backup w
 - Incident? Report in the [#incident-response](https://gsa-tts.slack.com/messages/incident-response) Slack channel
 - Questions? Ask in the [#g-security-compliance](https://gsa-tts.slack.com/messages/g-security-compliance) Slack channel
 - You can use this link to quickly
- <a href="mailto:itservicedesk@gsa.gov?subject=Incident:&cc=gsa-ir@gsa.gov;devops@gsa.gov">  send an email to IT Service Desk, GSA IR Team & TTS Tech Portfolio </a> at the same time. 
+  <a href="mailto:itservicedesk@gsa.gov?subject=Incident:&cc=gsa-ir@gsa.gov;devops@gsa.gov"> send an email to IT Service Desk, GSA IR Team & TTS Tech Portfolio </a> at the same time.
 - cloud.gov: [cloud.gov support team](mailto:cloud-gov-support@gsa.gov) or [#cg-incidents](https://gsa-tts.slack.com/messages/incident-response) Slack channel
 - cloud.gov: [#login-incidents](https://gsa-tts.slack.com/messages/incident-response) Slack channel
 - Need to find the Information System Security Officer (ISSO) or Information System Security Manager (ISSM) for a specific system? See the [directory of contacts for GSA systems](https://ea.gsa.gov/#!/FISMA_POC). (You'll need to be on the GSA network or VPN to access the directory.)


### PR DESCRIPTION
See second commit; the others are basically formatting fixes. Didn't feel like the GitHub issues were providing much value, and were getting in the way of urgent higher-value steps during an incident.

Pretty sure we had an issue with this idea, but I can't find it.

## Follow-up TODOs

- [ ] Archive [security-incidents](https://github.com/18F/security-incidents) repository