### PR TITLE
Update tock.md

### DIFF
--- a/_pages/software-tools/tock.md
+++ b/_pages/software-tools/tock.md
@@ -59,7 +59,7 @@ Account managers can request the creation of a project in [#tock](https://gsa-tt
 You **must** bill for the below activities because these are direct costs. This means they are directly bringing value to the partner agency you are working for. We have a legal obligation to bill for them. They include:
 
 - Work that enables project delivery, such as:
-    - Any activity that develops skills or knowledge used in project work
+    - Any activity that develops skills or knowledge necessary to perform work on an assigned project
         - Examples: guild meetings, guild work, working groups and communities, project related skill development like reading, studying, online searches, or fixing an issue on your project - basically if it applies to your project's work you should bill it
     - 1:1 with supervisor/facilitator (both individual and supervisor/facilitator should bill to the project)
     - Critique groups


### PR DESCRIPTION
Updating tock per OGC response 6/17 to reflect:
 For "[a]ny activity that develops skills or knowledge used in project work", you should tweak the language to more clearly state that the training ties into developing skills needed to complete a project. Generally, indirect costs (such as training) need to "bear a significant relationship to the service or work performed or the materials furnished"  56 Comp. Gen. 275 (1977) in order for us to seek reimbursement. The request is to change that language to better reflect that significant relationship. OCG edit: "Any activity that develops skills or knowledge necessary to perform work on an employee's assigned project"