### PR TITLE
include where to reach out with questions as page metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,19 @@
 # Contributing to the TTS Handbook
 
+## Front matter
+
+The Handbook has a special `contacts` [front matter](https://jekyllrb.com/docs/front-matter/) variable for pages:
+
+```yaml
+questions:
+  - name-of-slack-channel
+  - some@email.gov
+  - text: The text to display
+    url: https://somesite.gov
+```
+
+It is optional, and can contain one or more Slack channel name, email address, and/or link.
+
 ## What Cannot Be Included
 
 - TTS Staff should not include information that shouldn't be public.
@@ -39,7 +53,7 @@ Everyone, inside and outside TTS, can submit contributions to https://github.com
 
 There is no dedicated staff for the handbook; maintenance is done by TTS staff who are interested in helping.
 
-For long or important chunks of writing, consider asking the [18F Writing Lab](https://github.com/18F/writing-lab) to review and edit  before you propose significant changes to the handbook.
+For long or important chunks of writing, consider asking the [18F Writing Lab](https://github.com/18F/writing-lab) to review and edit before you propose significant changes to the handbook.
 
 Use of [Prettier](https://prettier.io/) is encouraged for formatting files, though formatting is not a blocker for merging changes.
 

--- a/_layouts/handbook_page.html
+++ b/_layouts/handbook_page.html
@@ -5,10 +5,10 @@ layout: page
 {% include page-outdated.html %}
 {{ content | smartify }}
 
-{% if page.contacts %}
+{% if page.questions %}
 <h2 id="questions">Questions?</h2>
 <ul>
-  {% for contact in page.contacts %}
+  {% for contact in page.questions %}
   <li>
     {% if contact contains "@" %}
       <a href="mailto:{{contact}}">{{contact}}</a>

--- a/_layouts/handbook_page.html
+++ b/_layouts/handbook_page.html
@@ -4,3 +4,18 @@ layout: page
 
 {% include page-outdated.html %}
 {{ content | smartify }}
+
+{% if page.contacts %}
+<h2>Questions?</h2>
+<ul>
+  {% for contact in page.contacts %}
+  <li>
+    {% if contact contains "@" %}
+      <a href="mailto:{{contact}}">{{contact}}</a>
+    {% else %}
+      <a href="https://gsa-tts.slack.com/messages/{{contact}}/">{{contact}}</a>
+    {% endif %}
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}

--- a/_layouts/handbook_page.html
+++ b/_layouts/handbook_page.html
@@ -6,14 +6,16 @@ layout: page
 {{ content | smartify }}
 
 {% if page.contacts %}
-<h2>Questions?</h2>
+<h2 id="questions">Questions?</h2>
 <ul>
   {% for contact in page.contacts %}
   <li>
     {% if contact contains "@" %}
       <a href="mailto:{{contact}}">{{contact}}</a>
+    {% elsif contact.text %}
+      <a href="{{contact.url}}">{{contact.text}}</a>
     {% else %}
-      <a href="https://gsa-tts.slack.com/messages/{{contact}}/">{{contact}}</a>
+      <a href="https://gsa-tts.slack.com/messages/{{contact}}/">#{{contact}}</a>
     {% endif %}
   </li>
   {% endfor %}

--- a/_pages/business-units/18f/chapters/acqstack.md
+++ b/_pages/business-units/18f/chapters/acqstack.md
@@ -1,5 +1,7 @@
 ---
 title: Acquisition
+contacts:
+  - acquisition
 ---
 
 Making procurement joyful
@@ -119,9 +121,3 @@ These are a couple of suggested reading materials meant to give you a better sen
 * **Ask for help.** Know there is a powerful ecosystem of 18Fers who are on-call to help with any areas where you need more assistance, whether it’s design, security practices, or product management best practices. We see new things every day, but it’s unlikely that someone hasn’t seen something like what you’re experiencing before and can offer a hand, ear, or whatever other body part you may need given the circumstances.
 
 * **Not everyone is ready for the 18F way on day one.** Our prinicples mirror agile software development and we are committed to modern procurement practices (ie. modular contracting). It’s ok to recognize that implementing new practices can be difficult and challenging.  What’s worse would be to force it onto someone not ready and see them stumble in [very predictable ways](https://18f.gsa.gov/2018/09/27/antipatterns-in-agile-contracting/). 
-
----
-
-#### Still have questions?
-
-Ask in Slack: [#acquisition](https://gsa-tts.slack.com/messages/acquisition)

--- a/_pages/business-units/18f/chapters/acqstack.md
+++ b/_pages/business-units/18f/chapters/acqstack.md
@@ -1,6 +1,6 @@
 ---
 title: Acquisition
-contacts:
+questions:
   - acquisition
 ---
 

--- a/_pages/business-units/18f/how-18f-works/client-accounts.md
+++ b/_pages/business-units/18f/how-18f-works/client-accounts.md
@@ -1,6 +1,6 @@
 ---
 title: Account management policy
-contacts:
+questions:
   - iaa
   - legalstuff
 ---

--- a/_pages/business-units/18f/how-18f-works/client-accounts.md
+++ b/_pages/business-units/18f/how-18f-works/client-accounts.md
@@ -1,5 +1,8 @@
 ---
 title: Account management policy
+contacts:
+  - iaa
+  - legalstuff
 ---
 
 _This control document outlines how 18F conducts business._
@@ -56,9 +59,3 @@ This document will be reviewed at least annually, as appropriate, by the 18F Exe
 ### How and when are 18F employees instructed on these procedures?
 
 This document is distributed to all new hires as part of our regular onboarding process.
-
----
-
-#### Still have questions?
-
-Ask in Slack: [#iaa](https://gsa-tts.slack.com/messages/iaa/) or [#legalstuff](https://gsa-tts.slack.com/messages/legalstuff/)

--- a/_pages/business-units/solutions/tech-portfolio.md
+++ b/_pages/business-units/solutions/tech-portfolio.md
@@ -3,6 +3,9 @@ title: TTS Technology Portfolio
 navtitle: Tech Portfolio
 redirect_from:
   - /infrastructure/
+contacts:
+  - "#infrastructure"
+  - devops@gsa.gov
 ---
 
 The goal of the Tech Portfolio is to oversee/manage/coordinate everything technology-related that cuts across TTS, and anything technology-related that will affect TTS from the outside: particularly security, compliance, infrastructure, and tech policy. We provide all the things that allow you to get your job done, at the highest quality level.
@@ -35,7 +38,7 @@ Rather than trying to exert control over everything technology at TTS, we focus 
 
 - [The Tech Portfolio Kanban board](https://github.com/orgs/18F/projects/11?fullscreen=true) - what we're working on
 - [Before You Ship](https://before-you-ship.18f.gov/) - TTS's internal documentation about security, compliance, and infrastructure
-- Maintaining the authoritative source documentation for components used across TTS  [Software-as-a-service (SaaS) ](https://docs.google.com/spreadsheets/d/12pfcEIEXaJTjIKex-3wnI89erIvgKf9B_XpGkDl6qsM/edit#gid=0), [Systems](https://docs.google.com/spreadsheets/u/1/d/1LGn9kZCphzf14V5HpBfV3aYjflu-k9GtHS5LmFvDywM/edit?usp=drive_web&ouid=114492559070606542558), and [Accounts](https://docs.google.com/spreadsheets/d/1DedSCiU9AsCAAVvAFZT0_Ii7AFIKlI-JNifzlpHNbDg/edit#gid=0)
+- Maintaining the authoritative source documentation for components used across TTS [Software-as-a-service (SaaS) ](https://docs.google.com/spreadsheets/d/12pfcEIEXaJTjIKex-3wnI89erIvgKf9B_XpGkDl6qsM/edit#gid=0), [Systems](https://docs.google.com/spreadsheets/u/1/d/1LGn9kZCphzf14V5HpBfV3aYjflu-k9GtHS5LmFvDywM/edit?usp=drive_web&ouid=114492559070606542558), and [Accounts](https://docs.google.com/spreadsheets/d/1DedSCiU9AsCAAVvAFZT0_Ii7AFIKlI-JNifzlpHNbDg/edit#gid=0)
 - [More internal documentation](https://github.com/18F/tts-tech-portfolio/wiki/Documents-for-TTS-Tech-Porfolio)
 - [Read more about us](https://github.com/18F/tts-tech-portfolio/blob/master/README.md)
 - The Technology Portfolio team is new as of July 2019, though, is the evolution of 18F/TTS Infrastructure.
@@ -43,7 +46,3 @@ Rather than trying to exert control over everything technology at TTS, we focus 
 ## Feedback?
 
 We're open and excited to hear [(anonymous) feedback](https://docs.google.com/forms/d/e/1FAIpQLSeVEH_l46flYCCQRl351KhID77XPCw5ulsQPh0iFqfRig2hxA/viewform) to hear how we're doing!
-
-## Questions
-
-Find us in Slack in [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure/) or email us at [devops@gsa.gov](mailto:devops@gsa.gov).

--- a/_pages/business-units/solutions/tech-portfolio.md
+++ b/_pages/business-units/solutions/tech-portfolio.md
@@ -3,7 +3,7 @@ title: TTS Technology Portfolio
 navtitle: Tech Portfolio
 redirect_from:
   - /infrastructure/
-contacts:
+questions:
   - infrastructure
   - devops@gsa.gov
 ---

--- a/_pages/business-units/solutions/tech-portfolio.md
+++ b/_pages/business-units/solutions/tech-portfolio.md
@@ -4,7 +4,7 @@ navtitle: Tech Portfolio
 redirect_from:
   - /infrastructure/
 contacts:
-  - "#infrastructure"
+  - infrastructure
   - devops@gsa.gov
 ---
 

--- a/_pages/how-we-work/purchase-requests.md
+++ b/_pages/how-we-work/purchase-requests.md
@@ -1,5 +1,10 @@
 ---
 title: Purchase requests
+contacts:
+  - micropurchase
+  - tts-purchasers@gsa.gov
+  - text: Book office hours
+    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
 ---
 
 **Short version:** Use the [micropurchase request form](https://docs.google.com/forms/d/e/1FAIpQLSd-GoOE9xWWfJvdZNRP3SE7mj5ysI_RfM8brxdG8YpyJV9yKA/viewform) for requesting purchases under $10,000.
@@ -105,7 +110,3 @@ Note: it is good practice to set this a few days in advance, as updates here onl
 For issues related to the Micropurchase request sheet and requests to update the logic of the script, reach out to TTS Micropurchase Sheet system owner ethan.heppner@gsa.gov.
 For issues related to Pegasys, reach out to the Business Applications Service Desk at (866) 450-6588.
 For issues related to automated logs not showing up as expected, reach out to GSA Micropurchase Bot system owner matthew.taylor@gsa.gov.
-
-## Questions
-
-Any questions? [#micropurchase](https://gsa-tts.slack.com/messages/micropurchase/), email [tts-purchasers@gsa.gov](mailto:tts-purchasers@gsa.gov), or [book office hours](https://sites.google.com/a/gsa.gov/tts-office-hours/).

--- a/_pages/how-we-work/purchase-requests.md
+++ b/_pages/how-we-work/purchase-requests.md
@@ -1,6 +1,6 @@
 ---
 title: Purchase requests
-contacts:
+questions:
   - micropurchase
   - tts-purchasers@gsa.gov
   - text: Book office hours

--- a/_pages/how-we-work/software.md
+++ b/_pages/how-we-work/software.md
@@ -1,5 +1,7 @@
 ---
 title: Software Under $10,000
+contacts:
+  - infrastructure
 ---
 
 Do you need software to do your job or make sure TTS is running smoothly? Follow the steps below to access software we own or request a software purchase of under $10,000.
@@ -52,7 +54,3 @@ The process on this page is for buying software. In general, open source develop
 
 **TTS SaaS Project Manager:** Melanie Leopold [melanie.leopold@gsa.gov](mailto:melanie.leopold@gsa.gov)
 **TTS Office of Acquisition Director:** Esther Praske [esther.praske@gsa.gov](mailto:esther.praske@gsa.gov)
-
-## Questions?
-
-Find us in Slack: [#tts-oa](https://gsa-tts.slack.com/messages/tts-oa/).

--- a/_pages/how-we-work/software.md
+++ b/_pages/how-we-work/software.md
@@ -1,6 +1,6 @@
 ---
 title: Software Under $10,000
-contacts:
+questions:
   - infrastructure
 ---
 

--- a/_pages/policies/employee-resources-policies/deaf-hoh.md
+++ b/_pages/policies/employee-resources-policies/deaf-hoh.md
@@ -1,6 +1,8 @@
 ---
 title: Resources for Deaf and Hard of Hearing individuals in TTS
-
+contacts:
+   - g-accessibility
+   - g-diversity
 ---
 
 Tools, services, points of contact, and tips for navigating the resources available to individuals and teams.
@@ -178,7 +180,3 @@ Work with this program within the Office of Civil Rights to get assistive techno
  * **Subtitles:** A text version of only the spoken dialogue appears on the visual display or screen. (*See difference, closed captioning*)
  * **Video Remote Interpreting (VRI):** An on-demand sign language interpreting service through webcam, internet connection and a VRI software app.
  * **Translator:** A translator converts information from written or recorded materials into sign language. (*See difference, interpreter*)
-
-## Questions
-
-Any questions? Find the Accessibility Guild and the Diversity Guild on Slack: [#g-accessibility](https://gsa-tts.slack.com/messages/g-accessibility/), [#g-diversity](https://gsa-tts.slack.com/messages/g-diversity/)

--- a/_pages/policies/employee-resources-policies/deaf-hoh.md
+++ b/_pages/policies/employee-resources-policies/deaf-hoh.md
@@ -1,8 +1,8 @@
 ---
 title: Resources for Deaf and Hard of Hearing individuals in TTS
-contacts:
-   - g-accessibility
-   - g-diversity
+questions:
+  - g-accessibility
+  - g-diversity
 ---
 
 Tools, services, points of contact, and tips for navigating the resources available to individuals and teams.

--- a/_pages/policies/employee-resources-policies/hosting-non-government-speakers.md
+++ b/_pages/policies/employee-resources-policies/hosting-non-government-speakers.md
@@ -1,5 +1,8 @@
 ---
 title: Guidance on hosting non-government speakers
+contacts:
+   - training-conferences
+   - outreach
 ---
 
 TTS teams, [Guilds]({{site.baseurl}}/working-groups-and-guilds-101/), and [Working Groups]({{site.baseurl}}/working-groups-and-guilds-101/) have the opportunity to invite individuals outside of the government to speak to our teams. Guest speakers provide a unique opportunity for federal employees to learn from industry professionals on modern practices. Hearing new perspectives provide employees not only with different points-of-view, but also with knowledge they can apply in their careers at TTS.
@@ -38,7 +41,3 @@ In addition to those steps, there are a couple important things to keep in mind 
 ## Accessibility
 
 Be sure to check out the resources on the [Deaf-HOH]({{site.baseurl}}/deaf-hoh/) page to provide the most accessible telecommunications services for Deaf/HoH and speech-disabled employees.
-
-## Questions
-
-Any questions? Ask the [#training-conferences](https://gsa-tts.slack.com/messages/training-conferences/) and/or [#outreach](https://gsa-tts.slack.com/messages/outreach/) channels on Slack.

--- a/_pages/policies/employee-resources-policies/hosting-non-government-speakers.md
+++ b/_pages/policies/employee-resources-policies/hosting-non-government-speakers.md
@@ -1,8 +1,8 @@
 ---
 title: Guidance on hosting non-government speakers
-contacts:
-   - training-conferences
-   - outreach
+questions:
+  - training-conferences
+  - outreach
 ---
 
 TTS teams, [Guilds]({{site.baseurl}}/working-groups-and-guilds-101/), and [Working Groups]({{site.baseurl}}/working-groups-and-guilds-101/) have the opportunity to invite individuals outside of the government to speak to our teams. Guest speakers provide a unique opportunity for federal employees to learn from industry professionals on modern practices. Hearing new perspectives provide employees not only with different points-of-view, but also with knowledge they can apply in their careers at TTS.

--- a/_pages/policies/tech-policies/password-requirements.md
+++ b/_pages/policies/tech-policies/password-requirements.md
@@ -1,6 +1,6 @@
 ---
 title: Requirements for Passwords
-contacts:
+questions:
   - it-issues
 ---
 

--- a/_pages/policies/tech-policies/password-requirements.md
+++ b/_pages/policies/tech-policies/password-requirements.md
@@ -1,5 +1,7 @@
 ---
 title: Requirements for Passwords
+contacts:
+  - it-issues
 ---
 
 Follow the steps below to create and maintain secure passwords.
@@ -49,9 +51,3 @@ This opens up a few risks: A person could try to guess your password based on in
 In other words, you could use a series of random words, plus a few numbers, capital letters, or symbols, if you like.
 
 Or try thinking of a sentence or line from a book, song, speech, poem, or other memorable source, then build a many-character password using the first letter of each word, with some capitalization, numbers, and symbols thrown in. Or just use the whole line or sentence as your password! (You'd need to pick a phrase that nobody would guess based on knowing you.)
-
----
-
-## Questions?
-
-Ask in [#it-issues](https://gsa-tts.slack.com/messages/questions/).

--- a/_pages/software-tools/zoom.md
+++ b/_pages/software-tools/zoom.md
@@ -1,5 +1,7 @@
 ---
 title: Zoom
+contacts:
+  - webmeetings@gsa.gov
 ---
 
 GSA offers [Zoom for Government](https://zoomgov.com/).
@@ -43,7 +45,3 @@ Per the `User Action Required for Zoom Usage` email on 4/13/20:
 > - Do not use a Personal Meeting ID (PMI) for Zoom meetings hosted by GSA.
 > - Do not share links to Zoom meetings or classrooms via publicly available social media outlets. Provide the links directly to specific invitees.
 > - For public meetings hosted by GSA, limit screen sharing to "Host Only".
-
-## Questions?
-
-[Reach out to webmeetings@gsa.gov](mailto:webmeetings@gsa.gov) for help.

--- a/_pages/software-tools/zoom.md
+++ b/_pages/software-tools/zoom.md
@@ -1,6 +1,6 @@
 ---
 title: Zoom
-contacts:
+questions:
   - webmeetings@gsa.gov
 ---
 

--- a/_pages/travel-leave/travel-and-leave-policies/travel-guide-faq.md
+++ b/_pages/travel-leave/travel-and-leave-policies/travel-guide-faq.md
@@ -1,5 +1,10 @@
 ---
 title: Travel Guide FAQ
+contacts:
+  - travel
+  - tts-travel@gsa.gov
+  - text: Book office hours
+    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
 ---
 
 [TTS Travel 101]({{site.baseurl}}/travel-101/) <br>
@@ -504,5 +509,3 @@ Attn:  Bryan DeLeve - 2SE
 Kansas City, MO 64108
 
 Reference the authorization and voucher number along with the payment.
-
-*Got questions? Ask [#travel](https://gsa-tts.slack.com/messages/travel)*, [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov), or book office hours [here](https://sites.google.com/a/gsa.gov/tts-office-hours/)

--- a/_pages/travel-leave/travel-and-leave-policies/travel-guide-faq.md
+++ b/_pages/travel-leave/travel-and-leave-policies/travel-guide-faq.md
@@ -1,6 +1,6 @@
 ---
 title: Travel Guide FAQ
-contacts:
+questions:
   - travel
   - tts-travel@gsa.gov
   - text: Book office hours


### PR DESCRIPTION
The display is super basic right now:

<img width="217" alt="Screen Shot 2020-09-15 at 11 53 37 PM" src="https://user-images.githubusercontent.com/86842/93290523-ec5b5480-f7ae-11ea-8495-1e8e4748d99a.png">

but I figure it will:

- Encourage the information to be included in a consistent way
- Allow fancier things down the road, such as:
   - Display somewhere special, like the sidebar or something
   - Automated validation that every page has contacts listed

I only converted a handful of pages; can do it more exhaustively later if we want to.