### PR TITLE
upgrade gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
     ethon (0.12.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
-    ffi (1.12.2)
+    ffi (1.13.1)
     forwardable-extended (2.6.0)
     hash-joiner (0.0.7)
       safe_yaml
@@ -31,9 +31,9 @@ GEM
       typhoeus (~> 1.3)
       yell (~> 2.0)
     http_parser.rb (0.6.0)
-    i18n (1.8.2)
+    i18n (1.8.4)
       concurrent-ruby (~> 1.0)
-    jekyll (4.1.0)
+    jekyll (4.1.1)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -56,8 +56,8 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.3.0)
-    kramdown (2.2.1)
+    json (2.3.1)
+    kramdown (2.3.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
@@ -67,11 +67,11 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     mini_portile2 (2.4.0)
-    nokogiri (1.10.9)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.2)
       nokogiri (~> 1.8, >= 1.8.4)
-    parallel (1.19.1)
+    parallel (1.19.2)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     power_assert (1.2.0)
@@ -83,13 +83,13 @@ GEM
     rerun (0.13.0)
       listen (~> 3.0)
     rexml (3.2.4)
-    rouge (3.19.0)
+    rouge (3.21.0)
     safe_yaml (1.0.5)
-    sassc (2.3.0)
+    sassc (2.4.0)
       ffi (~> 1.9)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    test-unit (3.3.5)
+    test-unit (3.3.6)
       power_assert
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
@@ -114,4 +114,4 @@ RUBY VERSION
    ruby 2.7.0p0
 
 BUNDLED WITH
-   2.1.2
+   2.1.4


### PR DESCRIPTION
Closes https://github.com/18F/handbook/pull/2042, since that didn't actually update the `Gemfile.lock`.