### PR TITLE
delete old onboarding schedule page

### DIFF
--- a/_pages/redirects/onboarding-schedule.md
+++ b/_pages/redirects/onboarding-schedule.md
@@ -1,5 +1,0 @@
----
-title: Onboarding Schedule
-redirect_to:
-  - /tts-classes/
----


### PR DESCRIPTION
Redirect is already in place in the destination page, so this file is redundant.