### PR TITLE
add more examples of what in Slack could be attributed back to users

### DIFF
--- a/_pages/how-we-work/sensitive-information.md
+++ b/_pages/how-we-work/sensitive-information.md
@@ -29,7 +29,7 @@ To contribute regular-expressions to match new rules, [see the documentation](ht
 
 ### Google Drive
 
-You can use [GSA Google Drive](../google-drive/) to share sensitive files, spreadsheets, and documents. This includes personally identifiable information (PII) of either federal staff or the public, but it *does not* include classified information of any kind. If you're handling PII, be absolutely sure you are only sharing Drive files with GSA staff and that those staff members have a direct need for the information.
+You can use [GSA Google Drive](../google-drive/) to share sensitive files, spreadsheets, and documents. This includes personally identifiable information (PII) of either federal staff or the public, but it _does not_ include classified information of any kind. If you're handling PII, be absolutely sure you are only sharing Drive files with GSA staff and that those staff members have a direct need for the information.
 
 ### OMB MAX
 
@@ -45,8 +45,8 @@ You can create an S3 service instance on cloud.gov and issue credentials for par
 
 Follow the linked instructions to password-protect a:
 
-* [PDF](https://support.apple.com/guide/preview/password-protect-a-pdf-prvw587dd90f/mac)
-* [ZIP](https://osxdaily.com/2012/01/07/set-zip-password-mac-os-x/) (which can be a folder full of files)
-   - [Information from GSA IT](https://insite.gsa.gov/employee-resources/information-technology/do-it-yourself-self-help/google-g-suite-apps/email-with-gmail/how-to-create-fipscompliant-zip-files)
+- [PDF](https://support.apple.com/guide/preview/password-protect-a-pdf-prvw587dd90f/mac)
+- [ZIP](https://osxdaily.com/2012/01/07/set-zip-password-mac-os-x/) (which can be a folder full of files)
+  - [Information from GSA IT](https://insite.gsa.gov/employee-resources/information-technology/do-it-yourself-self-help/google-g-suite-apps/email-with-gmail/how-to-create-fipscompliant-zip-files)
 
 Send the encrypted file and password to the recipient separately, with the latter ideally through something ephemeral like a phone call.

--- a/_pages/how-we-work/sensitive-information.md
+++ b/_pages/how-we-work/sensitive-information.md
@@ -8,7 +8,7 @@ Here's what you need to know about sensitive information at TTS.
 
 ## What is considered sensitive?
 
-To learn what information we consider sensitive, see [our Open Source Policy practices guide](https://github.com/18F/open-source-policy/blob/master/practice.md#protecting-sensitive-information). See also: [the GSA Controlled Unclassified Information (CUI) Guide](https://insite.gsa.gov/employee-resources/information-technology/security-and-privacy/controlled-unclassified-information-cui/cui-guide).
+Anything that would make our systems vulnerable or would impact the privacy of others if it fell into the wrong hands. To learn what information we consider sensitive, see [our Open Source Policy practices guide](https://github.com/18F/open-source-policy/blob/master/practice.md#protecting-sensitive-information). See also: [the GSA Controlled Unclassified Information (CUI) Guide](https://insite.gsa.gov/employee-resources/information-technology/security-and-privacy/controlled-unclassified-information-cui/cui-guide).
 
 ## Tools
 

--- a/tools/slack/guidelines.md
+++ b/tools/slack/guidelines.md
@@ -73,6 +73,10 @@ Slack Groups allow you to direct messages to a specific list of people in a more
 
 Groups are a great way to alert people who might not be in a channel about something that needs their attention or make sure urgent incidents are directed to the right people and not an entire channel. For example, you can ping **@github-admins** in #admins-github if you have an urgent issue instead of using an **@channel** or use **@federalist-team** to alert that group of a conversation in another channel that we should see immediately.
 
+## Add yourself to [our custom emoji](https://gsa-tts.slack.com/customize/emoji)
+
+Add your profile picture as a custom emoji with your name as the alias ("first-last"). This allows the whole TTS community to celebrate your contributions and serves as your introduction to our prolific custom emoji database. Post your emoji (and any other custom emojis you add) to the [#emoji-showcase](https://gsa-tts.slack.com/messages/C0X2T36AY) channel.
+
 ## Connectivity issues
 
 If you are having connectivity issues with Slack, see the [Slack status site](https://status.slack.com/) for more information, and move to [Hangouts Chat](https://support.google.com/a/users/answer/9300511?hl=en) or email.

--- a/tools/slack/rules.md
+++ b/tools/slack/rules.md
@@ -11,9 +11,10 @@ questions:
 - **Complete [your profile](https://gsa-tts.slack.com/account/profile).** A complete profile gives everyone a better chance of knowing who you are. This includes your first name, last name (optionally followed by your location and [personal](https://pronoun.is/) in parenthesis), profile picture (photos are preferred, but not required), phone number, and a summary of what you do and what teams you’re on.
 - **[Enable two-factor authentication (2FA)](https://slack.zendesk.com/hc/en-us/articles/204509068-Enabling-two-factor-authentication).** You can either do this through SMS or an authentication tool. Slack provides detailed instructions for both options. If you need to reset 2FA, Slack admins will re-verify your identity.
 - **Abide by [the TTS Code of Conduct]({{site.baseurl}}/code-of-conduct).** If you see anyone violating our Code of Conduct, see the reporting section.
-- **Assume everything you share will be made public, and attributed back to you.** Treat Slack as a public forum — you have _no_ privacy. This includes:
+- **Assume everything you share/do in Slack will be made public, and attributed back to you.** Treat Slack as a public forum — you have _no_ privacy. This includes:
   - File uploads to Slack
   - Any audio or video transmitted using a [Slack Call](https://slack.com/help/articles/115003498363-Slack-calls--the-basics)
+  - Channel names
   - [Custom emoji](https://slack.com/help/articles/206870177-Add-custom-emoji-to-your-workspace)
   - [Emoji reactions](https://slack.com/help/articles/206870317-Use-emoji-reactions)
 - **Do not post any [sensitive information]({{site.baseurl}}/sensitive-information/).** See the [list of alternatives]({{site.baseurl}}/sensitive-information/#tools).

--- a/tools/slack/rules.md
+++ b/tools/slack/rules.md
@@ -10,10 +10,9 @@ questions:
 
 - **Complete [your profile](https://gsa-tts.slack.com/account/profile).** A complete profile gives everyone a better chance of knowing who you are. This includes your first name, last name (optionally followed by your location and [personal](https://pronoun.is/) in parenthesis), profile picture (photos are preferred, but not required), phone number, and a summary of what you do and what teams you’re on.
 - **[Enable two-factor authentication (2FA)](https://slack.zendesk.com/hc/en-us/articles/204509068-Enabling-two-factor-authentication).** You can either do this through SMS or an authentication tool. Slack provides detailed instructions for both options. If you need to reset 2FA, Slack admins will re-verify your identity.
-- **[Add yourself to our custom emojis](https://gsa-tts.slack.com/customize/emoji).** Add your profile picture as a custom emoji with your name as the alias ("first-last"). This allows the whole TTS community to celebrate your contributions and serves as your introduction to our prolific custom emoji database. Post your emoji (and any other custom emojis you add) to the [#emoji-showcase](https://gsa-tts.slack.com/messages/C0X2T36AY) channel.
 - **Abide by [the TTS Code of Conduct]({{site.baseurl}}/code-of-conduct).** If you see anyone violating our Code of Conduct, see the reporting section.
 - **Assume everything you share will be made public**. Treat Slack as a public forum — you have _no_ privacy. This includes file uploads to Slack and any audio or video transmitted using a Slack Call.
-- **Do not post anything that would make our systems vulnerable or would impact the privacy of others if it fell into the wrong hands.** See [list of alternatives]({{site.baseurl}}/sensitive-information/#tools).
+- **Do not post any [sensitive information]({{site.baseurl}}/sensitive-information/).** See the [list of alternatives]({{site.baseurl}}/sensitive-information/#tools).
 
 ## Usage of TTS's Slack
 

--- a/tools/slack/rules.md
+++ b/tools/slack/rules.md
@@ -61,7 +61,7 @@ Some channels may have particular guidance for getting help, which you can usual
 ## Alumni
 
 - **Keep the conversation visible within #alumni and don't DM staff.** For direct communication, use methods available to the general public, such as email.
-- **If you would like documents or materials, you can either use publicly available methods to request that we publish them publicly, or you can file a FOIA request for GSA to release them.** Don't request materials that aren't already public to be sent to you — even if they were non-sensitive or documents that you personally authored while you were here. 
+- **If you would like documents or materials, you can either use publicly available methods to request that we publish them publicly, or you can file a FOIA request for GSA to release them.** Don't request materials that aren't already public to be sent to you — even if they were non-sensitive or documents that you personally authored while you were here.
 - **Don't share job postings.** This is especially true for your own employer, but applies to postings generally. We don't want our #alumni channel to be providing advantages to any particular company due to someone's access to it. You can use email or other publicly accessible methods to share job postings.
 
 ## Security

--- a/tools/slack/rules.md
+++ b/tools/slack/rules.md
@@ -11,7 +11,11 @@ questions:
 - **Complete [your profile](https://gsa-tts.slack.com/account/profile).** A complete profile gives everyone a better chance of knowing who you are. This includes your first name, last name (optionally followed by your location and [personal](https://pronoun.is/) in parenthesis), profile picture (photos are preferred, but not required), phone number, and a summary of what you do and what teams you’re on.
 - **[Enable two-factor authentication (2FA)](https://slack.zendesk.com/hc/en-us/articles/204509068-Enabling-two-factor-authentication).** You can either do this through SMS or an authentication tool. Slack provides detailed instructions for both options. If you need to reset 2FA, Slack admins will re-verify your identity.
 - **Abide by [the TTS Code of Conduct]({{site.baseurl}}/code-of-conduct).** If you see anyone violating our Code of Conduct, see the reporting section.
-- **Assume everything you share will be made public**. Treat Slack as a public forum — you have _no_ privacy. This includes file uploads to Slack and any audio or video transmitted using a Slack Call.
+- **Assume everything you share will be made public, and attributed back to you.** Treat Slack as a public forum — you have _no_ privacy. This includes:
+  - File uploads to Slack
+  - Any audio or video transmitted using a [Slack Call](https://slack.com/help/articles/115003498363-Slack-calls--the-basics)
+  - [Custom emoji](https://slack.com/help/articles/206870177-Add-custom-emoji-to-your-workspace)
+  - [Emoji reactions](https://slack.com/help/articles/206870317-Use-emoji-reactions)
 - **Do not post any [sensitive information]({{site.baseurl}}/sensitive-information/).** See the [list of alternatives]({{site.baseurl}}/sensitive-information/#tools).
 
 ## Usage of TTS's Slack


### PR DESCRIPTION
Did a couple of other cleanup things in that page as well — see commits.