### PR TITLE
specify contacts consistently through pages

### DIFF
--- a/_pages/about-us/diversity.md
+++ b/_pages/about-us/diversity.md
@@ -1,6 +1,5 @@
 ---
 title: Diversity, Equity, and Inclusion at TTS
-navtitle: Diversity, Equity, and Inclusion at TTS
 redirect_from:
   - /intro-to-the-diversity-guild/
 ---

--- a/_pages/about-us/history-and-values.md
+++ b/_pages/about-us/history-and-values.md
@@ -1,5 +1,7 @@
 ---
 title: History and values of 18F
+questions:
+  - why-did-we-do-that
 ---
 
 18F stands on the shoulders of giants! These teams paved the way for our existence: the Consumer Financial Protection Bureau, the Office of Personnel Management Lab (focused on user experience, user research, and human-centered design in government), the Sunlight Foundation, Code for America, the [Office of Products and Programs](https://www.gsa.gov/portal/content/124174) (our sister org, which has been around for a decade and runs things like USA.gov), the U.S. CTO’s office, and the Presidential Innovation Fellowship.
@@ -12,15 +14,17 @@ In 2012, the White House established the [Presidential Innovation Fellows](https
 
 The PIF program is administered as a partnership between the White House Office of Science and Technology Policy (OSTP), the White House Office of Management and Budget (OMB), and the General Services Administration (GSA). In 2013, the PIF program established a permanent home and program office within GSA. Housing PIF inside GSA gave it the resources necessary to grow.
 
+
 ## 18F: a civic consultancy
 
-18F grew directly out of the PIF program. During the second year of the program there was increasing chatter about wanting to create a permanent team of technologists, and the hypothesis was clearly proven — thousands of people applied for the first two classes of PIFs. But while there was talk of hiring "perma-PIFs" and a lot of talk about trying to create a GDS equivalent (the Government Digital Service in the UK) in the U.S., various bureaucratic hurdles kept getting in the way.
+18F grew directly out of the PIF program. During the second year of the program there was increasing chatter about wanting to create a permanent team of technologists, and the hypothesis was clearly proven — thousands of people applied for the first two classes of PIFs. But while there was talk of hiring "perma-PIFs"  and a lot of talk about trying to create a GDS equivalent (the Government Digital Service in the UK) in the U.S., various bureaucratic hurdles kept getting in the way.
 
 In October of 2013 (during the second class of PIFs), two rather big things happened: a certain government website failed, and the government shut down. There were several of us already chatting and scheming about how we could stay beyond our six-month fellowships, and these two events ramped up those discussions quite a bit. Two critical discoveries happened: we found a budget, and we realized that the PIFs were already GSA employees (which wasn't the case the year before), so extending our employment contracts was easy.
 
 On December 17th eight of us came to work as PIFs and the next day we came to work as GSA employees on an as-yet unnamed team who figured we would be prototyping, continuing fellowship projects, and generally looking for work that would help us move things forward. We partnered with a couple of amazing bureaucracy hackers inside GSA and quickly realized that there was broad support and enthusiasm for our mere existence. :) We were given the latitude to do what we needed to do to grow: to figure out what we needed to work as an agile, user-focused product team inside the government.
 
 We quickly hired a few folks from those organizations mentioned above (specifically CFPB and Sunlight), and we got to work hacking the bureaucracy around the two things we knew we be the ultimate blockers to a team like ours: ​*hiring*​ and ​*deployment*​ — we're still working on them! But the team's [early work](https://18f.gsa.gov/2014/05/14/hacking-bureaucracy-improving-hiring-and-software/) set the stage for our independence in these areas.
+
 
 GSA officially launched 18F on March 19, 2014. The name is an abbreviation for the intersection of 18th and F Streets in Washington, D.C., where GSA headquarters is located. In March 2014, the 18F team had 15 full-time staff. We've grown 10x in the last 18 months! :bow: to team <a href="https://gsa-tts.slack.com/messages/talent/">#talent</a> and <a href="https://gsa-tts.slack.com/messages/teamops/">#teamops</a>!
 

--- a/_pages/about-us/history-and-values.md
+++ b/_pages/about-us/history-and-values.md
@@ -1,6 +1,5 @@
 ---
 title: History and values of 18F
-navtitle: History and values
 ---
 
 18F stands on the shoulders of giants! These teams paved the way for our existence: the Consumer Financial Protection Bureau, the Office of Personnel Management Lab (focused on user experience, user research, and human-centered design in government), the Sunlight Foundation, Code for America, the [Office of Products and Programs](https://www.gsa.gov/portal/content/124174) (our sister org, which has been around for a decade and runs things like USA.gov), the U.S. CTO’s office, and the Presidential Innovation Fellowship.
@@ -13,17 +12,15 @@ In 2012, the White House established the [Presidential Innovation Fellows](https
 
 The PIF program is administered as a partnership between the White House Office of Science and Technology Policy (OSTP), the White House Office of Management and Budget (OMB), and the General Services Administration (GSA). In 2013, the PIF program established a permanent home and program office within GSA. Housing PIF inside GSA gave it the resources necessary to grow.
 
-
 ## 18F: a civic consultancy
 
-18F grew directly out of the PIF program. During the second year of the program there was increasing chatter about wanting to create a permanent team of technologists, and the hypothesis was clearly proven — thousands of people applied for the first two classes of PIFs. But while there was talk of hiring "perma-PIFs"  and a lot of talk about trying to create a GDS equivalent (the Government Digital Service in the UK) in the U.S., various bureaucratic hurdles kept getting in the way.
+18F grew directly out of the PIF program. During the second year of the program there was increasing chatter about wanting to create a permanent team of technologists, and the hypothesis was clearly proven — thousands of people applied for the first two classes of PIFs. But while there was talk of hiring "perma-PIFs" and a lot of talk about trying to create a GDS equivalent (the Government Digital Service in the UK) in the U.S., various bureaucratic hurdles kept getting in the way.
 
 In October of 2013 (during the second class of PIFs), two rather big things happened: a certain government website failed, and the government shut down. There were several of us already chatting and scheming about how we could stay beyond our six-month fellowships, and these two events ramped up those discussions quite a bit. Two critical discoveries happened: we found a budget, and we realized that the PIFs were already GSA employees (which wasn't the case the year before), so extending our employment contracts was easy.
 
 On December 17th eight of us came to work as PIFs and the next day we came to work as GSA employees on an as-yet unnamed team who figured we would be prototyping, continuing fellowship projects, and generally looking for work that would help us move things forward. We partnered with a couple of amazing bureaucracy hackers inside GSA and quickly realized that there was broad support and enthusiasm for our mere existence. :) We were given the latitude to do what we needed to do to grow: to figure out what we needed to work as an agile, user-focused product team inside the government.
 
 We quickly hired a few folks from those organizations mentioned above (specifically CFPB and Sunlight), and we got to work hacking the bureaucracy around the two things we knew we be the ultimate blockers to a team like ours: ​*hiring*​ and ​*deployment*​ — we're still working on them! But the team's [early work](https://18f.gsa.gov/2014/05/14/hacking-bureaucracy-improving-hiring-and-software/) set the stage for our independence in these areas.
-
 
 GSA officially launched 18F on March 19, 2014. The name is an abbreviation for the intersection of 18th and F Streets in Washington, D.C., where GSA headquarters is located. In March 2014, the 18F team had 15 full-time staff. We've grown 10x in the last 18 months! :bow: to team <a href="https://gsa-tts.slack.com/messages/talent/">#talent</a> and <a href="https://gsa-tts.slack.com/messages/teamops/">#teamops</a>!
 

--- a/_pages/about-us/one-tts.md
+++ b/_pages/about-us/one-tts.md
@@ -4,13 +4,13 @@ title: One TTS
 
 Government leaders are challenged to provide effective and efficient services using outdated technology, processes, and thinking. Government employees and the American public deserve better, and TTS has the expertise and experience to help federal agencies better serve their customers.
 
-In 2019, TTS created the One TTS operating model to better align our services and solutions to a new [TTS Strategy](https://docs.google.com/document/d/1uidmcUfdxOeCt23nJ4VI1M10HV3W44ImMPLgwbx1QJM/edit#), identifying the areas of government technology most in need of transformation.
+In 2019, TTS created the One TTS  operating model to better align our services and solutions to a new [TTS Strategy](https://docs.google.com/document/d/1uidmcUfdxOeCt23nJ4VI1M10HV3W44ImMPLgwbx1QJM/edit#), identifying the areas of government technology most in need of transformation.
 
 The Strategy outlines six areas with the greatest potential for transformational impact, aka our TTS Focus Areas. These are the areas where we should focus our time and talent to be uniquely positioned to drive the most change.
 
 ## The Six Focus Areas are:
 
-**1. Experience (formerly Omnichannel)**
+**1. Experience (formerly Omnichannel)** 
 
 **2. Artificial Intelligence**
 
@@ -22,12 +22,12 @@ The Strategy outlines six areas with the greatest potential for transformational
 
 **6. Identity Management**
 
+
 The [2019 TTS Accomplishments Report](https://docs.google.com/document/d/1x_8Yn6lVuy5JVIy3Hdw6sA61X-oP4OxTjtOt5XhHylQ/edit) (internal to TTS) highlighted a number of initiatives where teams across TTS are already making a difference in the federal technology landscape for our agency customers and the public.
 
 ## Additional Resources
 
 ### Official Documents
-
 Below is a comprehensive list of TTS’ organizational and strategy documents:
 
 - [TTS Org Chart](https://docs.google.com/presentation/d/1-sN16p24TUKlU64jFybzth0cVXKnMaYa5Dkp0wm3Al4/edit#slide=id.g60c56df037_0_0)
@@ -36,7 +36,7 @@ Below is a comprehensive list of TTS’ organizational and strategy documents:
 
 ## Meetings Notes & One TTS Newsletters
 
-### TTS Town Halls & All-Hands Meetings
+### TTS Town Halls &  All-Hands Meetings
 
 - 2019
   - February 2019
@@ -53,22 +53,22 @@ Below is a comprehensive list of TTS’ organizational and strategy documents:
   - April 2020
     - [Slide deck](https://docs.google.com/presentation/d/1jr68phAJrCwT95D40qvu59D_VsLlaJewrFxgweSVqBI/edit#slide=id.p1)
     - [Notes](https://docs.google.com/document/d/18C3nBiYFypCpPGvHqXkuFJBhQGfcHmgn_WUXwFrUJWg/edit)
-  - July 2020
+  - July 2020 
     - [Notes](https://docs.google.com/document/d/18C3nBiYFypCpPGvHqXkuFJBhQGfcHmgn_WUXwFrUJWg/edit)
 
 ### One TTS Newsletter
 
 - 2019
-  - [June 2019](https://docs.google.com/document/d/1MJq1KOJ5elvZsHhpgy-ZyvGiN2j6RXLRyQkdnyxU_Xk/edit)
-  - [July 2019](https://docs.google.com/document/d/1eLFfH7FBkIwSvSOwG-77rv-c8yxwpuC-WbSMFVx8uGc/edit)
-  - [August 2019](https://docs.google.com/document/d/15mVulaBYHVVshnjVDqDS2MYsHb6bnFnpE32DUlJEw1Q/edit)
-  - [September 2019](https://docs.google.com/document/d/10mQ9FjyZ2f479BxUvn30XGxq-Iabe_HvAURb50Jv_KQ/edit)
-  - [October 2019](https://docs.google.com/document/d/1hGUFtai-m3HTjs4VWdMDrPaktvKxrWfBu9o6MNsdpCM/edit)
-  - [November 2019](https://docs.google.com/document/d/1YcFf7qxwkmegyYgvXjL2NPlBgI56GQcPl6H2EDNqBp8/edit)
-  - [December 2019](https://docs.google.com/document/d/1yCiAU1zV1eFSHob-DnGpeHr1xJFJWPcuUKMCyRFahAA/edit)
+    - [June 2019](https://docs.google.com/document/d/1MJq1KOJ5elvZsHhpgy-ZyvGiN2j6RXLRyQkdnyxU_Xk/edit)
+    - [July 2019](https://docs.google.com/document/d/1eLFfH7FBkIwSvSOwG-77rv-c8yxwpuC-WbSMFVx8uGc/edit)
+    - [August 2019](https://docs.google.com/document/d/15mVulaBYHVVshnjVDqDS2MYsHb6bnFnpE32DUlJEw1Q/edit)
+    - [September 2019](https://docs.google.com/document/d/10mQ9FjyZ2f479BxUvn30XGxq-Iabe_HvAURb50Jv_KQ/edit)
+    - [October 2019](https://docs.google.com/document/d/1hGUFtai-m3HTjs4VWdMDrPaktvKxrWfBu9o6MNsdpCM/edit)
+    - [November 2019](https://docs.google.com/document/d/1YcFf7qxwkmegyYgvXjL2NPlBgI56GQcPl6H2EDNqBp8/edit)
+    - [December 2019](https://docs.google.com/document/d/1yCiAU1zV1eFSHob-DnGpeHr1xJFJWPcuUKMCyRFahAA/edit)
 - 2020
-  - [January 2020](https://docs.google.com/document/d/1foDiwfL1eBXc2ZphjYnAafMKJjkC8InFtMHxYZgW5UQ/edit)
-  - [February 2020](https://docs.google.com/document/d/1qdhgevtopCBIS5zaWgOtaHmc-MQiUkU3Z_rlelUX1MA/edit)
-  - [March 2020](https://docs.google.com/document/d/16BTHHUMV-PwIPWNamU5cxLom_Z9vOqgVnZ2PzeRJqE4/edit)
-  - [April 2020](https://docs.google.com/document/d/1vaFslp46ySKX4KZUtlHJfWAFLLID9tlkcwMJgSeWuNY/edit)
-  - [May/June 2020](https://docs.google.com/document/d/16ETbYD5nTVmkGhRBLorv9DtZgKFl6ftybvuQ5o3kRLo/edit)
+    - [January 2020](https://docs.google.com/document/d/1foDiwfL1eBXc2ZphjYnAafMKJjkC8InFtMHxYZgW5UQ/edit)
+    - [February 2020](https://docs.google.com/document/d/1qdhgevtopCBIS5zaWgOtaHmc-MQiUkU3Z_rlelUX1MA/edit)
+    - [March 2020](https://docs.google.com/document/d/16BTHHUMV-PwIPWNamU5cxLom_Z9vOqgVnZ2PzeRJqE4/edit)
+    - [April 2020](https://docs.google.com/document/d/1vaFslp46ySKX4KZUtlHJfWAFLLID9tlkcwMJgSeWuNY/edit)
+    - [May/June 2020](https://docs.google.com/document/d/16ETbYD5nTVmkGhRBLorv9DtZgKFl6ftybvuQ5o3kRLo/edit)

--- a/_pages/about-us/one-tts.md
+++ b/_pages/about-us/one-tts.md
@@ -1,17 +1,16 @@
 ---
 title: One TTS
-navtitle: One TTS
 ---
 
 Government leaders are challenged to provide effective and efficient services using outdated technology, processes, and thinking. Government employees and the American public deserve better, and TTS has the expertise and experience to help federal agencies better serve their customers.
 
-In 2019, TTS created the One TTS  operating model to better align our services and solutions to a new [TTS Strategy](https://docs.google.com/document/d/1uidmcUfdxOeCt23nJ4VI1M10HV3W44ImMPLgwbx1QJM/edit#), identifying the areas of government technology most in need of transformation.
+In 2019, TTS created the One TTS operating model to better align our services and solutions to a new [TTS Strategy](https://docs.google.com/document/d/1uidmcUfdxOeCt23nJ4VI1M10HV3W44ImMPLgwbx1QJM/edit#), identifying the areas of government technology most in need of transformation.
 
 The Strategy outlines six areas with the greatest potential for transformational impact, aka our TTS Focus Areas. These are the areas where we should focus our time and talent to be uniquely positioned to drive the most change.
 
 ## The Six Focus Areas are:
 
-**1. Experience (formerly Omnichannel)** 
+**1. Experience (formerly Omnichannel)**
 
 **2. Artificial Intelligence**
 
@@ -23,12 +22,12 @@ The Strategy outlines six areas with the greatest potential for transformational
 
 **6. Identity Management**
 
-
 The [2019 TTS Accomplishments Report](https://docs.google.com/document/d/1x_8Yn6lVuy5JVIy3Hdw6sA61X-oP4OxTjtOt5XhHylQ/edit) (internal to TTS) highlighted a number of initiatives where teams across TTS are already making a difference in the federal technology landscape for our agency customers and the public.
 
 ## Additional Resources
 
 ### Official Documents
+
 Below is a comprehensive list of TTS’ organizational and strategy documents:
 
 - [TTS Org Chart](https://docs.google.com/presentation/d/1-sN16p24TUKlU64jFybzth0cVXKnMaYa5Dkp0wm3Al4/edit#slide=id.g60c56df037_0_0)
@@ -37,7 +36,7 @@ Below is a comprehensive list of TTS’ organizational and strategy documents:
 
 ## Meetings Notes & One TTS Newsletters
 
-### TTS Town Halls &  All-Hands Meetings
+### TTS Town Halls & All-Hands Meetings
 
 - 2019
   - February 2019
@@ -54,22 +53,22 @@ Below is a comprehensive list of TTS’ organizational and strategy documents:
   - April 2020
     - [Slide deck](https://docs.google.com/presentation/d/1jr68phAJrCwT95D40qvu59D_VsLlaJewrFxgweSVqBI/edit#slide=id.p1)
     - [Notes](https://docs.google.com/document/d/18C3nBiYFypCpPGvHqXkuFJBhQGfcHmgn_WUXwFrUJWg/edit)
-  - July 2020 
+  - July 2020
     - [Notes](https://docs.google.com/document/d/18C3nBiYFypCpPGvHqXkuFJBhQGfcHmgn_WUXwFrUJWg/edit)
 
 ### One TTS Newsletter
 
 - 2019
-    - [June 2019](https://docs.google.com/document/d/1MJq1KOJ5elvZsHhpgy-ZyvGiN2j6RXLRyQkdnyxU_Xk/edit)
-    - [July 2019](https://docs.google.com/document/d/1eLFfH7FBkIwSvSOwG-77rv-c8yxwpuC-WbSMFVx8uGc/edit)
-    - [August 2019](https://docs.google.com/document/d/15mVulaBYHVVshnjVDqDS2MYsHb6bnFnpE32DUlJEw1Q/edit)
-    - [September 2019](https://docs.google.com/document/d/10mQ9FjyZ2f479BxUvn30XGxq-Iabe_HvAURb50Jv_KQ/edit)
-    - [October 2019](https://docs.google.com/document/d/1hGUFtai-m3HTjs4VWdMDrPaktvKxrWfBu9o6MNsdpCM/edit)
-    - [November 2019](https://docs.google.com/document/d/1YcFf7qxwkmegyYgvXjL2NPlBgI56GQcPl6H2EDNqBp8/edit)
-    - [December 2019](https://docs.google.com/document/d/1yCiAU1zV1eFSHob-DnGpeHr1xJFJWPcuUKMCyRFahAA/edit)
+  - [June 2019](https://docs.google.com/document/d/1MJq1KOJ5elvZsHhpgy-ZyvGiN2j6RXLRyQkdnyxU_Xk/edit)
+  - [July 2019](https://docs.google.com/document/d/1eLFfH7FBkIwSvSOwG-77rv-c8yxwpuC-WbSMFVx8uGc/edit)
+  - [August 2019](https://docs.google.com/document/d/15mVulaBYHVVshnjVDqDS2MYsHb6bnFnpE32DUlJEw1Q/edit)
+  - [September 2019](https://docs.google.com/document/d/10mQ9FjyZ2f479BxUvn30XGxq-Iabe_HvAURb50Jv_KQ/edit)
+  - [October 2019](https://docs.google.com/document/d/1hGUFtai-m3HTjs4VWdMDrPaktvKxrWfBu9o6MNsdpCM/edit)
+  - [November 2019](https://docs.google.com/document/d/1YcFf7qxwkmegyYgvXjL2NPlBgI56GQcPl6H2EDNqBp8/edit)
+  - [December 2019](https://docs.google.com/document/d/1yCiAU1zV1eFSHob-DnGpeHr1xJFJWPcuUKMCyRFahAA/edit)
 - 2020
-    - [January 2020](https://docs.google.com/document/d/1foDiwfL1eBXc2ZphjYnAafMKJjkC8InFtMHxYZgW5UQ/edit)
-    - [February 2020](https://docs.google.com/document/d/1qdhgevtopCBIS5zaWgOtaHmc-MQiUkU3Z_rlelUX1MA/edit)
-    - [March 2020](https://docs.google.com/document/d/16BTHHUMV-PwIPWNamU5cxLom_Z9vOqgVnZ2PzeRJqE4/edit)
-    - [April 2020](https://docs.google.com/document/d/1vaFslp46ySKX4KZUtlHJfWAFLLID9tlkcwMJgSeWuNY/edit)
-    - [May/June 2020](https://docs.google.com/document/d/16ETbYD5nTVmkGhRBLorv9DtZgKFl6ftybvuQ5o3kRLo/edit)
+  - [January 2020](https://docs.google.com/document/d/1foDiwfL1eBXc2ZphjYnAafMKJjkC8InFtMHxYZgW5UQ/edit)
+  - [February 2020](https://docs.google.com/document/d/1qdhgevtopCBIS5zaWgOtaHmc-MQiUkU3Z_rlelUX1MA/edit)
+  - [March 2020](https://docs.google.com/document/d/16BTHHUMV-PwIPWNamU5cxLom_Z9vOqgVnZ2PzeRJqE4/edit)
+  - [April 2020](https://docs.google.com/document/d/1vaFslp46ySKX4KZUtlHJfWAFLLID9tlkcwMJgSeWuNY/edit)
+  - [May/June 2020](https://docs.google.com/document/d/16ETbYD5nTVmkGhRBLorv9DtZgKFl6ftybvuQ5o3kRLo/edit)

--- a/_pages/business-units/18f/chapters/account-manager.md
+++ b/_pages/business-units/18f/chapters/account-manager.md
@@ -1,5 +1,7 @@
 ---
 title: Account Management at 18F
+questions:
+  - 18f-account-management
 ---
 
 Account Managers (AMs) at 18F are the connective tissue across 18F projects that allow us to build long-term relationships with partners and consistently help 18F project teams deliver value.

--- a/_pages/business-units/18f/chapters/design.md
+++ b/_pages/business-units/18f/chapters/design.md
@@ -2,6 +2,8 @@
 title: Design
 tags:
   - design
+questions:
+  - design
 ---
 
 The Design team at 18F includes content, user experience, front end, and visual designers as well as researchers, editors, prototypers, illustrators, and wordsmiths.

--- a/_pages/business-units/18f/chapters/engineering.md
+++ b/_pages/business-units/18f/chapters/engineering.md
@@ -1,5 +1,7 @@
 ---
 title: Engineering
+questions:
+  - dev
 ---
 
 18F Engineering is responsible for delivering high quality, robust, open source software. We also evangelize best practices relating to software testing, scalability, operations, security, and agile development.
@@ -9,10 +11,6 @@ Collectively, we’re experienced in a wide variety of technologies including Py
 ### Documentation
 
 Our [Engineering Best Practices guide](https://github.com/18F/development-guide#18f-development-guide) has details about Git, code reviews, and more. You might also enjoy the [open source](https://18f.gsa.gov/tags/open-source/) archives on the blog.
-
-### Communication
-
-If you have any questions, find us on Slack in [#dev](https://gsa-tts.slack.com/messages/dev), [#g-frontend](https://gsa-tts.slack.com/messages/g-frontend), [#g-devops](https://gsa-tts.slack.com/messages/g-devops),  [#wg-cybersec](https://gsa-tts.slack.com/messages/wg-cybersec), or [#wg-opensource](https://gsa-tts.slack.com/messages/wg-opensource).
 
 ---
 

--- a/_pages/business-units/18f/chapters/product.md
+++ b/_pages/business-units/18f/chapters/product.md
@@ -1,8 +1,10 @@
 ---
 title: Product
 tags:
-- product guide
-- product manager
+  - product guide
+  - product manager
+questions:
+  - product
 ---
 
 We use product management best practices to help teams deliver sustainable outcomes.

--- a/_pages/business-units/18f/how-18f-works/18f-bd.md
+++ b/_pages/business-units/18f/how-18f-works/18f-bd.md
@@ -1,5 +1,7 @@
 ---
 title: 18F Business Development
+questions:
+  - 18f-bd
 ---
 
 ## Who We Are

--- a/_pages/business-units/18f/how-18f-works/staffing-projects.md
+++ b/_pages/business-units/18f/how-18f-works/staffing-projects.md
@@ -1,5 +1,7 @@
 ---
 title: How We Staff Projects
+questions:
+  - 18f-staffing
 ---
 
 18F partner projects and 10x projects are staffed using a process outlined in the [staffing repo](https://github.com/18F/staffing).

--- a/_pages/business-units/18f/projects-partners/acquisition-engagement-types.md
+++ b/_pages/business-units/18f/projects-partners/acquisition-engagement-types.md
@@ -1,10 +1,12 @@
 ---
 title: Acquisition Engagements Types
 tags:
-- procurement
-- acquisitions
-- engagements
-- consulting
+  - procurement
+  - acquisitions
+  - engagements
+  - consulting
+questions:
+  - acquisition
 ---
 
 Generally speaking, there are two ways that 18F can work with a partner on a procurement - an *Acquisition Consulting Engagement* and an *Assisted Acquisition Engagement*.

--- a/_pages/business-units/18f/projects-partners/collaboration-tools.md
+++ b/_pages/business-units/18f/projects-partners/collaboration-tools.md
@@ -1,5 +1,7 @@
 ---
 title: Collaboration tools
+questions:
+  - questions
 ---
 
 Collaboration is a critical part of our work and organizational philosophy. There are a variety of tools to support our teams' collaboration and communication needs. While some tools are used often within TTS, working with an external partner may necessitate the use of a different tool that's best for the partner team and their internal IT policies.
@@ -217,4 +219,4 @@ Per the [IT Standards policy](<https://www.gsa.gov/directive/gsa-information-te
 
 > Collaboration with another agency through software or cloud services which they use for managing non-GSA data (either data owned by that agency or public data) does not require security or Section 508 compliance review, as that responsibility is assumed by the providing agency.  Other policies which may restrict the use of GSA Enterprise Accounts or the release of GSA-owned data may still apply.
 
-In other words, it is generally fine to use a tool authorized and maintained by a partner agency. If you're not sure, reach out to [ispcompliance@gsa.gov](mailto:ispcompliance@gsa.gov) and [devops@gsa.gov](mailto:devops@gsa.gov).
+In other words, it is generally fine to use a tool authorized and maintained by a partner agency. If you're not sure, ask.

--- a/_pages/business-units/18f/projects-partners/consulting-engineering-guide.md
+++ b/_pages/business-units/18f/projects-partners/consulting-engineering-guide.md
@@ -1,8 +1,8 @@
 ---
-title: Consulting engineering guide
-tag:
+title: 18F guide to consulting engineering
+questions:
+  - dev
 ---
-# 18F guide to consulting engineering
 
 Over the past few years, 18F has moved from a product organization (“we’ll build a thing for you”) to a consulting organization (“we’ll teach you to build, buy, and maintain a thing yourself”). We’ve found this to be a better fit for us and for our partners; it lets us consider not just tech but the systems in which tech operates, and it helps our partners practice the skills they need to keep building on our work long after we’re gone.
 

--- a/_pages/business-units/18f/projects-partners/how-we-relate-to-partners.md
+++ b/_pages/business-units/18f/projects-partners/how-we-relate-to-partners.md
@@ -1,7 +1,7 @@
 ---
 title: How we relate to partners
 tags:
-- consulting
+  - consulting
 ---
 
 18F's fundamental goal isn’t to implement agile, replace legacy systems, or change procurement. Our real goal is to **help each partner fulfill the mission of their agency and serve the public**.

--- a/_pages/business-units/18f/projects-partners/microrequests.md
+++ b/_pages/business-units/18f/projects-partners/microrequests.md
@@ -1,19 +1,20 @@
 ---
 title: Microrequests
+questions:
+  - microrequests
 ---
 
 ## What is a microrequest?
 
-A microrequest is a piece of carefully scoped work that can be completed quickly and without impacting the ability to complete other assigned work. This typically translates to fewer than eight hours of work in a week, and requests that should take no more than three weeks. Requests which require more resources than this will be handled on a case-by-case basis and may be handed off to the 18F staffing team or Business Development pipeline.
+A microrequest is a piece of carefully scoped work that can be completed quickly and without impacting the ability to complete other assigned work. This typically translates to fewer than eight hours of work in a week, and requests that should take no more than three weeks. Requests which require more resources than this will be handled on a case-by-case basis and may be handed off to the 18F staffing team or Business Development pipeline. 
 
 ## Is your request billable?
-
 If so, direct your request to #microrequests channel. If your tasks is non-billable, post it in #helpwanted.
 
 ## What capabilities can be extended through the microrequest process?
 
 - Writing and content strategy tasks including generative (coming up with ideas), developmental (structuring your thoughts), stylistic (checking the consistency of your voice and striking the right tone), or copy editing (checking for clarity and typos).
-- Engineering tasks including development, code/architecture reviews, security fixes, training, pairing, and more
+- Engineering tasks including development, code/architecture reviews, security fixes, training, pairing, and more 
 - Design tasks such as scoping, ideating, structuring, creating, styling, and/or refining design deliverables.
 - Something else or not sure? Ask in #microrequests and we’ll do our best to find help or direct you to the right place.
 
@@ -21,9 +22,9 @@ If so, direct your request to #microrequests channel. If your tasks is non-billa
 
 Describe your need in the #microrequests channel, where one of our channel managers will help to scope it and will then submit a [staffing request](https://github.com/18F/staffing/issues). Please do not request specific people when making your requests. The staffing leads will work to identify the right people to help you.
 
-The microrequest channel managers will make the determination about whether the description of the work matches the definition of a microrequest above. If the work is beyond the scope of a microrequest, we will make our best effort to complete the work, but will not put existing project work at risk.
+The microrequest channel managers will make the determination about whether the description of the work matches the definition of a microrequest above. If the work is beyond the scope of a microrequest, we will make our best effort to complete the work, but will not put existing project work at risk. 
 
-Requests for billable projects (including requests from CoE, PIF, Login, and Cloud) may be prioritized over non-billable work. Otherwise, microrequests will be handled on a first-come, first-served basis and according to the available resources. For example, if two requests for visual design support are made, the work will be completed in the order the request was made.
+Requests for billable projects (including requests from CoE, PIF, Login, and Cloud) may be prioritized over non-billable work. Otherwise, microrequests will be handled on a first-come, first-served basis and according to the available resources. For example, if two requests for visual design support are made, the work will be completed in the order the request was made. 
 
 ## Will microrequests always be fulfilled?
 

--- a/_pages/business-units/18f/projects-partners/microrequests.md
+++ b/_pages/business-units/18f/projects-partners/microrequests.md
@@ -1,19 +1,19 @@
 ---
 title: Microrequests
-navtitle: Microrequests
 ---
 
 ## What is a microrequest?
 
-A microrequest is a piece of carefully scoped work that can be completed quickly and without impacting the ability to complete other assigned work. This typically translates to fewer than eight hours of work in a week, and requests that should take no more than three weeks. Requests which require more resources than this will be handled on a case-by-case basis and may be handed off to the 18F staffing team or Business Development pipeline. 
+A microrequest is a piece of carefully scoped work that can be completed quickly and without impacting the ability to complete other assigned work. This typically translates to fewer than eight hours of work in a week, and requests that should take no more than three weeks. Requests which require more resources than this will be handled on a case-by-case basis and may be handed off to the 18F staffing team or Business Development pipeline.
 
 ## Is your request billable?
+
 If so, direct your request to #microrequests channel. If your tasks is non-billable, post it in #helpwanted.
 
 ## What capabilities can be extended through the microrequest process?
 
 - Writing and content strategy tasks including generative (coming up with ideas), developmental (structuring your thoughts), stylistic (checking the consistency of your voice and striking the right tone), or copy editing (checking for clarity and typos).
-- Engineering tasks including development, code/architecture reviews, security fixes, training, pairing, and more 
+- Engineering tasks including development, code/architecture reviews, security fixes, training, pairing, and more
 - Design tasks such as scoping, ideating, structuring, creating, styling, and/or refining design deliverables.
 - Something else or not sure? Ask in #microrequests and we’ll do our best to find help or direct you to the right place.
 
@@ -21,9 +21,9 @@ If so, direct your request to #microrequests channel. If your tasks is non-billa
 
 Describe your need in the #microrequests channel, where one of our channel managers will help to scope it and will then submit a [staffing request](https://github.com/18F/staffing/issues). Please do not request specific people when making your requests. The staffing leads will work to identify the right people to help you.
 
-The microrequest channel managers will make the determination about whether the description of the work matches the definition of a microrequest above. If the work is beyond the scope of a microrequest, we will make our best effort to complete the work, but will not put existing project work at risk. 
+The microrequest channel managers will make the determination about whether the description of the work matches the definition of a microrequest above. If the work is beyond the scope of a microrequest, we will make our best effort to complete the work, but will not put existing project work at risk.
 
-Requests for billable projects (including requests from CoE, PIF, Login, and Cloud) may be prioritized over non-billable work. Otherwise, microrequests will be handled on a first-come, first-served basis and according to the available resources. For example, if two requests for visual design support are made, the work will be completed in the order the request was made. 
+Requests for billable projects (including requests from CoE, PIF, Login, and Cloud) may be prioritized over non-billable work. Otherwise, microrequests will be handled on a first-come, first-served basis and according to the available resources. For example, if two requests for visual design support are made, the work will be completed in the order the request was made.
 
 ## Will microrequests always be fulfilled?
 

--- a/_pages/business-units/18f/projects-partners/working-on-an-acquisition-engagement.md
+++ b/_pages/business-units/18f/projects-partners/working-on-an-acquisition-engagement.md
@@ -1,11 +1,13 @@
 ---
 title: Work on an Acquisition Engagement
 tags:
-- procurement
-- acquisitions
-- engagements
-- consulting
-- staffing
+  - procurement
+  - acquisitions
+  - engagements
+  - consulting
+  - staffing
+questions:
+  - acquisition
 ---
 
 So you’ve been staffed to a procurement project. Here are some common questions that may come up.
@@ -48,9 +50,7 @@ However, no matter how well-versed our partners become in these practices, the r
 * **Award**: When an agency has completed the vetting and selection process for a procurement and identifies a specific vendor to work with. 
 * **Post-award**: The period after an award has been made, when the agency begins working with a specific vendor to take delivery of specific materials and artifacts as spelled out in the contract.
 
-## Where can I learn more? 
+## Where can I learn more?
 
-* Check out [related blog posts](https://18f.gsa.gov/tags/procurement/) 
-* Learn about the [two types of procurement support]({{site.baseurl}}/acquisition-engagement-types/) we can provide. 
-* Join the #acquisitions Slack channel
-
+* Check out [related blog posts](https://18f.gsa.gov/tags/procurement/)
+* Learn about the [two types of procurement support]({{site.baseurl}}/acquisition-engagement-types/) we can provide.

--- a/_pages/business-units/coe/centers-of-excellence.md
+++ b/_pages/business-units/coe/centers-of-excellence.md
@@ -1,5 +1,7 @@
 ---
 title: IT Modernization Centers of Excellence
+questions:
+  - centers-of-excellence
 ---
 
 ## Our Story

--- a/_pages/business-units/oa/OA-operational-guidance/contract-file-management.md
+++ b/_pages/business-units/oa/OA-operational-guidance/contract-file-management.md
@@ -1,5 +1,7 @@
 ---
 title: Contract File Management
+questions:
+  - tts-oa
 ---
 STANDARD OPERATING PROCEDURE: TC-17-CS4-001
 

--- a/_pages/business-units/oa/OA-operational-guidance/management-reviews-of-procurement-actions.md
+++ b/_pages/business-units/oa/OA-operational-guidance/management-reviews-of-procurement-actions.md
@@ -1,5 +1,7 @@
 ---
 title: Management Reviews of Procurement Actions
+questions:
+  - tts-oa
 ---
 STANDARD OPERATING PROCEDURE: TC-18-CS1-001
 

--- a/_pages/business-units/oa/OA-operational-guidance/tts-office-of-acquisition-team-roles-and-responsibilities.md
+++ b/_pages/business-units/oa/OA-operational-guidance/tts-office-of-acquisition-team-roles-and-responsibilities.md
@@ -1,5 +1,7 @@
 ---
 title: TTS Office of Acquisition Team Roles & Responsibilities
+questions:
+  - tts-oa
 ---
 Members of the TTS Office of Acquisition can serve in a variety of different roles. This document is designed to provide information on what to expect from each role within TTS’s Office of Acquisition team. Not all of these positions will be included on each procurement.
 

--- a/_pages/business-units/oa/oa.md
+++ b/_pages/business-units/oa/oa.md
@@ -1,5 +1,7 @@
 ---
 title: Office of Acquisition
+questions:
+  - tts-oa
 ---
 
 Welcome to TTS Office of Acquisition (OA) team page!

--- a/_pages/business-units/operations/outreach/blogging.md
+++ b/_pages/business-units/operations/outreach/blogging.md
@@ -1,8 +1,10 @@
 ---
 title: Blogging Guide
 tag:
-- blogging
-- guide
+  - blogging
+  - guide
+questions:
+  - outreach
 ---
 
 This guide helps 18F employees through the blogging process and assists them in properly framing their post so that it’s concise, readable, and achieves its goals. If you have any questions, ask them in \#blog or by email to [18f-outreach@gsa.gov](mailto:18f-outreach@gsa.gov).
@@ -214,9 +216,3 @@ The 18F blog welcomes guest authors from other government agencies. They're espe
 ### No authors
 
 On occasion, it can be useful to have posts written by 18F as an organization rather than as an individual. We may use this for posts that explain fundamental concepts of our business or culture where many team members contributed writing and editing. Posts with 18F as an author have a more formal and authoritative tone and are about statements of policy or fact rather than opinions.
-
----
-
-#### Still have questions?
-
-Ask in Slack: [#outreach](https://gsa-tts.slack.com/messages/outreach)

--- a/_pages/business-units/operations/outreach/social-media.md
+++ b/_pages/business-units/operations/outreach/social-media.md
@@ -1,10 +1,13 @@
 ---
 title: Social media
+questions:
+  - outreach
+  - tts-outreach@gsa.gov
 ---
 
 _Learn how TTS uses social media._
 
-As GSA employees, we all need to follow the [GSA Social Media Policy](https://www.gsa.gov/portal/content/180607) when posting on social media; this policy includes guidance for both official TTS social media accounts and personal use of social media. If you'd like to engage in a discussion or comment thread in your professional capacity as a GSA employee, please let the TTS Outreach team know beforehand so they can provide guidance. You can contact them in the [#outreach channel](https://gsa-tts.slack.com/messages/outreach) or via email at tts-outreach@gsa.gov. When posting on social media, always keep in mind the Hatch Act, FOIA, Ethics, and Code of Conduct.
+As GSA employees, we all need to follow the [GSA Social Media Policy](https://www.gsa.gov/portal/content/180607) when posting on social media; this policy includes guidance for both official TTS social media accounts and personal use of social media. If you'd like to engage in a discussion or comment thread in your professional capacity as a GSA employee, please let the TTS Outreach team know beforehand so they can provide guidance. When posting on social media, always keep in mind the Hatch Act, FOIA, Ethics, and Code of Conduct.
 
 If you’d like an official TTS or GSA account to tweet something or respond to a tweet let us know in [#tweet-this](https://gsa-tts.slack.com/messages/tweet-this). To see a list of the official TTS social media channels check out the [U.S. Digital Registry](https://usdigitalregistry.digitalgov.gov).
 

--- a/_pages/business-units/operations/talent/talent.md
+++ b/_pages/business-units/operations/talent/talent.md
@@ -63,10 +63,3 @@ Internal candidates can find opportunities via #tts-jobs in Slack or in the Hand
   * [#hiring](https://gsa-tts.slack.com/messages/hiring/)
 * Email:
   * [jointts@gsa.gov](mailto:jointts@gsa.gov) - for applicants, candidates, or other interested parties to contact the Talent Team. Also use this email if you'd like to submit an internal competition announcement for our review and for all hiring and onboarding related questions.
-
-
----
-
-#### Still have questions?
-
-Ask in Slack: [#hiring](https://gsa-tts.slack.com/messages/hiring/)

--- a/_pages/business-units/solutions/innovation-portfolio.md
+++ b/_pages/business-units/solutions/innovation-portfolio.md
@@ -1,5 +1,7 @@
 ---
 title: Innovation Portfolio
+questions:
+  - innovation-portfolio
 ---
 
 The Innovation Portfolio (IP) operates within GSA as part of the Technology Transformation Services (TTS) in the Office of Solutions (TTS Solutions). As a portfolio nested within an office, IP builds from the base missions of TTS and Solutions, as well as GSA overall. 

--- a/_pages/business-units/solutions/solutions-history.md
+++ b/_pages/business-units/solutions/solutions-history.md
@@ -2,6 +2,8 @@
 title: A Brief History of TTS Solutions
 redirect_from:
   - /opp-history/
+questions:
+  - solutions
 ---
 
 A brief history of TTS Solutions is hard to write: our work spans five decades and nine administrations!

--- a/_pages/business-units/solutions/tech-portfolio.md
+++ b/_pages/business-units/solutions/tech-portfolio.md
@@ -1,6 +1,5 @@
 ---
 title: TTS Technology Portfolio
-navtitle: Tech Portfolio
 redirect_from:
   - /infrastructure/
 questions:

--- a/_pages/general/who-we-are/glossary.md
+++ b/_pages/general/who-we-are/glossary.md
@@ -1,10 +1,12 @@
 ---
 title: Glossary
 tags:
-- Acronyms
-- Definitions
-- Jargon
-- Words
+  - Acronyms
+  - Definitions
+  - Jargon
+  - Words
+questions:
+  - questions
 ---
 
 * **[18F](https://18f.gsa.gov/)** - 18F develops partnerships with agencies to help them deliver exceptional digital experiences that address their strategic initiatives. They also aim to strengthen government technology practices in ways that last beyond their formal partnerships. 18F is an office within TTS.

--- a/_pages/getting-started/classes/accessibility.md
+++ b/_pages/getting-started/classes/accessibility.md
@@ -1,6 +1,7 @@
 ---
 title: Accessibility
-
+questions:
+  - g-accessibility
 ---
 
 The federal government is accountable for making all of its products 508 compliant, which means everything we make (or buy) needs to be accessible to all users, regardless of their abilities or disabilities. This usually means making sure our products can be used with screen readers and alternate input devices, and that they’re logically easy to follow.

--- a/_pages/getting-started/classes/gsa-internal-tools.md
+++ b/_pages/getting-started/classes/gsa-internal-tools.md
@@ -1,12 +1,11 @@
 ---
 title: GSA internal tools
+questions:
+  - people-ops
+  - it-issues
 ---
 
 _This post provides information on how to work with GSA's web tools and your GSA-issued equipment._
-
-## Communication
-
-If you have any questions, please ping [#teamops](https://gsa-tts.slack.com/archives/teamops) or [#it-issues](https://gsa-tts.slack.com/archives/it-issues).
 
 ## GSA tools
 

--- a/_pages/getting-started/classes/intro-to-TTS-Tech-Portfolio.md
+++ b/_pages/getting-started/classes/intro-to-TTS-Tech-Portfolio.md
@@ -1,6 +1,5 @@
 ---
 title: Intro to TTS Tech Portfolio
-navtitle: Infrastructure
 outdated: true
 ---
 

--- a/_pages/getting-started/classes/meetings-and-meeting-tools.md
+++ b/_pages/getting-started/classes/meetings-and-meeting-tools.md
@@ -1,5 +1,7 @@
 ---
 title: Meetings and meeting tools
+questions:
+  - it-issues
 ---
 
 Here, you'll find a list of tools folks at TTS use to schedule meetings, along with information about some specific meetings at TTS.

--- a/_pages/getting-started/classes/writing-lab.md
+++ b/_pages/getting-started/classes/writing-lab.md
@@ -1,6 +1,5 @@
 ---
 title: Writing Lab 101
-navtitle: Writing Lab
 ---
 
 The Writing Lab team knows that writing is hard: It can be time consuming and stress inducing, and can sometimes seem like a blocker to a project that’s humming along. That's why the Writing Lab came into being. The Lab is a virtual writing center where you can get personalized help from members of the 18F editorial team. (And, if you’re a writerly type yourself, you can join the Lab team and volunteer to help other folks with their writing and editing projects!)

--- a/_pages/getting-started/classes/writing-lab.md
+++ b/_pages/getting-started/classes/writing-lab.md
@@ -1,5 +1,7 @@
 ---
 title: Writing Lab 101
+questions:
+  - writing-lab
 ---
 
 The Writing Lab team knows that writing is hard: It can be time consuming and stress inducing, and can sometimes seem like a blocker to a project that’s humming along. That's why the Writing Lab came into being. The Lab is a virtual writing center where you can get personalized help from members of the 18F editorial team. (And, if you’re a writerly type yourself, you can join the Lab team and volunteer to help other folks with their writing and editing projects!)
@@ -11,13 +13,6 @@ The 18F Writing Lab is run by members of 18F’s editorial team, which includes 
 All Lab members volunteer their services and base their contributions on their availability at a given time. When you file an issue or ask for help in Slack, one of the Writing Lab members will offer to help and assign themselves the issue you create.
 
 The team’s collective experience is vast. Lab members hail from backgrounds in journalism, instructional design, creative writing, public media, and more. Whether you’re thinking about creating site copy or a conference presentation, someone from the Lab has the expertise to scrub in and help.
-
-## Communication
-
-Find us in Slack:
-
-- [#writing-lab](https://gsa-tts.slack.com/messages/writing-lab)
-- [#g-content](https://gsa-tts.slack.com/messages/g-content)
 
 ## Frequently asked questions
 

--- a/_pages/getting-started/equipment.md
+++ b/_pages/getting-started/equipment.md
@@ -1,5 +1,8 @@
 ---
 title: Equipment
+questions:
+  - equipment
+  - tts-equipment@gsa.gov
 ---
 
 GSA issues every TTS employee a badge, laptop, and phone. Your MacBook should be ready before your first day, but your phone may not be. The Operations Team submits phone requests to IT on your behalf, and you'll receive a confirmation email within a few weeks when your phone is ready for pickup.
@@ -122,9 +125,3 @@ If your equipment is returned to you, it may have been tampered with and should 
 ## Requirements for passwords
 
 Read the guide on [setting and managing passwords](../password-requirements/).
-
----
-
-#### Still have questions?
-
-Ask in Slack: [#equipment](https://gsa-tts.slack.com/messages/equipment), [#teamops](https://gsa-tts.slack.com/messages/teamops), or [tts-equipment@gsa.gov](mailto:tts-equipment@gsa.gov)

--- a/_pages/hiring-and-jobs/assignee-detail.md
+++ b/_pages/hiring-and-jobs/assignee-detail.md
@@ -1,10 +1,13 @@
 ---
 title: Detail Process
 tags:
-- assignees
-- detailees
-- details
-- assignee
+  - assignees
+  - detailees
+  - details
+  - assignee
+questions:
+  - people-ops
+  - PeopleOperations@gsa.gov
 ---
 
 A detail is when a person in one agency goes to work at another agency on a temporary, time-specific, and limited basis.
@@ -129,9 +132,3 @@ To learn about this process please visit the [Hiring page]({{site.baseurl}}/hiri
 ## Posting a Detail Opportunity on USAJobs
 
 USA Jobs has an [Open Opportunity](https://openopps.usajobs.gov/) section where you can post or apply to detail opportunties at other federal agencies. You must create a USAJobs account to do either.
-
---------------------------------------------------------------------------------
-
-### Still have questions?
-
-Please ping: [People-Ops](mailto:PeopleOperations@gsa.gov)

--- a/_pages/hiring-and-jobs/hiring-authorities.md
+++ b/_pages/hiring-and-jobs/hiring-authorities.md
@@ -1,10 +1,13 @@
 ---
 title: Hiring Authorities
 tags:
-- Hiring
-- hiring
-- hiring paths
-- hiring authorities
+  - Hiring
+  - hiring
+  - hiring paths
+  - hiring authorities
+questions:
+  - hiring
+  - joinTTS@gsa.gov
 ---
 This page explains the [different hiring paths within the federal government](https://www.usajobs.gov/Help/working-in-government/unique-hiring-paths/) available to TTS
 
@@ -57,9 +60,3 @@ veterans.
 * 5 Point. This class applies to veterans without a service-connected disability who meet other
 specific criteria. These criteria include the period served, whether the veteran received a campaign or
 expeditionary medal, duration, and character of active duty military service.
-
---------------------------------------------------------------------------------
-
-### Still have questions?
-
-**General questions** Please reach out to TTS Talent via [#hiring](https://gsa-tts.slack.com/messages/hiring/) or [email](mailto:jointts@gsa.gov) for information regarding hiring.

--- a/_pages/hiring-and-jobs/hiring.md
+++ b/_pages/hiring-and-jobs/hiring.md
@@ -1,8 +1,11 @@
 ---
 title: Hiring
 tags:
-- Hiring
-- hiring
+  - Hiring
+  - hiring
+questions:
+  - hiring
+  - joinTTS@gsa.gov
 ---
 
 This section provides a brief overview of the types of hiring actions along with any related process information.
@@ -100,9 +103,3 @@ It is the responsibility of the hiring manager to provide applications with the 
 ### TTS Hiring - Prioritization process
 
 For an overview of the way in which hiring actions are collected, prioritized and managed read our [TTS Hiring - Prioritization Process](https://docs.google.com/document/d/1V-7IyFIlLifgRg89TNKTS5oisOF-QdAZsWYCy7ot7AA/edit?usp=sharing)
-
---------------------------------------------------------------------------------
-
-### Still have questions?
-
-**General questions** Please reach out to TTS Talent via [#tts-jobs](https://gsa-tts.slack.com/messages/tts-jobs/) or [email](mailto:jointts@gsa.gov) for information regarding hiring.

--- a/_pages/hiring-and-jobs/promotions.md
+++ b/_pages/hiring-and-jobs/promotions.md
@@ -1,18 +1,21 @@
 ---
 title: Promotions
 tags:
-- Promotions
-- Promotions
-- promotion
-- promotion
-- raise
-- increase
-- Merit Promotion
-- merit promotion
-- Merit Promotions
-- merit promotions
-- Merit
-- merit
+  - Promotions
+  - Promotions
+  - promotion
+  - promotion
+  - raise
+  - increase
+  - Merit Promotion
+  - merit promotion
+  - Merit Promotions
+  - merit promotions
+  - Merit
+  - merit
+questions:
+  - hiring
+  - joinTTS@gsa.gov
 ---
 
 This page provides an overview of the Merit Promotion Process for both Competitive Service (Career) and Excepted Service positions.
@@ -86,9 +89,3 @@ Virtual trainings and information on writing a resume, navigating USAJobs, and g
 - <https://www.opm.gov/policy-data-oversight/hiring-information/competitive-hiring/>
 - <https://www.opm.gov/policy-data-oversight/pay-leave/pay-administration/fact-sheets/promotions/>
 - <https://insite.gsa.gov/topics/hr-pay-and-leave/hiring-and-staffing/supervisor-staffing-guide>
-
---------------------------------------------------------------------------------
-
-### Still have questions?
-
-Please reach out to TTS Talent via [#hiring](https://gsa-tts.slack.com/messages/hiring/) or [email](mailto:jointts@gsa.gov) for information regarding promotions.

--- a/_pages/hiring-and-jobs/resume.md
+++ b/_pages/hiring-and-jobs/resume.md
@@ -1,7 +1,9 @@
 ---
 title: Writing a federal government resume
 tags:
-- resume
+  - resume
+questions:
+  - joinTTS@gsa.gov
 ---
 
 This page provides an overview with examples of how to write a federal government resume, which have content and formatting that differ from most private sector resumes.  
@@ -190,9 +192,3 @@ Title: The Best Boss
 Email: teamlead@awesomeboss.com  
 
 `While I listed references on my resume, it’s not required. The hiring folks wouldn’t cold call your references, they’d ask you for their contact information later on in the process.`
-
---------------------------------------------------------------------------------
-
-### Still have questions?
-
-Please reach out to the TTS Talent Team by emailing [jointts@gsa.gov](mailto:jointts@gsa.gov).

--- a/_pages/hiring-and-jobs/term-extensions.md
+++ b/_pages/hiring-and-jobs/term-extensions.md
@@ -1,5 +1,7 @@
 ---
 title: Term extensions
+questions:
+  - people-ops
 ---
 
 Many TTS employees are hired on term appointments (under the Schedule A direct hiring authority), which sets a limit of 2 years for the initial period of employment with the option to renew for up to 2 additional years for a maximum term of 4 years.
@@ -47,9 +49,3 @@ Term renewals are not automatic. They require a lot of thought and deliberation 
 - HR reviews and confirms the PAR, checking that all information is accurate (employee has another term left, correct extension dates, etc.). HR is not "approving" the extension request at this step of the process. The extension has already been approved; this is just a matter of processing.
 - HR sends the approved PAR to CPC (Consolidated Processing Center in Kansas City, MO) to have it processed.
 - CPC processes the PAR. They process all approved personnel actions in GSA systems and complete the SF50, which is attached to your personnel record and can be viewed in HR Links. They process PARs based on action date, which is why you will not see the updates in HR Links or our internal systems until the extension date.
-
----
-
-### Still have questions?
-
-Please contact [#people-ops](https://gsa-tts.slack.com/messages/people-ops).

--- a/_pages/hiring-and-jobs/unconscious-bias.md
+++ b/_pages/hiring-and-jobs/unconscious-bias.md
@@ -1,9 +1,12 @@
 ---
 title: Unconscious Bias
 tags:
-- Unconscious Bias
-- unconscious
-- bias
+  - Unconscious Bias
+  - unconscious
+  - bias
+questions:
+  - hiring
+  - joinTTS@gsa.gov
 ---
 
 Remember that we all have unconscious bias, and that hiring is especially susceptible to bias. However, when we recognize and accept bias we can be on the lookout and it’ll be less likely to unconsciously guide our decisions.

--- a/_pages/how-we-work/accessing-dod-systems.md
+++ b/_pages/how-we-work/accessing-dod-systems.md
@@ -1,10 +1,12 @@
 ---
 title: Accessing DoD Systems
 tags:
-- dod
-- intelligence
-- security
-- system-access
+  - dod
+  - intelligence
+  - security
+  - system-access
+questions:
+  - portfolio-nat-security
 ---
 
 ## Certificate errors
@@ -29,7 +31,4 @@ When filling out the specific fields on the SAAR form:
 * Part II / Section 13: Justification for access should be the simplest, most straight forward way of expressing your need.
 * You may attempt to submit the form without filling out Part III. DoD agencies typically don't care that we have [public trust (moderate risk) investigations]({{site.baseurl}}/top-secret/). If they do care, then you'll need to get the SAAR form signed by the GSA security manager's team. Take a look at the [PERSEC insite page](https://insite.gsa.gov/organizations/staff-offices/office-of-mission-assurance/divisions-program-offices/personnel-security-division) and contact the branch deputy.
 
-
-## Questions / Problems
-
-If you run into issues getting your SAAR form approved, please contact your Account Manager, or the National Security & Intelligence Portfolio manager. You can also post questions about this process to the #portfolio-nat-security channel in Slack.
+If you run into issues getting your SAAR form approved, please contact your Account Manager, or the National Security & Intelligence Portfolio manager.

--- a/_pages/how-we-work/agreements.md
+++ b/_pages/how-we-work/agreements.md
@@ -1,5 +1,8 @@
 ---
 title: Agreements
+questions:
+  - iaa
+  - tts.agreements@gsa.gov
 ---
 
 TTS is a fee-for-service organization. Federal law requires that any agreement between agencies be recorded in some manner.

--- a/_pages/how-we-work/procurements-over-10000.md
+++ b/_pages/how-we-work/procurements-over-10000.md
@@ -86,14 +86,3 @@ Buying something over $10,000 means that the Office of Acquisition (OA) needs to
 ### Contract close out
 
 After all work under a contract has been delivered, it is time to close out the contract. To initiate the contract closeout process, your CO will ask you for a final report of the services and/or products received and the contractor’s final invoice. The CO will also confirm with the OCFO that all payment has been made to the contractor. Generally, a contract will be considered complete after the CO receives this information and your CO prepares a contract completion statement. After your CO marks the contract closed in the contract writing system, the contract is officially closed and you are finished. On to the next!
-
-## Still have questions?
-
-Ask in Slack: [#tts-oa](https://gsa-tts.slack.com/messages/tts-oa)
-
-
-
-
-
-
-

--- a/_pages/how-we-work/research-guidelines.md
+++ b/_pages/how-we-work/research-guidelines.md
@@ -1,13 +1,15 @@
 ---
 title: Doing research at TTS
+questions:
+  - g-research
 ---
 
 Research isn’t only usability testing. Testing our assumptions by actively engaging with the world around us is at the heart of how TTS works. We do research when we meet with stakeholders to learn about a project, when we investigate and compare tools and systems, and when we find members of the public to tell us about their experiences with the federal government. Research can include questionnaires and surveys, as well as analytics.
 
 These guidelines should be familiar to anyone who's done research in the private sector or in academia. However, as public servants, we need to make sure that we're following a few basic principles.
 
-- **Respect**: We honor people's opinions and choices, only blocking actions that are obviously going to harm others. We make sure that anyone participating in our research is doing so of their own free will, and that they have enough information to make that decision responsibly.
-- **Beneficence**: We do our best to further people's best interests, and we avoid actions that might hurt them. This goal extends to society at large: before doing research, we need to consider whether what we're doing is in the best interests not just of individual participants but of the organizations and the country that we serve.
+- **Respect**: We honor people's opinions and choices, only blocking actions that are obviously going to harm others. We make sure that anyone participating in our research is doing so of their own free will, and that they have enough information to make that decision responsibly.  
+- **Beneficence**: We do our best to further people's best interests, and we avoid actions that might hurt them. This goal extends to society at large: before doing research, we need to consider whether what we're doing is in the best interests not just of individual participants but of the organizations and the country that we serve.  
 - **Justice**: We do our best to ensure that we compensate research participants in some way for the time and energy that they contribute. We don't have to pay money, but we do have to give something back to participants. Sometimes that means just saying "thank you" and letting them know how much their input has helped improve government services. Other times, it can mean making a card or handing out cookies or fruit. Participation incentives, which are common in the private sector, are more tricky here in government. So please ask one of the Research Guild leaders if you think they're necessary for a specific study.
 
 While only scholarly researchers are strictly obligated to follow these principles, they are widely accepted in the United States as [a set of overarching values](https://www.hhs.gov/ohrp/regulations-and-policy/belmont-report/index.html#xethical) guiding all investigations involving humans.
@@ -26,7 +28,8 @@ TTS researchers have an obligation to ensure that our participants know what it 
 
 TTS gets explicit consent from anyone who participates in our moderated research, generally by asking that our research participants sign a "design research participant agreement". TTS maintains a [template](https://docs.google.com/document/d/16qg58Hn92UlXLsi-2taizi7qe5mvQ3LMSkcvyHk8Bdo/edit) for internal use, and an [example participant agreement](https://methods.18f.gov/participant-agreement/) for sharing with interested parties. Please make a copy of the participant agreement document template, put it into your project folder, and edit the highlighted text for each of your research studies. If your participants are likely not fully literate in English, consider having the form translated to the correct language or working out a process for verbal consent using a translator.
 
-When sending participant agreements electronically, please use our [participant agreement email template](https://docs.google.com/document/d/1t01t_eLYWJXuKdJkhiyBqkWf4Yr5XsFAbNv-BDAZqzE/edit). This template clearly specifies how people can opt out of a study and/or request that we do not contact them in the future.
+When sending participant agreements electronically, please use our [participant agreement email template](https://docs.google.com/document/d/1t01t_eLYWJXuKdJkhiyBqkWf4Yr5XsFAbNv-BDAZqzE/edit
+). This template clearly specifies how people can opt out of a study and/or request that we do not contact them in the future.
 
 ## Managing Personally Identifiable Information (PII)
 
@@ -48,7 +51,7 @@ with PII always makes that PII sensitive. However, determining what is and isn't
 
 Much of our research involves federal employees. When we are talking to federal employees (not contractors, and not vendors) about their work, they generally have no reasonable expectation of privacy. After all, the material may have to be disclosed pursuant to a judge's order, a Congressional request, or a FOIA request.
 
-As researchers, however, we need to follow the principle of beneficence. So just following the legal guidelines on PII isn't enough if you're collecting information that you know might harm or embarrass your participants if it became generally known, _whether or not those participants are federal employees_. Different agencies and organizations may have different levels of sensitivity and exposure concerns about types of personal information (identifying or not) you collect and how you use it. Attributing quotations with agency affiliation, for example, may be more sensitive than first name and photo. In those cases, the principle of beneficence demands that we think carefully about protecting participants before sharing working notes or finished reports, even if we have satisfied the law.
+As researchers, however, we need to follow the principle of beneficence. So just following the legal guidelines on PII isn't enough if you're collecting information that you know might harm or embarrass your participants if it became generally known, _whether or not those participants are federal employees_. Different agencies and organizations may have different levels of sensitivity and exposure concerns about types of personal information (identifying or not) you collect and how you use it. Attributing quotations with agency affiliation, for example, may be more sensitive than first name and photo. In those cases, the principle of beneficence demands that we think carefully about protecting participants before sharing working notes or finished reports, even if we have satisfied the law.   
 
 ### Storing PII and sharing research data
 
@@ -60,8 +63,10 @@ Be especially mindful about using Slack during interviews for sidebar conversati
 
 Carefully restricting access to personally identifiable information is a matter not just of people's right to respect but of their right to [privacy](https://methods.18f.gov/privacy/). For more information, please see the [Design research privacy impact assessment (PIA)](https://www.gsa.gov/cdnstatic/20200401_-_Design_Research_PIA_for%20posting.pdf), or [this 30-minute overview of privacy as it relates to research](https://gsa-tts.slack.com/files/U9KLLKS4W/FCSFWBZD3/researchguildprivacytalk091218.mp4) narrated by the GSA Privacy Office.
 
+
 **Bottom line: If you have questions about sharing information, just ask.** See the page on [sensitive information]({{site.baseurl}}/sensitive-information/). If you're not sure if you're collecting PII or need help with policy guidance, you can ask on Slack in [#g-research](https://gsa-tts.slack.com/archives/g-research). If you are not sure where the right place might be to store any given file, or what access permissions to grant, you can [ask the Tech Portfolio]({{site.baseurl}}/tech-portfolio/#questions).
+
 
 ## Join the research guild!
 
-The Guild talks in [#g-research](https://gsa-tts.slack.com/archives/g-research) and meets once a week to discuss the theory and practice of asking questions.
+The Guild meets once a week to discuss the theory and practice of asking questions.

--- a/_pages/how-we-work/research-guidelines.md
+++ b/_pages/how-we-work/research-guidelines.md
@@ -1,14 +1,13 @@
 ---
 title: Doing research at TTS
-navtitle: Research guidelines
 ---
 
 Research isn’t only usability testing. Testing our assumptions by actively engaging with the world around us is at the heart of how TTS works. We do research when we meet with stakeholders to learn about a project, when we investigate and compare tools and systems, and when we find members of the public to tell us about their experiences with the federal government. Research can include questionnaires and surveys, as well as analytics.
 
 These guidelines should be familiar to anyone who's done research in the private sector or in academia. However, as public servants, we need to make sure that we're following a few basic principles.
 
-- **Respect**: We honor people's opinions and choices, only blocking actions that are obviously going to harm others. We make sure that anyone participating in our research is doing so of their own free will, and that they have enough information to make that decision responsibly.  
-- **Beneficence**: We do our best to further people's best interests, and we avoid actions that might hurt them. This goal extends to society at large: before doing research, we need to consider whether what we're doing is in the best interests not just of individual participants but of the organizations and the country that we serve.  
+- **Respect**: We honor people's opinions and choices, only blocking actions that are obviously going to harm others. We make sure that anyone participating in our research is doing so of their own free will, and that they have enough information to make that decision responsibly.
+- **Beneficence**: We do our best to further people's best interests, and we avoid actions that might hurt them. This goal extends to society at large: before doing research, we need to consider whether what we're doing is in the best interests not just of individual participants but of the organizations and the country that we serve.
 - **Justice**: We do our best to ensure that we compensate research participants in some way for the time and energy that they contribute. We don't have to pay money, but we do have to give something back to participants. Sometimes that means just saying "thank you" and letting them know how much their input has helped improve government services. Other times, it can mean making a card or handing out cookies or fruit. Participation incentives, which are common in the private sector, are more tricky here in government. So please ask one of the Research Guild leaders if you think they're necessary for a specific study.
 
 While only scholarly researchers are strictly obligated to follow these principles, they are widely accepted in the United States as [a set of overarching values](https://www.hhs.gov/ohrp/regulations-and-policy/belmont-report/index.html#xethical) guiding all investigations involving humans.
@@ -27,8 +26,7 @@ TTS researchers have an obligation to ensure that our participants know what it 
 
 TTS gets explicit consent from anyone who participates in our moderated research, generally by asking that our research participants sign a "design research participant agreement". TTS maintains a [template](https://docs.google.com/document/d/16qg58Hn92UlXLsi-2taizi7qe5mvQ3LMSkcvyHk8Bdo/edit) for internal use, and an [example participant agreement](https://methods.18f.gov/participant-agreement/) for sharing with interested parties. Please make a copy of the participant agreement document template, put it into your project folder, and edit the highlighted text for each of your research studies. If your participants are likely not fully literate in English, consider having the form translated to the correct language or working out a process for verbal consent using a translator.
 
-When sending participant agreements electronically, please use our [participant agreement email template](https://docs.google.com/document/d/1t01t_eLYWJXuKdJkhiyBqkWf4Yr5XsFAbNv-BDAZqzE/edit
-). This template clearly specifies how people can opt out of a study and/or request that we do not contact them in the future.
+When sending participant agreements electronically, please use our [participant agreement email template](https://docs.google.com/document/d/1t01t_eLYWJXuKdJkhiyBqkWf4Yr5XsFAbNv-BDAZqzE/edit). This template clearly specifies how people can opt out of a study and/or request that we do not contact them in the future.
 
 ## Managing Personally Identifiable Information (PII)
 
@@ -50,7 +48,7 @@ with PII always makes that PII sensitive. However, determining what is and isn't
 
 Much of our research involves federal employees. When we are talking to federal employees (not contractors, and not vendors) about their work, they generally have no reasonable expectation of privacy. After all, the material may have to be disclosed pursuant to a judge's order, a Congressional request, or a FOIA request.
 
-As researchers, however, we need to follow the principle of beneficence. So just following the legal guidelines on PII isn't enough if you're collecting information that you know might harm or embarrass your participants if it became generally known, _whether or not those participants are federal employees_. Different agencies and organizations may have different levels of sensitivity and exposure concerns about types of personal information (identifying or not) you collect and how you use it. Attributing quotations with agency affiliation, for example, may be more sensitive than first name and photo. In those cases, the principle of beneficence demands that we think carefully about protecting participants before sharing working notes or finished reports, even if we have satisfied the law.   
+As researchers, however, we need to follow the principle of beneficence. So just following the legal guidelines on PII isn't enough if you're collecting information that you know might harm or embarrass your participants if it became generally known, _whether or not those participants are federal employees_. Different agencies and organizations may have different levels of sensitivity and exposure concerns about types of personal information (identifying or not) you collect and how you use it. Attributing quotations with agency affiliation, for example, may be more sensitive than first name and photo. In those cases, the principle of beneficence demands that we think carefully about protecting participants before sharing working notes or finished reports, even if we have satisfied the law.
 
 ### Storing PII and sharing research data
 
@@ -62,9 +60,7 @@ Be especially mindful about using Slack during interviews for sidebar conversati
 
 Carefully restricting access to personally identifiable information is a matter not just of people's right to respect but of their right to [privacy](https://methods.18f.gov/privacy/). For more information, please see the [Design research privacy impact assessment (PIA)](https://www.gsa.gov/cdnstatic/20200401_-_Design_Research_PIA_for%20posting.pdf), or [this 30-minute overview of privacy as it relates to research](https://gsa-tts.slack.com/files/U9KLLKS4W/FCSFWBZD3/researchguildprivacytalk091218.mp4) narrated by the GSA Privacy Office.
 
-
 **Bottom line: If you have questions about sharing information, just ask.** See the page on [sensitive information]({{site.baseurl}}/sensitive-information/). If you're not sure if you're collecting PII or need help with policy guidance, you can ask on Slack in [#g-research](https://gsa-tts.slack.com/archives/g-research). If you are not sure where the right place might be to store any given file, or what access permissions to grant, you can [ask the Tech Portfolio]({{site.baseurl}}/tech-portfolio/#questions).
-
 
 ## Join the research guild!
 

--- a/_pages/how-we-work/sensitive-information.md
+++ b/_pages/how-we-work/sensitive-information.md
@@ -1,5 +1,7 @@
 ---
 title: Sensitive information
+questions:
+  - questions
 ---
 
 Here's what you need to know about sensitive information at TTS.

--- a/_pages/performance-management/mid-year-hrlinks-steps.md
+++ b/_pages/performance-management/mid-year-hrlinks-steps.md
@@ -1,13 +1,15 @@
 ---
 title: Mid Year Performance Management HRLinks Steps
 tags:
-- Performance
-- Performance
-- Performance management
-- Performance review
-- review
-- HR links
-- HRLinks steps
+  - Performance
+  - Performance
+  - Performance management
+  - Performance review
+  - review
+  - HR links
+  - HRLinks steps
+questions:
+  - people-ops
 ---
 
 This page contains step-by-step instructions for employees and supervisors on how to complete the mid-year performance review cycle in HR Links.
@@ -109,10 +111,3 @@ A supervisor can acknowledge an employee evaluation if the employee is unable to
 * Step-by-step instructions:
   * No action required by employee
   * [Supervisor](https://docs.google.com/document/d/1iduOW_V1NNqGnZkm7TAwzzr4oIZPZW3UG-f1QdaLD-w/edit#heading=h.u17jlta6re6m)
-
-
---------------------------------------------------------------------------------
-
-### Still have questions?
-
-Ask [#people-ops](https://gsa-tts.slack.com/messages/people-ops)

--- a/_pages/performance-management/mid-year.md
+++ b/_pages/performance-management/mid-year.md
@@ -1,11 +1,13 @@
 ---
 title: Performance Management Mid Year Review
 tags:
-- Performance
-- Performance management
-- Performance review
-- review
-- mid year
+  - Performance
+  - Performance management
+  - Performance review
+  - review
+  - mid year
+questions:
+  - people-ops
 ---
 
 This page contains important dates, links, and information for the mid year performance review cycle.  Please see the [Mid Year Performance Management HRLinks Steps page]({{site.baseurl}}/mid-year-hrlinks-steps/) for guided instructions.
@@ -41,9 +43,3 @@ Resource | Use
   * **AFGE Union members:** a rating is required for each critical element of the performance plan and you must also inform the employee whether his/her overall performance to date remains consistent with the summary rating received on the last annual rating of record.
   * **NFFE Union members:** a rating is NOT required for each critical element but you must inform the employee whether his/her overall performance to date remains consistent with the summary rating received on the last annual rating of record. It is recommended that manager comments are documented in the GSA Elements Summary section in HR Links.
   * **Non-union employees:** a rating and/or comments is not required.
-
---------------------------------------------------------------------------------
-
-### Still have questions?
-
-Ask [#people-ops](https://gsa-tts.slack.com/messages/people-ops)

--- a/_pages/performance-management/performance-management-dates.md
+++ b/_pages/performance-management/performance-management-dates.md
@@ -1,11 +1,13 @@
 ---
 title: Performance Management Important Dates
 tags:
-- Performance
-- Performance
-- Performance management
-- Performance review
-- review
+  - Performance
+  - Performance
+  - Performance management
+  - Performance review
+  - review
+questions:
+  - people-ops
 ---
 
 This page contains important dates for the mid year and end of year performance review cycles.
@@ -34,9 +36,3 @@ October 23, 2020 | Audit of Employee self-assessment completion
 Oct 23 - Nov 6, 2020 | Supervisors hold 1:1 performance review meetings with their direct reports
 November 9, 2020 | TTS Internal ask due date to close out FY20 performance plans if not completed during 1:1s
 November 16, 2020 | Official GSA end of year close out due date for FY20 performance plans in HR Links
-
---------------------------------------------------------------------------------
-
-### Still have questions?
-
-Ask [#people-ops](https://gsa-tts.slack.com/messages/people-ops)

--- a/_pages/performance-management/performance-management-employee-resources.md
+++ b/_pages/performance-management/performance-management-employee-resources.md
@@ -1,12 +1,14 @@
 ---
 title: Performance Management Employee Resources
 tags:
-- Performance
-- Performance
-- Performance management
-- Performance review
-- review
-- employee resources
+  - Performance
+  - Performance
+  - Performance management
+  - Performance review
+  - review
+  - employee resources
+questions:
+  - people-ops
 ---
 
 This page contains additional resources and trainings for employees who are going through the performance management process.  Visit the Quick Links section of the [Performance Management Overview]({{site.baseurl}}/performance-management/) page for the Performance Management Employee Checklist.  
@@ -76,9 +78,3 @@ Courses include, but is not limited to the following:
 * Recognizing and Diagnosing a Performance Problem – Learn the importance of recognizing and managing poor performance timely.
 * Planning an Effective Appraisal - “Newly added” Learn to how to prepare and conduct an effective appraisal of performance.
 * Awards – Learn about the available awards within GSA.
-
---------------------------------------------------------------------------------
-
-### Still have questions?
-
-Ask [#people-ops](https://gsa-tts.slack.com/messages/people-ops)

--- a/_pages/performance-management/performance-management-hrlinks-steps.md
+++ b/_pages/performance-management/performance-management-hrlinks-steps.md
@@ -1,13 +1,15 @@
 ---
 title: End of Year Performance Management HRLinks Steps
 tags:
-- Performance
-- Performance
-- Performance management
-- Performance review
-- review
-- HR links
-- HRLinks steps
+  - Performance
+  - Performance
+  - Performance management
+  - Performance review
+  - review
+  - HR links
+  - HRLinks steps
+questions:
+  - people-ops
 ---
 
 This page contains step-by-step instructions for employees and supervisors on how to process and approve performance plans in HR Links for the end of year performance review cycle.
@@ -151,9 +153,3 @@ It is critical that all FY20 performance plan evaluations are acknowledged by em
 ### Selecting Time Off Award in lieu of cash performance award
 
 Information will be updated pending guidance from GSA.
-
---------------------------------------------------------------------------------
-
-### Still have questions?
-
-Ask [#people-ops](https://gsa-tts.slack.com/messages/people-ops)

--- a/_pages/performance-management/performance-management-supervisor-resources.md
+++ b/_pages/performance-management/performance-management-supervisor-resources.md
@@ -1,12 +1,14 @@
 ---
 title: Performance Management Supervisor Resources
 tags:
-- Performance
-- Performance
-- Performance management
-- Performance review
-- review
-- supervisor resources
+  - Performance
+  - Performance
+  - Performance management
+  - Performance review
+  - review
+  - supervisor resources
+questions:
+  - people-ops
 ---
 
 This page contains additional resources and trainings for supervisors who are going through the performance management process.  Visit the Quick Links section of the [Performance Management Overview]({{site.baseurl}}/performance-management/) page for additional resources, including the [Performance Management Employee Checklist](https://docs.google.com/spreadsheets/d/1nhV-jGGygdNgKfYJEamKAVux5eBW5rf5Lj1maXFUt08/edit#gid=160010559) which Supervisors can use to track the progress of their own performance reviews.  
@@ -153,9 +155,3 @@ Courses include, but is not limited to the following:
   * Recognizing and Diagnosing a Performance Problem – Learn the importance of recognizing and managing poor performance timely.
   * Planning an Effective Appraisal - “Newly added” Learn to how to prepare and conduct an effective appraisal of performance.
   * Awards – Learn about the available awards within GSA.
-
---------------------------------------------------------------------------------
-
-### Still have questions?
-
-Ask [#people-ops](https://gsa-tts.slack.com/messages/people-ops)

--- a/_pages/performance-management/performance-management.md
+++ b/_pages/performance-management/performance-management.md
@@ -1,15 +1,17 @@
 ---
 title: Performance Management Overview
 tags:
-- Performance
-- Performance
-- Performance
-- Performance
-- Performance
-- Performance
-- Performance management
-- Performance review
-- review
+  - Performance
+  - Performance
+  - Performance
+  - Performance
+  - Performance
+  - Performance
+  - Performance management
+  - Performance review
+  - review
+questions:
+  - people-ops
 ---
 
 This page contains performance management quicklinks, important dates, and guidance for employees and supervisors.  Visit the [development and training]({{site.baseurl}}/development-and-training/) page for opportunities within GSA that are available to TTS employees
@@ -57,9 +59,3 @@ Information will be updated pending guidance from GSA.
     * Mid-Year Self-Assessment
     * Acknowledge a Mid-Year Progress Review
     * Acknowledge an Evaluation
-
---------------------------------------------------------------------------------
-
-### Still have questions?
-
-Ask [#people-ops](https://gsa-tts.slack.com/messages/people-ops)

--- a/_pages/policies/business-and-ops-policies/top-secret.md
+++ b/_pages/policies/business-and-ops-policies/top-secret.md
@@ -1,12 +1,17 @@
 ---
 title: Top Secret / Sensitive Compartmented Information (TS/SCI) Clearance
 tags:
-- secret
-- clearance
-- top
-- security
+  - secret
+  - clearance
+  - top
+  - security
+questions:
+  - people-ops
+  - TTS-PeopleOps@gsa.gov
 ---
 Most TTS employees hold moderate risk Public Trust positions. However, for certain projects, partners need TTS employees to have access to classified national security information. These employees need to be granted security clearance eligibility (a.k.a a security clearance) to be able to view this information. This page covers the basics like clearance levels, your clearance status, your clearance obligations, and clearance upgrade requests.
+
+The Center for Development of Security Excellence's [Personnel Security page](https://www.cdse.edu/catalog/personnel-security.html) is GSA's recommended go-to source to learn about security clearances in depth.
 
 ## Clearance Levels
 There are [three national security clearance levels](https://en.wikipedia.org/wiki/List_of_U.S._security_clearance_terms): Confidential, Secret, and Top Secret. Work deemed Critical Sensitive requires a Top Secret clearance. Special Sensitive work requires access to Sensitive Compartmented Information and therefore a Top Secret / Sensitive Compartmented Information (TS/SCI) clearance. When TTS employees need a clearance, it is typically a TS/SCI.
@@ -63,10 +68,3 @@ The People Ops Team will contact GSA HR Classification and work with HR and the 
   * This delay is due to the backlogs at OPM. The SCI portion is controlled by the Central Intelligence Agency (CIA) and can only be requested after the TS is complete.  You should plan an additional 4-6 weeks for that process.
   
 ### 7. When a clearance has been approved, the assigned adjudicator from the Security Office will inform you directly and provide you further instructions. 
-
-
---------------------------------------------------------------------------------
-
-## Have questions?
-
-The Center for Development of Security Excellence's [Personnel Security page](https://www.cdse.edu/catalog/personnel-security.html) is GSA's recommended go-to source to learn about security clearances in depth. Ask [#people-ops](https://gsa-tts.slack.com/messages/people-ops) or [TTS-PeopleOps@gsa.gov](mailto:TTS-PeopleOps@gsa.gov)

--- a/_pages/policies/employee-resources-policies/overtime-and-comp-time.md
+++ b/_pages/policies/employee-resources-policies/overtime-and-comp-time.md
@@ -1,12 +1,13 @@
 ---
 title: Overtime and comp-time policy
 tags:
-- Overtime
-- over time
-- over-time
-- comp
-- comp-time
-- comptime
+  - Overtime
+  - over time
+  - over-time
+  - comp
+  - comp-time
+  - comptime
+questions:
+  - people-ops
+  - TTS-PeopleOps@gsa.gov
 ---
-
-Please reach out to TTS Talent via [#people-ops](https://gsa-tts.slack.com/messages/people-ops/) or [email](mailto:TTS-PeopleOps@gsa.gov) for information regarding overtime and comp time.

--- a/_pages/policies/employee-resources-policies/telework-agreement-new-ft.md
+++ b/_pages/policies/employee-resources-policies/telework-agreement-new-ft.md
@@ -1,10 +1,13 @@
 ---
 title: TTS Telework - How to submit Full Time Telework Agreement for new hires
 tags:
-- remote
-- telework
-- virtual
-- home
+  - remote
+  - telework
+  - virtual
+  - home
+questions:
+  - people-ops
+  - hrlinks@gsa.gov
 ---
 
 This is a short How-To guide for new employees in full time telework positions to quickly and easily submit your Telework Agreement through HR Links. In most, if not all cases, new employees that are “Virtual” in the final job offer have had initial telework documentation completed by their supervisors or the talent team. The Telework Agreement is still needed, but with those pre-approvals in place, the following steps should work for you.
@@ -55,10 +58,3 @@ Fill out the form using the following information for Part A:
 2. Save/Submit the form. 
 
 <img src="{{site.baseurl}}/images/hrlinks/ft-telework-3.png" alt="Screenshot of Employee Signature form section" />
-
-
---------------------------------------------------------------------------------
-
-### Still have questions?
-
-Please ping: [People Ops](https://gsa-tts.slack.com/messages/people-ops) or send an email to [hrlinks@gsa.gov](mailto:hrlinks@gsa.gov)

--- a/_pages/policies/employee-resources-policies/telework.md
+++ b/_pages/policies/employee-resources-policies/telework.md
@@ -1,10 +1,13 @@
 ---
 title: TTS Telework Guidance
 tags:
-- remote
-- telework
-- virtual
-- home
+  - remote
+  - telework
+  - virtual
+  - home
+questions:
+  - people-ops
+  - TTS-PeopleOps@gsa.gov
 ---
 
 A core belief of TTS is, “Work is what we do, not where we are.”  The goal of this TTS telework guidance is not to recreate or augment GSA policy but to answer the top telework questions and provide clarity around how often TTS employees can telework.  
@@ -77,9 +80,3 @@ Employees and supervisors must discuss pros and cons of becoming a full-time tel
   * Agency Impact:   Does TTS or GSA benefit from you being a full-time teleworker?  
 
   * Position:  Does your position description have any restrictions?  For example Administrative Support Specialists must report to an office and cannot be full-time teleworkers.
-
---------------------------------------------------------------------------------
-
-### Still have questions?
-
-Please ping: [Talent](https://gsa-tts.slack.com/messages/people-ops) or send an email to [TTS-PeopleOps@gsa.gov](mailto:TTS-PeopleOps@gsa.gov)

--- a/_pages/policies/employee-resources-policies/transit-benefit.md
+++ b/_pages/policies/employee-resources-policies/transit-benefit.md
@@ -1,11 +1,13 @@
 ---
 title: Transit Benefit
 tags:
-- transit
-- benefit
-- subsidy
-- transportation
-- public
+  - transit
+  - benefit
+  - subsidy
+  - transportation
+  - public
+questions:
+  - co-transit-subsidy@gsa.gov
 ---
 This page outlines how to sign up for and how to cancel the transit benefit.
 
@@ -55,7 +57,3 @@ Use `T-TECH TRANSFORMATION SERVICE` as your organizational code.  Make sure to s
 - Click on **Withdraw from the program**
 - Click **Continue**
 - Fill out and submit the form
-
-## Contact
-
-GSA's new Point of Contact for the transit subsidy program (CommuterConnections) is CO Transit Subsidy: [co-transit-subsidy@gsa.gov](mailto:co-transit-subsidy@gsa.gov).

--- a/_pages/policies/tech-policies/records-management.md
+++ b/_pages/policies/tech-policies/records-management.md
@@ -1,5 +1,7 @@
 ---
 title: Records management
+questions:
+  - legalstuff
 ---
 
 This page outlines how to properly treat federal records.
@@ -7,7 +9,7 @@ This page outlines how to properly treat federal records.
 ## Guidelines
 
 All GSA employees are responsible for records management. The widespread use of electronic mail (gmail) and electronic records through GSA’s online applications has highlighted the need for everyone to understand how to determine which documents are Federal records and how to manage them effectively. Records serve a number of purposes, including:
-  
+
   * planning administrative and program needs
   * documenting GSA activities
   * protecting the agency's legal and financial rights
@@ -18,9 +20,3 @@ All GSA employees are responsible for records management. The widespread use of 
 Records are critical to an organization to function effectively and efficient. [Visit GSA Insite Records Management Page](https://insite.gsa.gov/topics/directives-forms-and-regulations/records-management) for general procedures on identifying Federal records, determining what documents are needed to document Agency activities, for official files and managing records in accordance with the law.
 
 See also: [Records Management Primer for websites](https://drive.google.com/file/d/1Uew53TWW9Gx-N6gYzZE63_0SZlHBPxwc/view).
-
----
-
-#### Still have questions?
-
-Ask in Slack: [#legalstuff](https://gsa-tts.slack.com/messages/legalstuff/)

--- a/_pages/software-tools/github.md
+++ b/_pages/software-tools/github.md
@@ -2,6 +2,10 @@
 title: GitHub
 tag:
   - Git
+questions:
+  - git
+  - admins-github
+  - dev
 ---
 
 GitHub is a closed-source platform for [open-source](https://github.com/18F/open-source-policy) communities. It allows us to collaborate on documentation and code, both internally and with a broader audience.
@@ -193,9 +197,3 @@ We automate some administration of our repositories - see [`ghad`](https://githu
 - [Githug](https://github.com/Gazler/githug) is designed to give you a practical way of learning git. It has a series of levels, each requiring you to use git commands to arrive at a correct answer.
 
 - [Try Git](https://try.github.io/levels/1/challenges/1)
-
----
-
-#### Still have questions?
-
-Ask in Slack: [#git](https://gsa-tts.slack.com/messages/git), [#admins-github](https://gsa-tts.slack.com/messages/admins-github), [#dev](https://gsa-tts.slack.com/messages/dev)

--- a/_pages/software-tools/google-drive.md
+++ b/_pages/software-tools/google-drive.md
@@ -2,6 +2,8 @@
 title: Google Drive
 redirect_from:
   - /google-docs/
+questions:
+  - it-issues
 ---
 
 _a.k.a. G Suite_
@@ -58,9 +60,3 @@ If you're using a non-Google service and it requests access to your GSA Google D
 ## Local editing
 
 [Drive File Stream](https://support.google.com/drive/answer/7329379?hl=en) can be used for local editing of files on Drive, though offline editing is not yet supported for Macs at GSA. [InSite page.](https://insite.gsa.gov/employee-resources/information-technology/do-it-yourself-self-help/google-g-suite-apps/google-drive-and-shared-drive?term=drive%20file%20stream#Drive%20File%20Stream)
-
----
-
-## Still have questions?
-
-Ask in Slack: [#questions](https://gsa-tts.slack.com/messages/questions), [#teamops](https://gsa-tts.slack.com/messages/teamops), [#it-issues](https://gsa-tts.slack.com/messages/it-issues)

--- a/_pages/software-tools/google-groups.md
+++ b/_pages/software-tools/google-groups.md
@@ -1,5 +1,7 @@
 ---
 title: Google Groups
+questions:
+  - it-issues
 ---
 
 We use Google Groups to manage team and interest-based email distribution lists and listservs. A list of listservs and groups TTS uses is [here]({{site.baseurl}}/working-groups-and-guilds-101/).
@@ -21,9 +23,3 @@ To find the groups that you are in and manage any groups where you are an admin,
 - People outside GSA can't access GSA Google groups via the Google Groups website, but email still works depending on the permissions. To adjust those permissions so non-GSA people can email your listserv, click on your listserv, then the "Settings" gear. Then "Group Settings." On the left menu of that screen, go to "Permissions" then "Basic Permissions." Click the dropdown box labeled "Post" and select "Public." Save your changes.
 
 You can subscribe to Google Groups with the following RSS feed URL: `https://groups.google.com/forum/feed/<GROUP_NAME>/msgs/rss.xml`
-
----
-
-#### Still have questions?
-
-Ask in Slack: [#questions](https://gsa-tts.slack.com/messages/questions), [#teamops](https://gsa-tts.slack.com/messages/teamops), or [#it-issues](https://gsa-tts.slack.com/messages/it-issues)

--- a/_pages/software-tools/google-meet.md
+++ b/_pages/software-tools/google-meet.md
@@ -5,6 +5,8 @@ tags:
    - sound
 redirect_from:
    - /google-hangouts/
+questions:
+  - it-issues
 ---
 
 Google Meet (which has mostly replaced Google Hangouts) is an online video conferencing tool that integrates with Google calendar.
@@ -55,9 +57,3 @@ If you're doing a virtual presentation it can be a bit tricky, so here are some 
 2. Resize the browser window with the active Meet (C) to be half of your screen.
 4. Select "present window" and choose the window (A) with your presentation slides.
 5. Align your presenter view (B) with the meet on half your screen - now you can see your notes, the folks you are presenting to, _and_ a thumbnail of your presentation all on your monitor!
-
----
-
-## Still have questions?
-
-Ask in Slack: [#questions](https://gsa-tts.slack.com/messages/questions), [#teamops](https://gsa-tts.slack.com/messages/teamops), [#it-issues](https://gsa-tts.slack.com/messages/it-issues)

--- a/_pages/software-tools/sharedcalendars.md
+++ b/_pages/software-tools/sharedcalendars.md
@@ -1,7 +1,9 @@
 ---
 title: Sharing calendars with partners
 tags:
-- calendars
+  - calendars
+questions:
+  - it-issues
 ---
 If you’re running a project with a partner, gaining ready visibility into team member calendars can make life (or at least scheduling meetings) a bit easier so you know when people may be available to meet.
 
@@ -67,10 +69,3 @@ Sharing non-GSA federal calendars from Outlook using MAX.gov (depends on agency)
 
  - https://community.max.gov/pages/viewpage.action?pageId=658899186
  - https://community.max.gov/display/Help/Feedback+for+Synching+to+MAX+Calendar
-
-
----
-
-## Still have questions?
-
-Ask in Slack: [#questions](https://gsa-tts.slack.com/messages/questions), [#teamops](https://gsa-tts.slack.com/messages/teamops), [#it-issues](https://gsa-tts.slack.com/messages/it-issues)

--- a/_pages/software-tools/text-editors.md
+++ b/_pages/software-tools/text-editors.md
@@ -1,5 +1,7 @@
 ---
 title: Text editors
+questions:
+  - questions
 ---
 
 We use text editors to write documentation in [Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) and to develop code.
@@ -26,9 +28,3 @@ We use text editors to write documentation in [Markdown](https://github.com/adam
     - WordCount
     - EditorConfig
     - Markdown Preview
-
----
-
-#### Still have questions?
-
-Ask in Slack: [#questions](https://gsa-tts.slack.com/messages/questions/) or [#teamops](https://gsa-tts.slack.com/messages/teamops/)

--- a/_pages/software-tools/text-editors.md
+++ b/_pages/software-tools/text-editors.md
@@ -1,6 +1,5 @@
 ---
 title: Text editors
-navtitle: Text editors
 ---
 
 We use text editors to write documentation in [Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) and to develop code.

--- a/_pages/software-tools/tock.md
+++ b/_pages/software-tools/tock.md
@@ -1,18 +1,20 @@
 ---
 title: Tock
+questions:
+  - tock
 ---
 
 ## Quick reference
 
 **18F staff should only enter time in the following categories:**
 
-- **18F Non-Billable Work - #968:** Time spent working on non-project work for 18F. 
-- **18F Business Ops - #1195:** Time specifically spent working on 18F business development efforts. 
+- **18F Non-Billable Work - #968:** Time spent working on non-project work for 18F.
+- **18F Business Ops - #1195:** Time specifically spent working on 18F business development efforts.
 - **18F Hiring - #1241:** Time specifically spent working on 18F hiring (such as preparing interview guides, reading resumes, interviews and debriefs).
 - **GSA-mandated Non-Billable Work - #969:** Time spent on compulsory overhead: HRLinks, mandatory OLU trainings, IDPs, midyear & annual reviews, SF-182s, OGE-450s, seeking training approvals, tech support for GSA-required software, etc.
 - **Out of Office - #670:** Vacation time, federal holidays, or sick time
 - **18F Project work - project ID varies:** The specific projects you're working on.
-- **(Coming Soon!) 18F Engagement Management - project ID varies:** This code is used for non-primary project team members (i.e. staffing leads, supervisors, etc.) who are participating in staffing the project, providing feedback to their staff regarding their project, conducting post-mortems, etc. 
+- **(Coming Soon!) 18F Engagement Management - project ID varies:** This code is used for non-primary project team members (i.e. staffing leads, supervisors, etc.) who are participating in staffing the project, providing feedback to their staff regarding their project, conducting post-mortems, etc.
 
 **Cloud.gov**
 - Tock your usual 40 hours to the cloud.gov P&L (#955) generally unless you’re doing billable work for something in 18F.  More specific Tock instructions for Cloud team members can be found [here](https://docs.google.com/document/d/16wGnM2vD9y5nrD3Jhufjc-G1r1cs3lkX2Ny-opYk9do/edit#heading=h.2uuhlgoi43ro).
@@ -36,12 +38,12 @@ Timecards for the current week should be available no later than Monday at 9AM P
 
 ## Tock and HR Links
 
-Tock is a different tool than HR Links and is used for a different purpose: 
+Tock is a different tool than HR Links and is used for a different purpose:
 
-- Tock is an internal TTS tool that tracks our billable hours on projects; we often use that data to bill our agency partners. 
+- Tock is an internal TTS tool that tracks our billable hours on projects; we often use that data to bill our agency partners.
 - HR Links is a GSA-level tool that records how much and what kind of leave (sick, annual, family) an employee takes during a given two-week pay period.
 
-It can be confusing because out of office time IS tracked in Tock. But that’s only so we can understand that you weren’t billing to a project because you were out of the office. Leave can only be officially requested via HR Links. 
+It can be confusing because out of office time IS tracked in Tock. But that’s only so we can understand that you weren’t billing to a project because you were out of the office. Leave can only be officially requested via HR Links.
 
 Supervisors approve and submit HR Links timesheets every two weeks (during the week following the end of a pay period), and while out of office time in Tock should match what’s in the official record of HR Links, any emails you receive about timesheet errors are related to HR Links, not Tock. Forward those to your supervisor for assistance.
 
@@ -102,17 +104,17 @@ That leaves up to 10% of your time to be spent on non-billable work. There are a
 
 GSA-mandated non-billable work includes time spent in HR Links, mandatory OLU trainings, IDPs, SF-182s, annual reviews, troubleshooting GSA-issued hardware (like PIV readers), and so forth. These are the things we don’t have a choice but to spend time on.
 
-18F non-billable work includes time spent on hiring, in guilds and working groups (that are not in service of project work), team coffees, chapter meetings, approved internal projects, conference attendance, training events, and anything else that contributes to the running of TTS as an organization. 
+18F non-billable work includes time spent on hiring, in guilds and working groups (that are not in service of project work), team coffees, chapter meetings, approved internal projects, conference attendance, training events, and anything else that contributes to the running of TTS as an organization.
 
 However, time within those activities spent discussing a billable project may also be billable. For example, if you're in a 1:1 or guild meeting working through a difficult project issue, that's billable.
 
 Not sure whether work you’re doing is billable? If it’s not explicitly an indirect cost, it’s project work.
 
-Effective July 6, 2020 for 18F: 
+Effective July 6, 2020 for 18F:
 
 So for most people in a given 40-hour week, the expectation is to bill at least 36 hours to project work. But what about holidays or leave time? Then you’ll need to spend 90% of the time you’re working that week on billable work. Here’s what that looks like if you’re out of the office for a few days:
 
-Work week | Billable time (minimum hours expected) | Non-billable time (not to exceed) 
+Work week | Billable time (minimum hours expected) | Non-billable time (not to exceed)
 --- | --- | ---
 5 days | 36 hours (90% of 40 hours) | 4 hours
 4 days | 29 hours (90% of 32 hours) | 3 hours
@@ -149,7 +151,7 @@ In short, we need to know if our scoping is accurate. We'd rather be over budget
 
 ### Tocking for Out of Office Time
 
-You cannot request paid time off in Tock (see the [Leave](../leave/) page for guidance on requesting paid time off using HR Links). But you do need to record out of office time as part of your weekly Tock. Staff should Tock any out of office time (federal holidays, sick leave, annual leave, family leave, etc) to Tock line #670, Out of Office. This is so we can understand that you weren’t billing to a project for those hours because you were out of the office. 
+You cannot request paid time off in Tock (see the [Leave](../leave/) page for guidance on requesting paid time off using HR Links). But you do need to record out of office time as part of your weekly Tock. Staff should Tock any out of office time (federal holidays, sick leave, annual leave, family leave, etc) to Tock line #670, Out of Office. This is so we can understand that you weren’t billing to a project for those hours because you were out of the office.
 
 If you are going to be out of the office for an extended period of time, head to the #tock channel in slack before you leave and ask that the team submit your Tock hours for you during your out of office period. Example:
 
@@ -171,7 +173,3 @@ Tock likely doesn't have your start date listed correctly. To fix this:
 ### How do I change a reporting period I already filled out?
 
 Submit a Tock change request using [this form](https://docs.google.com/forms/d/1EpVTxXgRNgYfoSA2J8Oi-csjhFKqFm5DT542vIlahpU/viewform?edit_requested=true). You can also ping us in [#tock](https://gsa-tts.slack.com/messages/tock) and we'll help you out.
-
-## Still have questions?
-
-Ask in Slack: [#tock](https://gsa-tts.slack.com/messages/tock)

--- a/_pages/software-tools/trello.md
+++ b/_pages/software-tools/trello.md
@@ -1,5 +1,7 @@
 ---
 title: Trello
+questions:
+  - admins-trello
 ---
 
 [Trello](https://trello.com/18f3/) is a collaborative task and project-management tool.
@@ -8,7 +10,7 @@ title: Trello
 
 ### Account creation
 
-[Trello](https://trello.com) accounts support multiple email addresses, so you can use an existing account (if you have one) by adding your GSA email address. 
+[Trello](https://trello.com) accounts support multiple email addresses, so you can use an existing account (if you have one) by adding your GSA email address.
 
 If you **do not have an existing Trello account**, go to [Trello](https://trello.com), click the green "Sign Up" button, and create a Trello account by signing up with your GSA Google account.
 
@@ -49,9 +51,3 @@ People use Trello to track ideas from conception through execution. It's common 
 ### Chrome extensions
 
 See [general info]({{site.baseurl}}/software/#chrome-extensions).
-
----
-
-#### Still have questions?
-
-Ask in Slack: [#admins-trello](https://gsa-tts.slack.com/messages/admins-trello/)

--- a/_pages/training-development/intro-to-github.md
+++ b/_pages/training-development/intro-to-github.md
@@ -1,6 +1,5 @@
 ---
 title: Intro to GitHub
-navtitle: Intro to GitHub
 tags:
   - github
 ---

--- a/_pages/training-development/working-groups-and-guilds-101.md
+++ b/_pages/training-development/working-groups-and-guilds-101.md
@@ -1,6 +1,5 @@
 ---
 title: Working groups, guilds, and other communities
-navtitle: Working groups and guilds
 redirect_from:
   - /general-contacts-and-listservs/
 ---
@@ -53,8 +52,8 @@ Most working groups will create a Slack channel to coordinate efforts. These cha
 
 The [TTS Working Groups & Guilds Calendar](https://www.google.com/calendar/embed?src=gsa.gov_o1aqcv28k1f0nmca5bkch8los4%40group.calendar.google.com) can help you find working group meeting times.
 
-
 ## Guilds
+
 Guilds are long-running groups sponsored by the TTS Chief of Staff, and as such are expected to coordinate practices and solve problems across TTS. Because they are cross-TTS structures, their leadership should come from more than one part of TTS and they should provide clear value to a broad cross-section of TTS through training and promotion of best practices in their subject area.
 
 18F provides non-billable hours to guild leads to help them meet those expectations.
@@ -176,9 +175,10 @@ Typically guilds follow a lightweight leadership selection process:
 1. A current guild leader announces the new leader, who takes up the position immediately.
 
 ## 18F Collectives
+
 18F has developed Collectives, with "Collective Leads" guiding them. These collectives are an experiment in how we can support important practices and focus areas long-term within the tight constraints of a cost-recoverable organization.
 
- A collective is a group of people that share or are motivated by at least one common issue or interest, or work together to achieve a common objective.
+A collective is a group of people that share or are motivated by at least one common issue or interest, or work together to achieve a common objective.
 
 These collectives should all have Slack channels with a `c-` prefix. Since their channels are one of their best ways of promoting best practices, you're encouraged to join any you find interesting.
 
@@ -240,12 +240,11 @@ Current 18F Collectives (and Leads) include:
   </table>
 </div>
 
-
 ## Communities of Practice
+
 A Community of Practice (CoP) provides for government-wide knowledge-sharing. They attract members from across government agencies, and provide a good opportunity for Guilds to connect with others in government and influence best practices beyond TTS.
 
 Digital.gov [hosts the Communities of Practice](https://digital.gov/communities/).
-
 
 ## Listservs, Google Groups and mailing lists
 

--- a/_pages/training-development/working-groups-and-guilds-101.md
+++ b/_pages/training-development/working-groups-and-guilds-101.md
@@ -52,8 +52,8 @@ Most working groups will create a Slack channel to coordinate efforts. These cha
 
 The [TTS Working Groups & Guilds Calendar](https://www.google.com/calendar/embed?src=gsa.gov_o1aqcv28k1f0nmca5bkch8los4%40group.calendar.google.com) can help you find working group meeting times.
 
-## Guilds
 
+## Guilds
 Guilds are long-running groups sponsored by the TTS Chief of Staff, and as such are expected to coordinate practices and solve problems across TTS. Because they are cross-TTS structures, their leadership should come from more than one part of TTS and they should provide clear value to a broad cross-section of TTS through training and promotion of best practices in their subject area.
 
 18F provides non-billable hours to guild leads to help them meet those expectations.
@@ -175,10 +175,9 @@ Typically guilds follow a lightweight leadership selection process:
 1. A current guild leader announces the new leader, who takes up the position immediately.
 
 ## 18F Collectives
-
 18F has developed Collectives, with "Collective Leads" guiding them. These collectives are an experiment in how we can support important practices and focus areas long-term within the tight constraints of a cost-recoverable organization.
 
-A collective is a group of people that share or are motivated by at least one common issue or interest, or work together to achieve a common objective.
+ A collective is a group of people that share or are motivated by at least one common issue or interest, or work together to achieve a common objective.
 
 These collectives should all have Slack channels with a `c-` prefix. Since their channels are one of their best ways of promoting best practices, you're encouraged to join any you find interesting.
 
@@ -240,11 +239,12 @@ Current 18F Collectives (and Leads) include:
   </table>
 </div>
 
-## Communities of Practice
 
+## Communities of Practice
 A Community of Practice (CoP) provides for government-wide knowledge-sharing. They attract members from across government agencies, and provide a good opportunity for Guilds to connect with others in government and influence best practices beyond TTS.
 
 Digital.gov [hosts the Communities of Practice](https://digital.gov/communities/).
+
 
 ## Listservs, Google Groups and mailing lists
 

--- a/_pages/travel-leave/travel-and-leave-policies/first-time-travel-complete-concur-profile.md
+++ b/_pages/travel-leave/travel-and-leave-policies/first-time-travel-complete-concur-profile.md
@@ -1,5 +1,10 @@
 ---
 title: First Time Travel Complete Concur Profile
+questions:
+  - travel
+  - tts-travel@gsa.gov
+  - text: Book office hours
+    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
 ---
 
 [TTS Travel Guide Table of Contents]({{site.baseurl}}/travel-guide-table-of-contents) <br>
@@ -26,5 +31,3 @@ It will make booking hotels in Concur easier, and allow you to personally redeem
 
 #### Having Trouble
 Check out the screen shots [here](https://docs.google.com/drawings/d/1eP5E7Tq1K4Iva7aNSHjLukJcZzD2Cdkf6LCoEDRzsFM/edit)
-
-*Got questions? Ask [#travel](https://gsa-tts.slack.com/messages/travel)*, [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov), or book office hours [here](https://sites.google.com/a/gsa.gov/tts-office-hours/)

--- a/_pages/travel-leave/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
+++ b/_pages/travel-leave/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
@@ -1,5 +1,10 @@
 ---
 title: Get set up to travel for TTS <em>before</em> GSA onboarding
+questions:
+  - travel
+  - tts-travel@gsa.gov
+  - text: Book office hours
+    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
 ---
 
 [TTS Travel Guide Table of Contents]({{site.baseurl}}/travel-guide-table-of-contents) <br>
@@ -10,7 +15,7 @@ Steps to take after onboarding <br>
 
 If you're traveling for TTS during your first two weeks (normally for orientation, if you're based in a city that doesn't have a TTS office), you'll need to follow special procedures to get your account set up, which will allow you to make your flight and hotel reservations via AdTrav by calling (877) 472-6716. Here's what you need to do:
 
-1. First thing to get is a **“travel vendor ID”**, which you can request by filling out [the EFT form](https://drive.google.com/a/gsa.gov/file/d/0B0Kck5dqF_Ebb0FFZ29RR0JmVVk/view?usp=sharing) and sending it to:  
+1. First thing to get is a **“travel vendor ID”**, which you can request by filling out [the EFT form](https://drive.google.com/a/gsa.gov/file/d/0B0Kck5dqF_Ebb0FFZ29RR0JmVVk/view?usp=sharing) and sending it to:
 [kc-vendor.number.requests@gsa.gov](mailto:kc-vendor.number.requests@gsa.gov).
 
    _Note if you haven't started and don't have your GSA email address yet_:
@@ -44,5 +49,3 @@ The easiest option is to have your airline reschedule you. If that's not possibl
 If you are traveling to orientation and are worried that you will miss it because of delays or cancellations, please email the [TTS Talent team](mailto:tts-jointts@gsa.gov) and copy anyone who helped you set up travel.  We will make arrangements for you to swear in when you expect to arrive. You may have to attend GSA orientation in your home city 2 weeks later, but please continue to travel to the office where your orientation was scheduled to be for onboarding.
 
 While the Talent and Travel Teams won't be available until Monday if your cancellation occurs over the weekend, please feel comfortable rebooking your travel either though the airline or via Ad-Trav, and rest assured that you will be in good hands when you arrive at TTS.
-
-*Got questions? Ask [#travel](https://gsa-tts.slack.com/messages/travel)*, [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov), or [book office hours here](https://sites.google.com/a/gsa.gov/tts-office-hours/).

--- a/_pages/travel-leave/travel-and-leave-policies/first-time-travel-get-in-concur.md
+++ b/_pages/travel-leave/travel-and-leave-policies/first-time-travel-get-in-concur.md
@@ -1,5 +1,10 @@
 ---
 title: Get access to Concur
+questions:
+  - travel
+  - tts-travel@gsa.gov
+  - text: Book office hours
+    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
 ---
 
 [TTS Travel Guide Table of Contents]({{site.baseurl}}/travel-guide-table-of-contents) <br />
@@ -13,7 +18,7 @@ There are four required steps to gain access to [Concur](https://travel.gsa.gov/
 
 2. Take the 2019 GSA Mandatory Cyber Security and Privacy Training in [OLU](https://gsaolu.gsa.gov). This can take several hours. Follow the instructions [here]({{site.baseurl}}/olu/#help-with-olu) if you need help.
 
-3. Complete the [CGE Access Request Form](https://drive.google.com/a/gsa.gov/file/d/0B0Kck5dqF_EbM3ZRaHRqRHFWSzA/view?usp=sharing), minus the EFT enrollment form. Either an electronic or ink signature is fine. Don't forget to get your supervisor's signature as well!  
+3. Complete the [CGE Access Request Form](https://drive.google.com/a/gsa.gov/file/d/0B0Kck5dqF_EbM3ZRaHRqRHFWSzA/view?usp=sharing), minus the EFT enrollment form. Either an electronic or ink signature is fine. Don't forget to get your supervisor's signature as well!
 *_Not sure about a particular field? Get help by reading the_ [_FAQ below_](#frequently-asked-questions)
 
 4. Email completed CGE form to [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov). _Do not email it to cge-access-requests@gsa.gov,_ as the form specifies. Only email it to tts-travel@gsa.gov. Your account will be set up before [the next travel office hours](https://sites.google.com/a/gsa.gov/tts-office-hours/), which you can also book any time if you have questions.
@@ -35,7 +40,3 @@ GSA employee (Virtual) if based anywhere else.
 
 #### Whose signature should I get for the supervisor field?
 That of your functional supervisor.
-
-### Got other questions?
-
-*Got questions? Ask [#travel](https://gsa-tts.slack.com/messages/travel)*, [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov), or book office hours [here](https://sites.google.com/a/gsa.gov/tts-office-hours/)

--- a/_pages/travel-leave/travel-and-leave-policies/first-time-travel-travel-card.md
+++ b/_pages/travel-leave/travel-and-leave-policies/first-time-travel-travel-card.md
@@ -1,6 +1,5 @@
 ---
 title: First-Time Travel Get a Travel Card
-navtitle: First-Time Travel Get a Travel Card
 ---
 
 [TTS Travel 101]({{site.baseurl}}/travel-101/) <br>
@@ -74,4 +73,4 @@ After you have registered and signed into the U.S. Bank Access Online website wi
 
 #### Having trouble?
 
-*Reach out to ronnail.rawls@gsa.gov
+Reach out to ronnail.rawls@gsa.gov

--- a/_pages/travel-leave/travel-and-leave-policies/first-time-travel-travel-card.md
+++ b/_pages/travel-leave/travel-and-leave-policies/first-time-travel-travel-card.md
@@ -1,5 +1,7 @@
 ---
 title: First-Time Travel Get a Travel Card
+questions:
+  - ronnail.rawls@gsa.gov
 ---
 
 [TTS Travel 101]({{site.baseurl}}/travel-101/) <br>
@@ -70,7 +72,3 @@ After you have registered and signed into the U.S. Bank Access Online website wi
 [Visit the GSA SmartPay 3 purchase card page on InSite for more information](https://insite.gsa.gov/topics/acquisition-purchases-and-payments/gsa-purchase-card/preparing-and-implementing-gsa-smartpay-3-sp3).
 
 [Next Step: Complete Your Concur Profile]({{site.baseurl}}/first-time-travel-complete-concur-profile)
-
-#### Having trouble?
-
-Reach out to ronnail.rawls@gsa.gov

--- a/_pages/travel-leave/travel-and-leave-policies/travel-guide-1-book-travel.md
+++ b/_pages/travel-leave/travel-and-leave-policies/travel-guide-1-book-travel.md
@@ -1,5 +1,10 @@
 ---
 title: Step 1 - Book Travel in Concur and Secure Approvals
+questions:
+  - travel
+  - tts-travel@gsa.gov
+  - text: Book office hours
+    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
 ---
 
 [TTS Travel 101]({{site.baseurl}}/travel-101) <br>
@@ -33,5 +38,3 @@ Once you have finalized your reservations, there are still a few more steps to f
 Ensure all of the above steps are completed no later than 3:30 PM ET the last business day before travel to give the travel team sufficient time to review. After-hours or emergency travel requests may be made in coordination with your supervisor and AdTrav via the process outlined [here]({{site.baseurl}}/travel-guide-b-after-hours-emergency-travel-authorizations).<br>
 <br>
 Should you need to rebook your travel at any point in the process, read the instructions [here]({{site.baseurl}}/travel-guide-a-amended-authorizations).
-
-*Got questions? Ask [#travel](https://gsa-tts.slack.com/messages/travel), [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov), or book office hours [here](https://sites.google.com/a/gsa.gov/tts-office-hours/)*

--- a/_pages/travel-leave/travel-and-leave-policies/travel-guide-2-travel.md
+++ b/_pages/travel-leave/travel-and-leave-policies/travel-guide-2-travel.md
@@ -1,5 +1,10 @@
 ---
 title: Step 2 - Travel
+questions:
+  - travel
+  - tts-travel@gsa.gov
+  - text: Book office hours
+    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
 ---
 
 [TTS Travel 101]({{site.baseurl}}/travel-101/) <br>
@@ -97,5 +102,3 @@ Why the rush? Filling out a voucher correctly allows you to:
 On the other side, when travel expenses are submitted late, it’s a major drain on resources for the finance and agreements teams, which sometimes have to reopen billing and even modify agreements in order to recover our costs for the trip, which the Economy Act requires us to do. So, **future travel may not be approved for anyone with travel expenses that are more than 5 business days outstanding.**
 
 [Back from your trip? Head on over to get reimbursed!]({{site.baseurl}}/travel-guide-3-reimbursement)
-
-*Got questions? Ask [#travel](https://gsa-tts.slack.com/messages/travel)*, [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov), or book office hours [here](https://sites.google.com/a/gsa.gov/tts-office-hours/)

--- a/_pages/travel-leave/travel-and-leave-policies/travel-guide-3-reimbursement.md
+++ b/_pages/travel-leave/travel-and-leave-policies/travel-guide-3-reimbursement.md
@@ -1,5 +1,10 @@
 ---
 title: Step 3 - Get Reimbursed
+questions:
+  - travel
+  - tts-travel@gsa.gov
+  - text: Book office hours
+    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
 ---
 
 [TTS Travel 101]({{site.baseurl}}/travel-101) <br>
@@ -28,5 +33,3 @@ Finally, don't forget to [stamp and submit for travel team approval!]({{site.bas
 [Confused by error messages?](https://docs.google.com/document/d/1zD020XAXRIpuXPKgY0zadLBNJmBaRj_29-DhClrkZAo/edit)
 
 [Have issues with reimbursements or outstanding travel card balances?]({{site.baseurl}}/travel-guide-faq/#issues-with-reimbursement)
-
-*Got questions? Ask [#travel](https://gsa-tts.slack.com/messages/travel)*, [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov), or [book office hours](https://sites.google.com/a/gsa.gov/tts-office-hours/).

--- a/_pages/travel-leave/travel-and-leave-policies/travel-guide-a-amended-authorizations.md
+++ b/_pages/travel-leave/travel-and-leave-policies/travel-guide-a-amended-authorizations.md
@@ -1,6 +1,5 @@
 ---
 title: Appendix A - Amended authorizations
-navtitle: Amended Authorizations
 ---
 
 [TTS Travel 101]({{site.baseurl}}/travel-101/) <br>

--- a/_pages/travel-leave/travel-and-leave-policies/travel-guide-a-amended-authorizations.md
+++ b/_pages/travel-leave/travel-and-leave-policies/travel-guide-a-amended-authorizations.md
@@ -1,5 +1,10 @@
 ---
 title: Appendix A - Amended authorizations
+questions:
+  - travel
+  - tts-travel@gsa.gov
+  - text: Book office hours
+    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
 ---
 
 [TTS Travel 101]({{site.baseurl}}/travel-101/) <br>
@@ -96,5 +101,3 @@ If you changed your travel plans via **Concur**, an amended authorization which 
 If you changed your travel plans via **AdTrav**, an amended authorization was likely automatically generated for you, though this can take up to an hour after your call with them, so be patient! Once the amendment is generated, you can see it by navigating to the **Authorizations** tab and selecting your trip. Verify that all of the right changes have been made (and reach out to the Business Applications Service desk at (866) 450-6588 if you need any help), and then continue on with [submitting your amended authorization for approval]({{site.baseurl}}/travel-guide-faq/#how-to-stamp-and-submit-for-travel-team-approval).
 
 If you changed your travel plans outside of Concur or AdTrav but still need to amend your authorization based on the guidance above, go ahead and [manually amend your authorization](#manually-amending-an-authorization-in-concur).
-
-*Got questions? Ask [#travel](https://gsa-tts.slack.com/messages/travel)*, [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov), or book office hours [here](https://sites.google.com/a/gsa.gov/tts-office-hours/)

--- a/_pages/travel-leave/travel-and-leave-policies/travel-guide-b-after-hours-emergency-travel-authorizations.md
+++ b/_pages/travel-leave/travel-and-leave-policies/travel-guide-b-after-hours-emergency-travel-authorizations.md
@@ -1,6 +1,5 @@
 ---
 title: Appendix B - After-hours emergency travel authorizations
-navtitle: After-hours emergency travel authorizations
 ---
 
 [TTS Travel 101]({{site.baseurl}}/travel-101/) <br>

--- a/_pages/travel-leave/travel-and-leave-policies/travel-guide-b-after-hours-emergency-travel-authorizations.md
+++ b/_pages/travel-leave/travel-and-leave-policies/travel-guide-b-after-hours-emergency-travel-authorizations.md
@@ -1,5 +1,10 @@
 ---
 title: Appendix B - After-hours emergency travel authorizations
+questions:
+  - travel
+  - tts-travel@gsa.gov
+  - text: Book office hours
+    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
 ---
 
 [TTS Travel 101]({{site.baseurl}}/travel-101/) <br>
@@ -29,5 +34,3 @@ Except where noted here, all fields will need to be correctly filled out:
 22. Include any justification required earlier in the form, as well as any additional details requested by your approving official.
 23. You can look up the appropriate accounting code for your team [here](https://docs.google.com/spreadsheets/d/1twEX5wrriQ3Tbn25wN4n8rZPF9h5NqRQWIskkW6xQpY/edit#gid=0).
 24. You and your authorizing official will both need to sign and date the completed form before sending it to gvtagents@adtrav.com for ticketing.
-
-*Got questions? Ask [#travel](https://gsa-tts.slack.com/messages/travel)*, [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov), or book office hours [here](https://sites.google.com/a/gsa.gov/tts-office-hours/)

--- a/_pages/travel-leave/travel-and-leave-policies/travel-guide-email-templates.md
+++ b/_pages/travel-leave/travel-and-leave-policies/travel-guide-email-templates.md
@@ -1,5 +1,10 @@
 ---
 title: Travel Approval Email Templates
+questions:
+  - travel
+  - tts-travel@gsa.gov
+  - text: Book office hours
+    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
 ---
 
 [TTS Travel 101]({{site.baseurl}}/travel-101) <br>
@@ -44,6 +49,3 @@ Below is the travel cost break out for [ work to be performed ] for [ Budget nam
 Many thanks,
 
 [ requestor_name ]
-
-
-*Got questions? Ask [#travel](https://gsa-tts.slack.com/messages/travel)*, [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov), or book office hours [here](https://sites.google.com/a/gsa.gov/tts-office-hours/)

--- a/_pages/travel-leave/travel-guide-table-of-contents.md
+++ b/_pages/travel-leave/travel-guide-table-of-contents.md
@@ -1,5 +1,10 @@
 ---
 title: Travel Guide Table of Contents
+questions:
+  - travel
+  - tts-travel@gsa.gov
+  - text: Book office hours
+    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
 ---
 
 * [Travel 101]({{site.baseurl}}/travel-101/)
@@ -64,6 +69,3 @@ title: Travel Guide Table of Contents
 * [GSA conference and event policy](https://www.gsa.gov/cdnstatic/OAS_5785.1_Conference_and_Event_Management_%28Signed_on_January_28__2015%29.pdf)
 * [GSA official guide to Concur](https://seags1tmwp05.concursolutions.com/tm/help508/GTMWebHelp.htm)
 * Business Applications Service Desk (Concur Helpdesk): (866) 450-6588, press 2 or businessapps@gsa.gov
-
-
-*Got questions? Ask [#travel](https://gsa-tts.slack.com/messages/travel)*, [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov), or book office hours [here](https://sites.google.com/a/gsa.gov/tts-office-hours/)

--- a/tools/slack.md
+++ b/tools/slack.md
@@ -2,6 +2,8 @@
 title: Slack
 redirect_from:
   - /slack/
+questions:
+  - admins-slack
 ---
 
 See the following sub-pages for information about Slack at TTS:

--- a/tools/slack/external-collaboration.md
+++ b/tools/slack/external-collaboration.md
@@ -1,5 +1,7 @@
 ---
 title: External collaboration through Slack
+questions:
+  - admins-slack
 ---
 
 [_Back to Slack page_](../)

--- a/tools/slack/guidelines.md
+++ b/tools/slack/guidelines.md
@@ -1,5 +1,7 @@
 ---
 title: Slack guidelines
+questions:
+  - admins-slack
 ---
 
 [_Back to Slack page_](../)
@@ -74,9 +76,3 @@ Groups are a great way to alert people who might not be in a channel about somet
 ## Connectivity issues
 
 If you are having connectivity issues with Slack, see the [Slack status site](https://status.slack.com/) for more information, and move to [Hangouts Chat](https://support.google.com/a/users/answer/9300511?hl=en) or email.
-
----
-
-#### Still have questions?
-
-Ask in Slack: [#admins-slack](https://gsa-tts.slack.com/messages/admins-slack), [#it-issues](https://gsa-tts.slack.com/messages/it-issues), [#questions](https://gsa-tts.slack.com/messages/questions), [#teamops](https://gsa-tts.slack.com/messages/teamops)

--- a/tools/slack/integrations.md
+++ b/tools/slack/integrations.md
@@ -1,5 +1,7 @@
 ---
 title: Slack integrations
+questions:
+  - admins-slack
 ---
 
 [_Back to Slack page_](../)

--- a/tools/slack/records.md
+++ b/tools/slack/records.md
@@ -1,5 +1,7 @@
 ---
 title: Slack records
+questions:
+  - admins-slack
 ---
 
 [_Back to Slack page_](../)

--- a/tools/slack/rules.md
+++ b/tools/slack/rules.md
@@ -1,5 +1,7 @@
 ---
 title: Slack rules
+questions:
+  - admins-slack
 ---
 
 [_Back to Slack page_](../)

--- a/tools/slack/user-management.md
+++ b/tools/slack/user-management.md
@@ -2,6 +2,8 @@
 title: Slack user management
 redirect_from:
   - /slack-admin/
+questions:
+  - admins-slack
 ---
 
 [_Back to Slack page_](../)
@@ -48,9 +50,3 @@ Here are the resources used by Slack Admins to track and manage Slack accounts:
   - [New public user requests (external)](https://docs.google.com/forms/d/e/1FAIpQLSfYQ-D82rIGwbCmwF3kAQERqczi5syVGq6GtmQNR6fhxRAA2Q/viewform?usp=sf_link)
   - [Integration requests](https://docs.google.com/a/gsa.gov/forms/d/1sH-eLcDMDSBE9xvUnbE39N0PFOcfg6Mf3mnWU8xzBz8/edit#responses)
 - [Delegation of functionality](https://docs.google.com/a/gsa.gov/document/d/1gDuScce7R6q6NqQPPS3cFe3dZFYO_ZEp60dmuzVDYwg/edit?usp=sharing)
-
----
-
-## Still have questions?
-
-Ask in Slack: [#admins-slack](https://gsa-tts.slack.com/messages/admins-slack)


### PR DESCRIPTION
Follow-up to https://github.com/18F/handbook/pull/2142.

This pull request converts the remaining pages (that were easily convert-able) to use the new `questions` front matter. I adjusted the Slack channels that were being pointed to in a few cases, and made some small formatting improvements here and there.

It's a big pull request, but the changes to most pages are almost identical. I suggest reviewing [ignoring whitespace](https://github.com/18F/handbook/pull/2148/files?w=1).