### PR TITLE
add section on Mac admin rights

### DIFF
--- a/_pages/getting-started/equipment.md
+++ b/_pages/getting-started/equipment.md
@@ -28,6 +28,24 @@ Your laptop will come preloaded with the latest, GSA-approved Mac operating syst
 
 You can [request a loaner PC through the IT Service Desk](https://gsa.servicenowservices.com/sp/?id=sc_cat_item&sys_id=403e07527897a400ce3ddff91a649427&sysparm_category=2318125b7cec0100a6e757fe35f45f9f).
 
+### Admin rights
+
+People doing technical work often have a need to install software dependencies and utilities like command line tools. These vary greatly from task to task and developer to developer and change frequently, and thus it is not realistic to have them packaged by GSA IT for installation. Similarly, there are occasions where a developer may need to make modifications to their operating system that require `sudo`, such as modifying the `/etc/hosts` file. For these reasons, people doing technical work at GSA have a need for administrative rights.
+
+A user can be granted administrative rights on a GSA-issued Mac if they need to run/edit any custom software locally. This custom software can be web applications, static site generators, scripts, etc. for things like:
+
+- Software development
+- Infrastructure maintenance
+- Prototyping
+- Content auditing
+- Testing
+- Data science
+- etc.
+
+"Engineer" (or similar) being part of their title is not required.
+
+See the [**procedures to request admin rights**](https://docs.google.com/document/d/1xepZsh83lxPDykrb1NXoeHxj8m78qsdW-9KqzO_CHOQ/edit).
+
 ### Tips
 
 - Run the [laptop script](https://github.com/18F/laptop) which will turn your Mac into an awesome web development machine.

--- a/_pages/software-tools/github.md
+++ b/_pages/software-tools/github.md
@@ -106,7 +106,7 @@ Here's our current process to address both operational and security concerns:
 1. In the "Description" of the team, put something reasonable plus a point-of-contact email address for the collaborators.
    - Ideally this is the address of someone senior — someone you can email if issues come up and who can rally the troops.
 1. (Ask #admins-github to) [add the members to the team](https://help.github.com/articles/maintaining-teams/).
-1. Give the team read/write permissions on the relevant repositories. Admin rights should be limited exclusively to 18F staff.
+1. Give the team read/write permissions on the relevant repositories. Admin rights should be limited exclusively to TTS staff.
 
 When the engagement is over, you must let [#admins-github](https://gsa-tts.slack.com/messages/admins-github) know so the team can be deleted and access removed.
 

--- a/_pages/software-tools/office.md
+++ b/_pages/software-tools/office.md
@@ -10,7 +10,7 @@ The offering of Office for Mac 2016 licenses from GSA has been on-again-off-agai
 
 ## Requesting a license
 
-**_It is not currently possible to install Office for Mac 2016 on machines without admin rights. The Tech Portfolio is looking into paths forward._**
+**_It is not currently possible to install Office for Mac 2016 on machines without [admin rights]({{site.baseurl}}/equipment/#admin-rights). The Tech Portfolio is looking into paths forward._**
 
 To request a Microsoft Office license for your Mac, please **send an email to <tts-software@gsa.gov> with a short explanation of why you need Office rather than using G Suite**.
 


### PR DESCRIPTION
Was pointing people to [the doc where it was drafted](https://docs.google.com/document/d/15Fg1C5ltJAuTgIcchUlxWCbWF5S5YwJ0wG-xsYcyK1Q/edit#heading=h.drusktc3gof3)—preferable to have it somewhere more canonical.