### PR TITLE
centralize IT Standards and Tech Portfolio links

### DIFF
--- a/_pages/business-units/18f/chapters/design.md
+++ b/_pages/business-units/18f/chapters/design.md
@@ -94,7 +94,7 @@ Most of the design team works on a mix of partner-agency projects and internal i
 
 Here are some common tools we use, how we use them, and how you can get access to them. If you can’t find the information you need in the chart below, get in touch with your design lead; they’ll be able to point you in the right direction.
 
-And one more thing: before you start using any new tool that asks for access to files/browser data, please check the [full list]({{site.baseurl}}/software/search/) of approved tools. If what you want to use isn’t there, you’ll need to ask in [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure) first. New tools often create hard-to-anticipate security problems.
+And one more thing: before you start using any new tool that asks for access to files/browser data, see the [Software]({{base.baseurl}}/software/) page.
 
 #### Drawing lines on a screen
 

--- a/_pages/business-units/18f/chapters/design.md
+++ b/_pages/business-units/18f/chapters/design.md
@@ -94,7 +94,7 @@ Most of the design team works on a mix of partner-agency projects and internal i
 
 Here are some common tools we use, how we use them, and how you can get access to them. If you can’t find the information you need in the chart below, get in touch with your design lead; they’ll be able to point you in the right direction.
 
-And one more thing: before you start using any new tool that asks for access to files/browser data, see the [Software]({{base.baseurl}}/software/) page.
+And one more thing: before you start using any new tool that asks for access to files/browser data, see the [Software]({{base.baseurl}}/software/) page and assure the tool is approved.
 
 #### Drawing lines on a screen
 

--- a/_pages/business-units/18f/chapters/design.md
+++ b/_pages/business-units/18f/chapters/design.md
@@ -94,7 +94,7 @@ Most of the design team works on a mix of partner-agency projects and internal i
 
 Here are some common tools we use, how we use them, and how you can get access to them. If you can’t find the information you need in the chart below, get in touch with your design lead; they’ll be able to point you in the right direction.
 
