### PR TITLE
clarify that only GitHub admins can transfer repositories

### DIFF
--- a/_pages/software-tools/github.md
+++ b/_pages/software-tools/github.md
@@ -64,8 +64,8 @@ Go to the [18F people page](https://github.com/orgs/18F/people). Click where it 
 
 - **Ask TTS Tech Portfolio before deleting repositories.** As a government team, we can’t delete repositories without TTS Tech Portfolio first reviewing them for information that they may need to retain/archive (including issues, pull request comments, commit history, and other information). If you want to delete a repository, go to [#admins-github](https://gsa-tts.slack.com/messages/admins-github/) and explain what you'd like to do and why, and wait for approval before deleting it.
 
-- **You do not need approval to transfer a repository.** In some cases, it may make sense to transfer a repository to a client. The person performing the transfer will need to be a member of both organizations. After transferring the repository to the client's organization, create a fork of it in the 18F organization. This is so that:
-  - We have a record of the repository in our GitHub organization
+- **You are welcome to [transfer repositories](https://docs.github.com/en/github/administering-a-repository/transferring-a-repository#transferring-a-repository-owned-by-your-organization) to partner agencies.** [#admins-github](https://gsa-tts.slack.com/messages/admins-github) will need to do it for you, so ask there. After transferring the repository to the client's organization, create a fork of it in [on of our organizations](#organizations). This is so that:
+  - We have a record of the repository
   - We have a copy of the code, should the decide to delete the transferred repository, make it private, etc.
 
 ## How-to

--- a/_pages/software-tools/github.md
+++ b/_pages/software-tools/github.md
@@ -64,7 +64,7 @@ Go to the [18F people page](https://github.com/orgs/18F/people). Click where it 
 
 - **Ask TTS Tech Portfolio before deleting repositories.** As a government team, we can’t delete repositories without TTS Tech Portfolio first reviewing them for information that they may need to retain/archive (including issues, pull request comments, commit history, and other information). If you want to delete a repository, go to [#admins-github](https://gsa-tts.slack.com/messages/admins-github/) and explain what you'd like to do and why, and wait for approval before deleting it.
 
-- **You are welcome to [transfer repositories](https://docs.github.com/en/github/administering-a-repository/transferring-a-repository#transferring-a-repository-owned-by-your-organization) to partner agencies.** [#admins-github](https://gsa-tts.slack.com/messages/admins-github) will need to do it for you, so ask there. After transferring the repository to the client's organization, create a fork of it in [on of our organizations](#organizations). This is so that:
+- **You are welcome to [transfer repositories](https://docs.github.com/en/github/administering-a-repository/transferring-a-repository#transferring-a-repository-owned-by-your-organization) to partner agencies.** [#admins-github](https://gsa-tts.slack.com/messages/admins-github) will need to do it for you, so ask there. After transferring the repository to the client's organization, create a fork of it in [one of our organizations](#organizations). This is so that:
   - We have a record of the repository
   - We have a copy of the code, should the decide to delete the transferred repository, make it private, etc.
 


### PR DESCRIPTION
Apparently we have this setting disabled, which [I think is a good idea](https://gsa-tts.slack.com/archives/C02KXM98G/p1594761872271800?thread_ts=1594757460.270400&cid=C02KXM98G).

<img width="688" alt="Screen Shot 2020-07-14 at 5 23 34 PM" src="https://user-images.githubusercontent.com/86842/87478256-73e1e700-c5f7-11ea-8e3f-ff1ecb24f75c.png">
