### PR TITLE
remove redundant lock icons

### DIFF
--- a/_pages/about-us/diversity.md
+++ b/_pages/about-us/diversity.md
@@ -9,15 +9,15 @@ A diverse organization creates a spectrum of solutions and ideas, and helps us c
 
 The TTS Diversity Guild has collaboratively drafted this handbook page to outline how we approach DEI in TTS. We believe that diversity is vital to a successful organization and that it is crucial to reflect the diversity of the public we serve. We also recognize that [a diverse workforce is not enough](https://www.opm.gov/policy-data-oversight/diversity-and-inclusion/). We are committed to promoting an inclusive environment where all individuals feel like they can bring their whole selves, their uniqueness is valued, and they are an integral part of [TTS’s mission](https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services) to improve the public’s experience with the government.
 
-## Code of Conduct 
+## Code of Conduct
 
 The foundation for the Diversity Guild’s work is based on the [TTS Code of Conduct]({{site.baseurl}}/code-of-conduct/).
- 
+
 We strive to create a community where everyone feels empowered to speak up. However, we recognize that there are always power dynamics at play and that each of us has personal preferences when discussing sensitive information. If you would like to discuss an issue without disclosing your name, [please use this anonymous form](https://docs.google.com/forms/d/1xIaxaHD957MtfDwHy7Ec_Xf4C4VXbOy_bpwWL7f6e94/edit?ts=5d52ff9b).
 
 ## Resources
 
-We actively work to eliminate bigotry and subtle forms of disrespect (e.g. [microaggressions](https://en.wikipedia.org/wiki/Microaggression), microinvalidations,  etc.) from our workplace. We also understand that in order to address [unconscious bias](https://diversity.ucsf.edu/resources/unconscious-bias) you have to start somewhere. Below are resources for anyone to learn more about diversity and inclusion principles and best-practices.
+We actively work to eliminate bigotry and subtle forms of disrespect (e.g. [microaggressions](https://en.wikipedia.org/wiki/Microaggression), microinvalidations, etc.) from our workplace. We also understand that in order to address [unconscious bias](https://diversity.ucsf.edu/resources/unconscious-bias) you have to start somewhere. Below are resources for anyone to learn more about diversity and inclusion principles and best-practices.
 
 - [18F Inclusive Language Guide](https://content-guide.18f.gov/inclusive-language/) - principles, resources, and suggestions for writing and talking about diverse groups of people.
 - Preference, Tradition, or Requirement? [“Here’s EY’s Simple But Effective Strategy For Increasing Diversity”](https://fortune.com/2017/02/10/ey-simple-effective-diversity-inclusiveness-strategy/) - Is something a preference, tradition, or requirement? This article covers how Ernst and Young used the “PTR” framework to hire a more diverse workforce. It can be used widely to critically assess all aspects of a work culture.
@@ -30,48 +30,50 @@ We actively work to eliminate bigotry and subtle forms of disrespect (e.g. [micr
 We believe there are four sources of inclusiveness at every organization, and we work to align our organization to these principles.
 
 **1. Organizational level: Practices and activities that contribute to, or detract from, an inclusive organization.**
-  -  Formal communications (mission statement, strategy, annual reports, etc.) reflect a commitment to diversity, equity and inclusion.
-  -  Diversity, equity, and inclusion are part of the core values of senior leadership and are treated as priorities.
-  -  There are transparent and equitable processes around interviews, hiring, promotions, salaries, training approvals, and evaluations. Additionally, there are systems in place to regularly re-examine and remove any potential bias in these processes.
-  -  There are clearly communicated ways to support individual employees, including mentorship, development plans, and advancement opportunities.
-  -  There is accountability and action when issues arise. 
+
+- Formal communications (mission statement, strategy, annual reports, etc.) reflect a commitment to diversity, equity and inclusion.
+- Diversity, equity, and inclusion are part of the core values of senior leadership and are treated as priorities.
+- There are transparent and equitable processes around interviews, hiring, promotions, salaries, training approvals, and evaluations. Additionally, there are systems in place to regularly re-examine and remove any potential bias in these processes.
+- There are clearly communicated ways to support individual employees, including mentorship, development plans, and advancement opportunities.
+- There is accountability and action when issues arise.
 
 **2. Management: The support you receive from your managers - this includes program managers, leads, and/or supervisors.**
-  -  Your manager is reliable, ethical, and transparent.
-  -  Your manager includes you in discussions, and you feel like an invaluable member of the team. 
-  -  Your manager models the importance of creating strong, supportive teams.
-  -  Your manager acknowledges the power dynamics that are created with managerial titles does their best to make interactions more fair and balanced.
-  -  Your manager creates an environment that feels safe for you to bring your whole self to work and upholds strong expectations that everyone else does the same.
-  -  Your manager serves as an advocate and supports you in your professional growth. 
-  -  Your manager has challenging conversations when needed, and approaches them with respect and empathy.
-  -  Leveraging Diversity is a new metric for evaluating supervisors across GSA. It will go into effect FY20.
+
+- Your manager is reliable, ethical, and transparent.
+- Your manager includes you in discussions, and you feel like an invaluable member of the team.
+- Your manager models the importance of creating strong, supportive teams.
+- Your manager acknowledges the power dynamics that are created with managerial titles does their best to make interactions more fair and balanced.
+- Your manager creates an environment that feels safe for you to bring your whole self to work and upholds strong expectations that everyone else does the same.
+- Your manager serves as an advocate and supports you in your professional growth.
+- Your manager has challenging conversations when needed, and approaches them with respect and empathy.
+- Leveraging Diversity is a new metric for evaluating supervisors across GSA. It will go into effect FY20.
 
 **3. Work-group level: Day-to-day interpersonal relationships and the team climate.**
-  -  Your coworkers treat you as an insider to decision-making, respect your opinions, value you, and emphasize that you belong on the team.
-  -  Your uniqueness is celebrated, and you do not feel the need to assimilate in order to fit in.
-  -  You are treated as a valued participant to interpersonal and group learning.
+
+- Your coworkers treat you as an insider to decision-making, respect your opinions, value you, and emphasize that you belong on the team.
+- Your uniqueness is celebrated, and you do not feel the need to assimilate in order to fit in.
+- You are treated as a valued participant to interpersonal and group learning.
 
 **4. Individual level: The contributions you make that affect inclusion and awareness of diversity.**
-  -  You share decision-making and power with your colleagues.
-  -  You take the time to build relationships with colleagues on a personal level
-  -  You are mindful of your actions and words and take responsibility for the impact they have on others.
-  -  You put in the work to educate yourself around subjects you are unfamiliar with before asking someone to educate you.
-  -  You acknowledge your privilege and balance listening and supporting colleagues. 
-  -  You are an ally and use your voice to advocate for those who are overlooked or interrupted.  
-  -  You practice empathy and approach situations with curiosity rather than defensiveness — you try to understand where someone else is coming from.
-  -  You recognize that it’s ok to disagree with others, but practice respectful discourse.
-  -  You treat yourself with kindness. Mistakes happen; you apologize and grow from them. 
 
+- You share decision-making and power with your colleagues.
+- You take the time to build relationships with colleagues on a personal level
+- You are mindful of your actions and words and take responsibility for the impact they have on others.
+- You put in the work to educate yourself around subjects you are unfamiliar with before asking someone to educate you.
+- You acknowledge your privilege and balance listening and supporting colleagues.
+- You are an ally and use your voice to advocate for those who are overlooked or interrupted.
+- You practice empathy and approach situations with curiosity rather than defensiveness — you try to understand where someone else is coming from.
+- You recognize that it’s ok to disagree with others, but practice respectful discourse.
+- You treat yourself with kindness. Mistakes happen; you apologize and grow from them.
 
 ## Diversity Guild
 
 The Diversity [Guild]({{site.baseurl}}/working-groups-and-guilds-101/) is a formal, on-going way for employees to share experiences, resources, and learn from one another via weekly meetings and the [#g-diversity](https://gsa-tts.slack.com/messages/g-diversity/)🔒 Slack channel. The Guild is currently led by [Austin Hernandez](https://gsa-tts.slack.com/messages/@austinhernandez)🔒 and [Victoria Wales](https://gsa-tts.slack.com/messages/@v)🔒.
 
-
 ### How to get involved
 
 Not only does the Diversity Guild provide a space for learning, it also promotes the belief in sharing what you’ve learned. The group also tries to provide insight on how TTS currently integrates DEI and could better integrate DEI principles at every point: from recruitment, interviewing, and onboarding, all the way to terming out, leaving the organization, or even returning to TTS.
 
-- Join our Slack channel, [#g-diversity](https://gsa-tts.slack.com/messages/g-diversity/). 
-  -  Read the [Guidelines for the #G-Diversity Channel](https://docs.google.com/document/d/1IP0GERswH8t5nQxH0VyYPidj5TrkNtfJEmaPz3_y-go/edit)
+- Join our Slack channel, [#g-diversity](https://gsa-tts.slack.com/messages/g-diversity/).
+  - Read the [Guidelines for the #G-Diversity Channel](https://docs.google.com/document/d/1IP0GERswH8t5nQxH0VyYPidj5TrkNtfJEmaPz3_y-go/edit)
 - Come to our meetings. We meet weekly, every Friday at 12:30-1pm EST. We also have open coworking sessions every Friday at 1pm EST, or the option to extend meeting topics to one hour. The meetings currently show up on the [TTS Working Groups and Guilds Calendar](https://www.google.com/calendar/embed?src=gsa.gov_o1aqcv28k1f0nmca5bkch8los4%40group.calendar.google.com)🔒 If you would like to be added to the invites directly, please [message Austin Hernandez](https://gsa-tts.slack.com/messages/@austinhernandez)🔒 or [Victoria Wales](https://gsa-tts.slack.com/messages/@v)🔒.

--- a/_pages/about-us/diversity.md
+++ b/_pages/about-us/diversity.md
@@ -68,7 +68,7 @@ We believe there are four sources of inclusiveness at every organization, and we
 
 ## Diversity Guild
 
-The Diversity [Guild]({{site.baseurl}}/working-groups-and-guilds-101/) is a formal, on-going way for employees to share experiences, resources, and learn from one another via weekly meetings and the [#g-diversity](https://gsa-tts.slack.com/messages/g-diversity/)🔒 Slack channel. The Guild is currently led by [Austin Hernandez](https://gsa-tts.slack.com/messages/@austinhernandez)🔒 and [Victoria Wales](https://gsa-tts.slack.com/messages/@v)🔒.
+The Diversity [Guild]({{site.baseurl}}/working-groups-and-guilds-101/) is a formal, on-going way for employees to share experiences, resources, and learn from one another via weekly meetings and the [#g-diversity](https://gsa-tts.slack.com/messages/g-diversity/) Slack channel. The Guild is currently led by [Austin Hernandez](https://gsa-tts.slack.com/messages/@austinhernandez) and [Victoria Wales](https://gsa-tts.slack.com/messages/@v).
 
 ### How to get involved
 
@@ -76,4 +76,4 @@ Not only does the Diversity Guild provide a space for learning, it also promotes
 
 - Join our Slack channel, [#g-diversity](https://gsa-tts.slack.com/messages/g-diversity/).
   - Read the [Guidelines for the #G-Diversity Channel](https://docs.google.com/document/d/1IP0GERswH8t5nQxH0VyYPidj5TrkNtfJEmaPz3_y-go/edit)
-- Come to our meetings. We meet weekly, every Friday at 12:30-1pm EST. We also have open coworking sessions every Friday at 1pm EST, or the option to extend meeting topics to one hour. The meetings currently show up on the [TTS Working Groups and Guilds Calendar](https://www.google.com/calendar/embed?src=gsa.gov_o1aqcv28k1f0nmca5bkch8los4%40group.calendar.google.com)🔒 If you would like to be added to the invites directly, please [message Austin Hernandez](https://gsa-tts.slack.com/messages/@austinhernandez)🔒 or [Victoria Wales](https://gsa-tts.slack.com/messages/@v)🔒.
+- Come to our meetings. We meet weekly, every Friday at 12:30-1pm EST. We also have open coworking sessions every Friday at 1pm EST, or the option to extend meeting topics to one hour. The meetings currently show up on the [TTS Working Groups and Guilds Calendar](https://www.google.com/calendar/embed?src=gsa.gov_o1aqcv28k1f0nmca5bkch8los4%40group.calendar.google.com) If you would like to be added to the invites directly, please [message Austin Hernandez](https://gsa-tts.slack.com/messages/@austinhernandez) or [Victoria Wales](https://gsa-tts.slack.com/messages/@v).


### PR DESCRIPTION
The locks are automatically generated through JavaScript, so having them in the Markdown makes them show up twice.

<img width="295" alt="Screen Shot 2020-08-08 at 5 22 26 AM" src="https://user-images.githubusercontent.com/86842/89706824-2d9e5000-d937-11ea-943f-9576dcb71944.png">

See the latter commit.