-And one more thing: before you start using any new tool that asks for access to files/browser data, please check the [full list](https://ea.gsa.gov/#!/itstandards) of approved tools. If what you want to use isn’t there, you’ll need to ask in [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure) first. New tools often create hard-to-anticipate security problems.
+And one more thing: before you start using any new tool that asks for access to files/browser data, please check the [full list]({{site.baseurl}}/software/search/) of approved tools. If what you want to use isn’t there, you’ll need to ask in [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure) first. New tools often create hard-to-anticipate security problems.
 
 #### Drawing lines on a screen
 

--- a/_pages/business-units/18f/chapters/engineering.md
+++ b/_pages/business-units/18f/chapters/engineering.md
@@ -130,4 +130,4 @@ Most of the Engineering team works on a mix of partner agency projects and inter
 
 Here are some [common tools we use]({{site.baseurl}}/#software-and-tools), how we use them, and how you can get access to them. If you can’t find the information you need in the chart below, get in touch with your design lead; they’ll be able to point you in the right direction.
 
-And one more thing: before you start using any new tool that asks for access to files/browser data, see the [Software]({{base.baseurl}}/software/) page.
+And one more thing: before you start using any new tool that asks for access to files/browser data, see the [Software]({{base.baseurl}}/software/) page and assure the tool is approved. If what you want to use isn’t there or not approved, you’ll need to ask [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure) first. 

--- a/_pages/business-units/18f/chapters/engineering.md
+++ b/_pages/business-units/18f/chapters/engineering.md
@@ -130,4 +130,4 @@ Most of the Engineering team works on a mix of partner agency projects and inter
 
 Here are some [common tools we use]({{site.baseurl}}/#software-and-tools), how we use them, and how you can get access to them. If you can’t find the information you need in the chart below, get in touch with your design lead; they’ll be able to point you in the right direction.
 
-And one more thing: before you start using any new tool that asks for access to files/browser data, please check the [full list](https://ea.gsa.gov/#!/itstandards) of approved tools. If what you want to use isn’t there, you’ll need to ask [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure) first. New tools often create hard-to-anticipate security problems.
+And one more thing: before you start using any new tool that asks for access to files/browser data, please check the [full list]({{site.baseurl}}/software/search/) of approved tools. If what you want to use isn’t there, you’ll need to ask [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure) first. New tools often create hard-to-anticipate security problems.

--- a/_pages/business-units/18f/chapters/engineering.md
+++ b/_pages/business-units/18f/chapters/engineering.md
@@ -130,4 +130,4 @@ Most of the Engineering team works on a mix of partner agency projects and inter
 
 Here are some [common tools we use]({{site.baseurl}}/#software-and-tools), how we use them, and how you can get access to them. If you can’t find the information you need in the chart below, get in touch with your design lead; they’ll be able to point you in the right direction.
 
-And one more thing: before you start using any new tool that asks for access to files/browser data, please check the [full list]({{site.baseurl}}/software/search/) of approved tools. If what you want to use isn’t there, you’ll need to ask [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure) first. New tools often create hard-to-anticipate security problems.
+And one more thing: before you start using any new tool that asks for access to files/browser data, see the [Software]({{base.baseurl}}/software/) page.

--- a/_pages/business-units/18f/chapters/product.md
+++ b/_pages/business-units/18f/chapters/product.md
@@ -77,7 +77,7 @@ The product chapter communicates primarily in Slack. 18f-product@gsa.gov is a lo
 ### Tools
 [The TTS handbook lists the tools we use the most.]({{site.baseurl}}/#software-and-tools) If you can’t find what you need, reach out in the [#product](https://slack.com/app_redirect?channel=product) or talk to your supervisor.
 
-Before you start using any new tool, please check the [full list](https://ea.gsa.gov/#!/itstandards) of approved tools. If what you want to use isn’t there, you’ll need to ask in [#infrastructure](https://slack.com/app_redirect?channel=infrastructure) first. New tools often create hard-to-anticipate security problems.
+Before you start using any new tool, please check the [full list]({{site.baseurl}}/software/search/) of approved tools. If what you want to use isn’t there, you’ll need to ask in [#infrastructure](https://slack.com/app_redirect?channel=infrastructure) first. New tools often create hard-to-anticipate security problems.
 
 Here are a few particularly useful essentials:
 

--- a/_pages/business-units/18f/chapters/product.md
+++ b/_pages/business-units/18f/chapters/product.md
@@ -77,7 +77,7 @@ The product chapter communicates primarily in Slack. 18f-product@gsa.gov is a lo
 ### Tools
 [The TTS handbook lists the tools we use the most.]({{site.baseurl}}/#software-and-tools) If you can’t find what you need, reach out in the [#product](https://slack.com/app_redirect?channel=product) or talk to your supervisor.
 
-Before you start using any new tool, please check the [full list]({{site.baseurl}}/software/search/) of approved tools. If what you want to use isn’t there, you’ll need to ask in [#infrastructure](https://slack.com/app_redirect?channel=infrastructure) first. New tools often create hard-to-anticipate security problems.
+Before you start using any new tool, please see the [Software]({{base.baseurl}}/software/) page.
 
 Here are a few particularly useful essentials:
 

--- a/_pages/business-units/18f/chapters/product.md
+++ b/_pages/business-units/18f/chapters/product.md
@@ -77,7 +77,7 @@ The product chapter communicates primarily in Slack. 18f-product@gsa.gov is a lo
 ### Tools
 [The TTS handbook lists the tools we use the most.]({{site.baseurl}}/#software-and-tools) If you can’t find what you need, reach out in the [#product](https://slack.com/app_redirect?channel=product) or talk to your supervisor.
 
-Before you start using any new tool, please see the [Software]({{base.baseurl}}/software/) page.
+And one more thing: before you start using any new tool that asks for access to files/browser data, see the [Software]({{base.baseurl}}/software/) page and assure the tool is approved. If what you want to use isn’t there or not approved, you’ll need to ask [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure) first. 
 
 Here are a few particularly useful essentials:
 

--- a/_pages/business-units/solutions/tech-portfolio.md
+++ b/_pages/business-units/solutions/tech-portfolio.md
@@ -46,4 +46,4 @@ We're open and excited to hear [(anonymous) feedback](https://docs.google.com/fo
 
 ## Questions
 
-Find us in Slack in [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure/), email us at [devops@gsa.gov](mailto:devops@gsa.gov), or [file an issue](https://github.com/18F/tts-tech-portfolio/issues/new).
+Find us in Slack in [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure/) or email us at [devops@gsa.gov](mailto:devops@gsa.gov).

--- a/_pages/getting-started/classes/intro-to-TTS-Tech-Portfolio.md
+++ b/_pages/getting-started/classes/intro-to-TTS-Tech-Portfolio.md
@@ -24,7 +24,7 @@ Our team helps other TTS teams with security, compliance, and technology best pr
 
 ### Obeying the law
 
-Rule #1 is if you don't see us doing something already, and you can't find express authorization to do it, please ask first in Slack [#tts-tech-portfolio channel](https://gsa-tts.slack.com/archives/CNW3GL70S) or by emailing `devops@gsa.gov`. We promise to get you an answer quickly. For example, if there is software or hardware that chapters need to accomplish their mission or don't know how to get, hop into [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure/) and ask.
+Rule #1 is if you don't see us doing something already, and you can't find express authorization to do it, please [ask the Tech Portfolio]({{site.baseurl}}/tech-portfolio/#questions). We promise to get you an answer quickly. If there is software that chapters need to accomplish their mission or don't know how to get, see the [Software]({{site.baseurl}}/software/) page.
 
 ### Security
 
@@ -48,7 +48,7 @@ This brings us to Rule #3: You cannot spend a single penny, or create the expect
 
 There are some things that you might have been used to doing outside of government that you cannot do now.
 
-You cannot use or deploy to whatever third party tool you want without asking in [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure/) or by submitting a [Google App Script Approval Form](https://docs.google.com/a/gsa.gov/forms/d/e/1FAIpQLSdOCtxCaSKJC87CedZW1FKGspMvnRzyOauMvKIOfrSV7PBdag/viewform) .
+You cannot use or deploy to whatever third party tool you want without [asking the Tech Portfolio]({{site.baseurl}}/tech-portfolio/#questions) or by submitting a [Google App Script Approval Form](https://docs.google.com/a/gsa.gov/forms/d/e/1FAIpQLSdOCtxCaSKJC87CedZW1FKGspMvnRzyOauMvKIOfrSV7PBdag/viewform) .
 
 If you're an engineer of any kind, the most important part of your job in the government at the moment is **security.** If you're building anything, a good place to start is [18F's security standards](https://pages.18f.gov/before-you-ship/security/).
 
@@ -70,4 +70,4 @@ TTS Ops focuses on what would normally be considered the "back office" financial
 
 ---
 
-Ask in Slack: [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure/)
+[Get in touch]({{site.baseurl}}/tech-portfolio/#questions)

--- a/_pages/getting-started/how-to-log-in.md
+++ b/_pages/getting-started/how-to-log-in.md
@@ -62,4 +62,4 @@ To learn how to connect to the GSA network on campus and remotely, take a look a
 
 #### Still have questions?
 
-Ask in [#it-issues](https://gsa-tts.slack.com/messages/questions/), [#distributed](https://gsa-tts.slack.com/messages/distributed/) or ping [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure)
+Ask the [Service Desk]({{site.baseurl}}/gsa-internal-tools/#it-service-desk).

--- a/_pages/how-we-work/research-guidelines.md
+++ b/_pages/how-we-work/research-guidelines.md
@@ -63,7 +63,7 @@ Be especially mindful about using Slack during interviews for sidebar conversati
 Carefully restricting access to personally identifiable information is a matter not just of people's right to respect but of their right to [privacy](https://methods.18f.gov/privacy/). For more information, please see the [Design research privacy impact assessment (PIA)](https://www.gsa.gov/cdnstatic/20200401_-_Design_Research_PIA_for%20posting.pdf), or [this 30-minute overview of privacy as it relates to research](https://gsa-tts.slack.com/files/U9KLLKS4W/FCSFWBZD3/researchguildprivacytalk091218.mp4) narrated by the GSA Privacy Office.
 
 
-**Bottom line: If you have questions about sharing information, just ask.** If you're not sure if you're collecting PII or need help with policy guidance, you can ask on Slack in [#g-research](https://gsa-tts.slack.com/archives/g-research). If you are not sure where the right place might be to store any given file, or what access permissions to grant, you can post a question to [#infrastructure](https://gsa-tts.slack.com/archives/infrastructure).
+**Bottom line: If you have questions about sharing information, just ask.** See the page on [sensitive information]({{site.baseurl}}/sensitive-information/). If you're not sure if you're collecting PII or need help with policy guidance, you can ask on Slack in [#g-research](https://gsa-tts.slack.com/archives/g-research). If you are not sure where the right place might be to store any given file, or what access permissions to grant, you can [ask the Tech Portfolio]({{site.baseurl}}/tech-portfolio/#questions).
 
 
 ## Join the research guild!

--- a/_pages/how-we-work/software.md
+++ b/_pages/how-we-work/software.md
@@ -24,21 +24,19 @@ _Note: If you're looking for MS Office, see [this page]({{site.baseurl}}/office/
 
 ## Purchase new software
 
-Here at TTS, we want to stay current and take advantage of as many emergign technologies as possible. We believe that getting the software you need to do your job should be difficult, time-consuming or stressful. If the software is not in the TTS inventory or GSA IT Catalog (or if there are no licenses available), the TTS Tech Portfolio will work with you to meet your needs as best as possible
+Here at TTS, we want to stay current and take advantage of as many emerging technologies as possible. We believe that getting the software you need to do your job should not be difficult, time-consuming or stressful. If the software is not in the [TTS inventory](https://docs.google.com/spreadsheets/d/12pfcEIEXaJTjIKex-3wnI89erIvgKf9B_XpGkDl6qsM/edit#gid=0) or GSA IT Catalog (or if there are no licenses available), the TTS Tech Portfolio will work with you to meet your needs as best as possible.
 
 ### Step 1: Request within TTS
 
-If you haven't already used the [TTS Tech Portfolio Software Request Form](https://forms.gle/w3MqKNMmLj1vbpWv8) to get a _New Software (consult)_ please do so.
+Use the [TTS Tech Portfolio Software Request Form](https://forms.gle/w3MqKNMmLj1vbpWv8) to get a _New Software (consult)_. Please ensure that your justification in the Google Form is detailed, so it can be used to request FITARA approval.
 
-Please ensure that your justification in the Google Form is detailed, so it can be used to request FITARA approval.
-
-### Step 2: find or get an ATO
+### Step 2: Find or get an ATO
 
 An Authority to Operate (ATO) is the result of the Assessment and Authorization process where someone (the Authorizing Official) accepts the risk as it pertains to cybersecurity. The ATO typically has certain conditions (such limiting use of certain data, needing to be on a VPN, etc) and as long as the software is used under those conditions, the Authorizing Official accepts the risk. Based on the nature of changing threat landscap, ATOs have an expiration date and will need to be assessed again before a new authorization is issued.
 
-To check for an ATO, you need to go to [GEAR, IT Standards list](https://ea.gsa.gov/#!/itstandards) (aka Salesforce). _Note: you will need VPN to view the list._ If the software you are purchasing has a valid ATO listed in GEAR, then you can proceed with the rest of the process. You should save a copy of the ATO to your desktop so you can attach it to the request later.
+To check for an ATO, you need to go to [check the IT Standards list]({{site.baseurl}}/software/search/). If the software you are purchasing has a valid ATO listed in GEAR, then you can proceed with the rest of the process. You should save a copy of the ATO to your desktop so you can attach it to the request later.
 
-If the ATO is expired or you cannot find it in GEAR, you can post in the Slack channel [#tts-tech-portfolio](https://gsa-tts.slack.com/messages/tts-tech-portfolio/) to ask if there is an updated ATO. If there is no ATO or the ATO is expired, you will need to go through the ATO process to ensure your software is approved by security. The ATO process can take 4-6 weeks and [costs money](https://docs.google.com/spreadsheets/d/1PokRIGaGl04sxMxEHGwMIRaJDx4OPEXpJ7g69ekDdz8/edit#gid=1451563242z) and there is no guarantee it will be approved. If your need is urgent, try to find something in [GEAR, IT Standards](https://ea.gsa.gov/#!/itstandards) list that is already approved and meets your needs.
+If the ATO is expired or you cannot find it in GEAR, you can post in the Slack channel [#tts-tech-portfolio](https://gsa-tts.slack.com/messages/tts-tech-portfolio/) to ask if there is an updated ATO. If there is no ATO or the ATO is expired, you will need to go through the ATO process to ensure your software is approved by security. The ATO process can take 4-6 weeks and [costs money](https://docs.google.com/spreadsheets/d/1PokRIGaGl04sxMxEHGwMIRaJDx4OPEXpJ7g69ekDdz8/edit#gid=1451563242z) and there is no guarantee it will be approved. If your need is urgent, try to find something in the [IT Standards]({{site.baseurl}}/software/search/) list that is already approved and meets your needs.
 
 ### Step 3: [Submit a micropurchase request.]({{site.baseurl}}/purchase-requests/)
 

--- a/_pages/policies/tech-policies/fitara.md
+++ b/_pages/policies/tech-policies/fitara.md
@@ -68,4 +68,4 @@ TTS issued policy effective February 28, 2017, implementing the policy and proce
 
 #### Still have questions?
 
-Ask in Slack: [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure/)
+[Ask the Tech Portfolio.]({{site.baseurl}}/tech-portfolio/#questions)

--- a/_pages/policies/tech-policies/password-requirements.md
+++ b/_pages/policies/tech-policies/password-requirements.md
@@ -54,4 +54,4 @@ Or try thinking of a sentence or line from a book, song, speech, poem, or other 
 
 ## Questions?
 
-Ask in [#it-issues](https://gsa-tts.slack.com/messages/questions/) or ping [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure)
+Ask in [#it-issues](https://gsa-tts.slack.com/messages/questions/).

--- a/_pages/policies/tech-policies/security-incidents.md
+++ b/_pages/policies/tech-policies/security-incidents.md
@@ -97,4 +97,4 @@ The soundness/fitness of purpose of our systems or information. So if a backup w
 - You can use this link to <a href="mailto:itservicedesk@gsa.gov?subject=Incident:&cc=gsa-ir@gsa.gov;devops@gsa.gov">quickly send an email to IT Service Desk, GSA IR Team & TTS Tech Portfolio</a> at the same time.
 - cloud.gov: [cloud.gov support team](mailto:cloud-gov-support@gsa.gov) or [#cg-incidents](https://gsa-tts.slack.com/messages/incident-response) Slack channel
 - cloud.gov: [#login-incidents](https://gsa-tts.slack.com/messages/incident-response) Slack channel
-- Need to find the Information System Security Officer (ISSO) or Information System Security Manager (ISSM) for a specific system? See the [directory of contacts for GSA systems](https://ea.gsa.gov/#!/FISMA_POC). (You'll need to be on the GSA network or VPN to access the directory.)
+- Need to find the Information System Security Officer (ISSO) or Information System Security Manager (ISSM) for a specific system? See the [directory of contacts for GSA systems](https://ea.gsa.gov/#!/FISMA_POC). You'll need to be [on the GSA network]({{site.baseurl}}/how-to-log-in/#connecting-to-gsa-networks) to access the directory.)

--- a/_pages/software-tools/office.md
+++ b/_pages/software-tools/office.md
@@ -30,4 +30,4 @@ You should receive a reply from the SaaS (Software as a Service) Manager after y
 
 **If you cannot find Microsoft Office on your computer after you download:** Click on each link separately for Microsoft Word, Excel, Powerpoint, and they will download individually. You will have to sign in or create an account each time you download. This should install the applications you need on your computer.
 
-If you have any questions, please ask [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure).
+If you have any questions, please [ask the Tech Portfolio]({{site.baseurl}}/tech-portfolio/#questions).


### PR DESCRIPTION
- Now that we have the software search page, link there instead of to GEAR.
- Link to the Tech Portfolio Questions section, so that the Slack channel and email don't need to be included everywhere.