### PR TITLE
Fix sticky subnav overflowing on smaller screens

### DIFF
--- a/_sass/inline-nav.scss
+++ b/_sass/inline-nav.scss
@@ -1,4 +1,16 @@
 .with-inline-navigation {
+  .usa-content h1 {
+    @media screen and (min-width: 895px) {
+      max-width: 66%;
+    }
+  }
+  .usa-content hr {
+    @media screen and (min-width: 895px) {
+      max-width: 66%;
+      margin-left: 0;
+    }
+  }
+
   .usa-layout-docs-main_content {
     position: relative;
   }
@@ -7,6 +19,7 @@
     @media screen and (min-width: 895px) {
       position: absolute;
       right: 0;
+      top: 0;
       height: 100%;
       width: 256px;
     }
@@ -14,7 +27,7 @@
 
   .inline-navigation {
     font-size: 16px;
-    background: none;
+    background: #ffffff;
     padding: 16px;
     position: sticky;
     top: 0;
@@ -23,6 +36,12 @@
     margin: 0 auto 1.4em;
     box-shadow: 0 0 0 2px #fafafa;
     width: 90%;
+
+    @media screen and (min-width: 895px) {
+      top: 10px;
+      max-height: calc(100vh - 20px);
+      overflow-y: auto;
+    }
 
     h1 {
       letter-spacing: 0;


### PR DESCRIPTION
This is my best go at a working sticky subnav that fixes #1702.

**What this changes:**

The subnav is positioned at the top of the main content area, flush with the page's top-level header.  This solves the problem of long subnavs colliding with the footer when the page is scrolled to the bottom.

On screens wider than 895px, the subnav is set to a strict height equal to the height of the viewport and made scrollable. This solves the problem of long inline subnavs overflowing on smaller screens.

Example preview page with long subnav: https://federalist-cf8341ad-ca07-488c-bd96-0738014c79ca.app.cloud.gov/preview/18f/handbook/sticky-in-page-nav-fix/getting-started/

**Known issues:**

* IE >= 11 does not support `position: sticky`. With these changes, a subnav that is taller than the height of the window will require scrolling but will not be sticky. The nav is still functional, but this feels like odd behavior.

* On devices that hide scrollbars (eg, macOS), tall subnavs could be "perfectly cropped" in such a way that there is no indication that the nav is scrollable and links would effectively be hidden from users.