### PR TITLE
fix heading levels on performance management pages

### DIFF
--- a/_pages/performance-management/mid-year-hrlinks-steps.md
+++ b/_pages/performance-management/mid-year-hrlinks-steps.md
@@ -16,9 +16,7 @@ This page contains step-by-step instructions for employees and supervisors on ho
 
 If you're having issues with logging into HR Links while using Google Chrome, please use these [instructions to clear your site cache](https://docs.google.com/document/d/13j6e8bAVSWFSNNkqmU2hMfwXOCBsi49d_2EqvL3aKXE/edit?usp=sharing).
 
-## HR Links performance management steps
-
-### Submitting a performance plan for employee acknowledgment
+## Submitting a performance plan for employee acknowledgment
 
 * Step-by-step instructions:
   * No action required by employee
@@ -27,7 +25,7 @@ If you're having issues with logging into HR Links while using Google Chrome, pl
 * HR Links in-depth guide (with screenshots):
   * [Supervisor (Section 1, Topic 1.2)](https://drive.google.com/open?id=15Xm9NF_KfcWN-ZxPomooowEAq51073Xi)
 
-### Acknowledging a performance plan
+## Acknowledging a performance plan
 
 * Step-by-step instructions:
   * [Employee](https://docs.google.com/document/d/1VxwbatliieP78-qN_VmdHxt1ROvSro4yKe9-OkjQd58/edit#heading=h.u5b15qifcg0q)
@@ -38,7 +36,7 @@ If you're having issues with logging into HR Links while using Google Chrome, pl
   * [Employee (Section 1, Topic 1.3)](https://drive.google.com/file/d/1NhoDr9MlNTP9VEgBx72H-KoPjNeivOwv/view)
   * [Supervisor (Section 1, Topic 1.2)](https://drive.google.com/open?id=15Xm9NF_KfcWN-ZxPomooowEAq51073Xi)
 
-### Overriding an employee performance plan acknowledgment
+## Overriding an employee performance plan acknowledgment
 
 A supervisor can acknowledge an employee performance plan on behalf of their employee if the employee is unable to (i.e. on vacation) or refuses to do so (i.e. does not agree with the evaluation).
 
@@ -46,7 +44,7 @@ A supervisor can acknowledge an employee performance plan on behalf of their emp
   * No action required by employee
   * [Supervisor](https://docs.google.com/document/d/1iduOW_V1NNqGnZkm7TAwzzr4oIZPZW3UG-f1QdaLD-w/edit#heading=h.g8d9qupcsxiz)
 
-### Re-opening a performance plan
+## Re-opening a performance plan
 
 If modifications need to be made to an existing performance plan, a plan can be re-opened by the Supervisor and [resubmitted to the employee to acknowledge]({{site.baseurl}}/performance-management-hrlinks-steps/#submitting-a-performance-plan-for-employee-approval).
 
@@ -56,7 +54,7 @@ If modifications need to be made to an existing performance plan, a plan can be 
   * No action required by employee
   * [Supervisor](https://docs.google.com/document/d/1iduOW_V1NNqGnZkm7TAwzzr4oIZPZW3UG-f1QdaLD-w/edit#heading=h.hf3nfjxrhb8h)
 
-### Entering a self-assessment
+## Entering a self-assessment
 
 Self-assessments are **not required** for the mid year review; however, Supervisors can request that their direct reports submit one.
 
@@ -70,7 +68,7 @@ Self-assessments are **not required** for the mid year review; however, Supervis
 * Additional resource guide:
   * [GSA Employee Guide to Writing an Effective Self-Assessment](https://drive.google.com/open?id=1EFwZLMB4qZLZdz98NKGV-TLnJrquLiqo)
 
-### Reviewing an employee mid year self-assessment
+## Reviewing an employee mid year self-assessment
 
 Self-assessments are **not required** for the mid year review; however, Supervisors can request that their direct reports submit one.
 
@@ -78,19 +76,19 @@ Self-assessments are **not required** for the mid year review; however, Supervis
   * No action required by employee
   * [Supervisor](https://docs.google.com/document/d/1iduOW_V1NNqGnZkm7TAwzzr4oIZPZW3UG-f1QdaLD-w/edit#heading=h.dc4dfn7ht52u)
 
-### Submitting mid year assessment comments
+## Submitting mid year assessment comments
 
 * Step-by-step instructions:
   * No action required by employee
   * [Supervisor](https://docs.google.com/document/d/1iduOW_V1NNqGnZkm7TAwzzr4oIZPZW3UG-f1QdaLD-w/edit#heading=h.c3fz56zdlqf2)
 
-### Submitting a mid year progress review
+## Submitting a mid year progress review
 
 * Step-by-step instructions:
   * No action required by employee
   * [Supervisor](https://docs.google.com/document/d/1iduOW_V1NNqGnZkm7TAwzzr4oIZPZW3UG-f1QdaLD-w/edit#heading=h.htn3ziu4jxow)
 
-### Tracking employee progress
+## Tracking employee progress
 
 It is critical that all mid-year performance plan evaluations are acknowledged by employees before June 1.
 
@@ -98,13 +96,13 @@ It is critical that all mid-year performance plan evaluations are acknowledged b
   * No action required by employee
   * [Supervisor](https://docs.google.com/document/d/1iduOW_V1NNqGnZkm7TAwzzr4oIZPZW3UG-f1QdaLD-w/edit#heading=h.34676ir5s3g8)
 
-### Acknowledging a review
+## Acknowledging a review
 
 * Step-by-step instructions:
   * [Employee](https://docs.google.com/document/d/1VxwbatliieP78-qN_VmdHxt1ROvSro4yKe9-OkjQd58/edit#heading=h.6ykmn1ge2hlk)
   * No action required by supervisor
 
-### Overriding an employee acknowledgment
+## Overriding an employee acknowledgment
 
 A supervisor can acknowledge an employee evaluation if the employee is unable to (i.e. on vacation) or refuses to do so (i.e. does not agree with the evaluation).
 

--- a/_pages/performance-management/performance-management-employee-resources.md
+++ b/_pages/performance-management/performance-management-employee-resources.md
@@ -13,16 +13,14 @@ questions:
 
 This page contains additional resources and trainings for employees who are going through the performance management process.  Visit the Quick Links section of the [Performance Management Overview]({{site.baseurl}}/performance-management/) page for the Performance Management Employee Checklist.  
 
-## Employee resources
-
-### [Employee performance management checklist](https://docs.google.com/spreadsheets/d/1nhV-jGGygdNgKfYJEamKAVux5eBW5rf5Lj1maXFUt08/edit#gid=48334538)
+## [Employee performance management checklist](https://docs.google.com/spreadsheets/d/1nhV-jGGygdNgKfYJEamKAVux5eBW5rf5Lj1maXFUt08/edit#gid=48334538)
 
 * Use the [Employee performance management checklist](https://docs.google.com/spreadsheets/d/1nhV-jGGygdNgKfYJEamKAVux5eBW5rf5Lj1maXFUt08/edit#gid=48334538) (please make a copy!) to guide you through the end of FY19 performance review process
   * *NOTE: Items highlighted in green are particularly important steps*
 
-### Guidance
+## Guidance
 
-#### [InSite](https://insite.gsa.gov)
+### [InSite](https://insite.gsa.gov)
 
 * [InSite Performance Plan FAQ](https://insite.gsa.gov/topics/hr-pay-and-leave/performance-management/policies/associate-performance-plan-and-appraisal-system-appas-faqs)
 
@@ -35,7 +33,7 @@ This page contains additional resources and trainings for employees who are goin
     * Employee Guide for Writing a Self-Assessment
     * Supervisors Award Guide
 
-#### [HR Links](https://hrlinks.gsa.gov/)
+### [HR Links](https://hrlinks.gsa.gov/)
 
 * [HR Links Performance Management Guide](https://drive.google.com/file/d/1mn-3yC3tN5dC4ppDSoRFi41W1vWSZzGX/view): Guide for entering all components of a performance review into HR Links
     * Establishing a performance plan
@@ -44,13 +42,13 @@ This page contains additional resources and trainings for employees who are goin
     * Acknowledging a performance plan
     * Entering a self-assessment (Page 7, Section 3.3)
 
-#### Gather supporting documentation
+### Gather supporting documentation
 
 Supporting documentation that aligns with your Performance Management Plan is ***optional*** for the performance review process. Examples of supporting documentation include emails, written performance counseling, customer feedback, survey results, supervisory notes, database/spreadsheets, and/or work samples within the current rating cycle.
 
 This information can be shared with your Supervisor during your mid-year and end-of-year 1:1 performance review conversation.
 
-### Training
+## Training
 
 * Online [Performance Management Program](https://hcm03.ns2cloud.com/sf/learning?destUrl=https%3a%2f%2fgsa%2dhcm03%2ens2cloud%2ecom%2flearning%2fuser%2fdeeplink%5fredirect%2ejsp%3flinkId%3dPROGRAM%5fDETAILS%26programID%3dGSA%2dPERFORMANCE%5fMANAGEMENT%26fromSF%3dY&company=GSAHCM03) to support performance management of both organizations and employees including tools and job aids.  Courses include, but is not limited to the following:
     * Performance Management Overview – Refresher and introduction of the performance management program.
@@ -66,7 +64,7 @@ This information can be shared with your Supervisor during your mid-year and end
     * Acknowledge a Mid-Year Progress Review
     * Acknowledge an Evaluation
 
-#### [OLU Performance Management Program](https://hcm03.ns2cloud.com/sf/learning?destUrl=https%3a%2f%2fgsa%2dhcm03%2ens2cloud%2ecom%2flearning%2fuser%2fdeeplink%5fredirect%2ejsp%3flinkId%3dPROGRAM%5fDETAILS%26programID%3dGSA%2dPERFORMANCE%5fMANAGEMENT%26fromSF%3dY&company=GSAHCM03)
+### [OLU Performance Management Program](https://hcm03.ns2cloud.com/sf/learning?destUrl=https%3a%2f%2fgsa%2dhcm03%2ens2cloud%2ecom%2flearning%2fuser%2fdeeplink%5fredirect%2ejsp%3flinkId%3dPROGRAM%5fDETAILS%26programID%3dGSA%2dPERFORMANCE%5fMANAGEMENT%26fromSF%3dY&company=GSAHCM03)
 
 Courses include, but is not limited to the following:
 

--- a/_pages/performance-management/performance-management-hrlinks-steps.md
+++ b/_pages/performance-management/performance-management-hrlinks-steps.md
@@ -16,9 +16,7 @@ This page contains step-by-step instructions for employees and supervisors on ho
 
 If you're having issues with logging into HR Links while using Google Chrome, please use these [instructions to clear your site cache](https://docs.google.com/document/d/13j6e8bAVSWFSNNkqmU2hMfwXOCBsi49d_2EqvL3aKXE/edit?usp=sharing).
 
-## HR Links performance management steps
-
-### Creating a new performance plan
+## Creating a new performance plan
 In most cases, supervisors should own the creation of performance plans for direct reports.  This step applies to employees who require a new performance plan such as new employees and existing employees who have recently changed roles.
 
 * Step-by-step instructions:
@@ -29,14 +27,14 @@ In most cases, supervisors should own the creation of performance plans for dire
 * HR Links in-depth guide (with screenshots):
   * [Supervisor (Section 1, Topic 1.1)](https://drive.google.com/open?id=15Xm9NF_KfcWN-ZxPomooowEAq51073Xi)
 
-### Copying an existing performance plan
+## Copying an existing performance plan
 In most cases, supervisors should own the creation of performance plans for direct reports.  This step applies to employees that will be on a performance plan that is consistent with their prior year.
 
 * Step-by-step instructions:
   * No action required by employee
   * [Supervisor](https://docs.google.com/document/d/1TM7PPr1rSRRdot92uguf_bJJ5HWdAAqKyhcI2BqlCBs/edit#heading=h.4ov23tpb7l01)
   
-### Updating a performance plan
+## Updating a performance plan
 After copying (cloning) a prior year performance plan, updates to the critical elements will likely be needed to align with current fiscal year goals.  This section provides resources, including prior year examples, for updating performance plans.
 
 * [FY21 TTS Performance Plan Framework](https://docs.google.com/document/d/1Hxj17-hm9GaAKRRZRPA0_f1RPqswIlmuN6yQknWgba8/edit)
@@ -46,7 +44,7 @@ After copying (cloning) a prior year performance plan, updates to the critical e
 * [FY21 Business Unit Critical Elements Builder](https://docs.google.com/spreadsheets/d/1mWpN4mSYUaFxYUP8QmcQPMUwVzki-0-0vz1R70-uNkQ/edit#gid=612468956)
   * Provides a template to write out critical elements, definitions of the critical elements, and links to prior year examples
 
-### Submitting a performance plan for employee approval
+## Submitting a performance plan for employee approval
 
 * Step-by-step instructions:
   * No action required by employee
@@ -55,7 +53,7 @@ After copying (cloning) a prior year performance plan, updates to the critical e
 * HR Links in-depth guide (with screenshots):
   * [Supervisor (Section 1, Topic 1.2)](https://drive.google.com/open?id=15Xm9NF_KfcWN-ZxPomooowEAq51073Xi)
 
-### Acknowledging a performance plan
+## Acknowledging a performance plan
 
 * Step-by-step instructions:
   * [Employee](https://docs.google.com/document/d/1VxwbatliieP78-qN_VmdHxt1ROvSro4yKe9-OkjQd58/edit#heading=h.u5b15qifcg0q)
@@ -66,7 +64,7 @@ After copying (cloning) a prior year performance plan, updates to the critical e
   * [Employee (Section 1, Topic 1.3)](https://drive.google.com/file/d/1NhoDr9MlNTP9VEgBx72H-KoPjNeivOwv/view)
   * [Supervisor (Section 1, Topic 1.2)](https://drive.google.com/open?id=15Xm9NF_KfcWN-ZxPomooowEAq51073Xi)
 
-### Re-opening a performance plan
+## Re-opening a performance plan
 
 If modifications need to be made to an existing performance plan, a plan can be re-opened by the Supervisor and [resubmitted to the employee to acknowledge]({{site.baseurl}}/performance-management-hrlinks-steps/#submitting-a-performance-plan-for-employee-approval).
 
@@ -76,7 +74,7 @@ If modifications need to be made to an existing performance plan, a plan can be 
   * No action required by employee
   * [Supervisor](https://docs.google.com/document/d/1TM7PPr1rSRRdot92uguf_bJJ5HWdAAqKyhcI2BqlCBs/edit#heading=h.hf3nfjxrhb8h)
 
-### Entering a self-assessment
+## Entering a self-assessment
 
 * Step-by-step instructions:
   * [Employee](https://docs.google.com/document/d/1VxwbatliieP78-qN_VmdHxt1ROvSro4yKe9-OkjQd58/edit#heading=h.2bzg793t31vu)
@@ -88,7 +86,7 @@ If modifications need to be made to an existing performance plan, a plan can be 
 * Additional resource guide:
   * [GSA Employee Guide to Writing an Effective Self-Assessment](https://drive.google.com/open?id=1EFwZLMB4qZLZdz98NKGV-TLnJrquLiqo)
 
-### Nominating participant reviewer(s)
+## Nominating participant reviewer(s)
 
 This process allows supervisors and employees to [solicit feedback](https://drive.google.com/open?id=1O3G3fa2ezbz_SUqBRT3OZRt0QPrLapl6) from other supervisors or colleagues regarding their Performance Plan. HR Links allows both employees and supervisors to nominate and track participant reviews; however, only supervisors can officially submit a nomination.  If an employee nominates another employee for feedback on their performance, the nomination is submitted to the supervisor for approval.
 
@@ -102,7 +100,7 @@ Once nominated, participant reviewers receive a notification alerting them of th
   * [Employee (Section 3, Topic 3.1)](https://drive.google.com/file/d/1NhoDr9MlNTP9VEgBx72H-KoPjNeivOwv/view)
   * [Supervisor (Section 3, Topic 3.2)](https://drive.google.com/open?id=15Xm9NF_KfcWN-ZxPomooowEAq51073Xi)
 
-### Submitting a participant review
+## Submitting a participant review
 Submitting a participant review in HR Links is the same process for all nominated colleagues regardless of their reporting relationship to the employee.  TTS Supervisors will have to review and approve all participant reviews for their direct reports in HR Links as part of the final employee evaluation submittal process.
 
 * Step-by-step instructions:
@@ -112,7 +110,7 @@ Submitting a participant review in HR Links is the same process for all nominate
 * HR Links in-depth guide:
   * [Employee (Section 3, Topic 3.2)](https://drive.google.com/file/d/1NhoDr9MlNTP9VEgBx72H-KoPjNeivOwv/view)
 
-### Reviewing an employee self-assessment
+## Reviewing an employee self-assessment
 
 * Step-by-step instructions:
   * No action required by employee
@@ -121,7 +119,7 @@ Submitting a participant review in HR Links is the same process for all nominate
 * HR Links in-depth guide (with screenshots):
   * [Supervisor (Section 3, Topic 3.3)](https://drive.google.com/open?id=15Xm9NF_KfcWN-ZxPomooowEAq51073Xi)
 
-### Reviewing evaluations from participant reviewer(s)
+## Reviewing evaluations from participant reviewer(s)
 
 * Step-by-step instructions:
   * No action required by employee
@@ -131,7 +129,7 @@ Submitting a participant review in HR Links is the same process for all nominate
  * HR Links in-depth guide (with screenshots):
   * [Supervisor (Section 3, Topic 3.3)](https://drive.google.com/open?id=15Xm9NF_KfcWN-ZxPomooowEAq51073Xi)
 
-### Submitting an evaluation
+## Submitting an evaluation
 
 * Step-by-step instructions:
   * No action required by employee
@@ -140,7 +138,7 @@ Submitting a participant review in HR Links is the same process for all nominate
 * HR Links in-depth guide (with screenshots):
   * [Supervisor (Section 3, Topic 3.4)](https://drive.google.com/open?id=15Xm9NF_KfcWN-ZxPomooowEAq51073Xi)
 
-### Acknowledging an evaluation
+## Acknowledging an evaluation
 
 * Step-by-step instructions:
   * [Employee](https://docs.google.com/document/d/1VxwbatliieP78-qN_VmdHxt1ROvSro4yKe9-OkjQd58/edit#heading=h.6ykmn1ge2hlk)
@@ -149,7 +147,7 @@ Submitting a participant review in HR Links is the same process for all nominate
 * HR Links in-depth guide (with screenshots):
   * [Employee (Section 3, Topic 3.4)](https://drive.google.com/file/d/1NhoDr9MlNTP9VEgBx72H-KoPjNeivOwv/view)
 
-### Confirming that performance plans have been established
+## Confirming that performance plans have been established
 
 It is critical that all FY20 performance plan evaluations are acknowledged by employees before November 16 and all FY21 performance plans are acknowledged by employees before November 30. The status of employee performance management can be checked in the *Team Performance Supervisor dashboard*:
 
@@ -160,7 +158,7 @@ It is critical that all FY20 performance plan evaluations are acknowledged by em
 * HR Links in-depth guide (with screenshots):
   * [Supervisor (Section 3, Topic 3.1)](https://drive.google.com/open?id=15Xm9NF_KfcWN-ZxPomooowEAq51073Xi)
   
-### Closing out an interim performance plan (the plan will not factor into the end of year performance award)
+## Closing out an interim performance plan (the plan will not factor into the end of year performance award)
 
 If a TTS employees has two performance plans of record for FY20, both plans need to be closed out; however, only the most recent plan will factor into the end of year performance award if the other plan is closed out properly.  Supervisors should discuss both plans with their direct reports and provide ratings that are as accurate as possible because both plans will still be visible in the employee's record.  The step-by-step instructions below show how to rate and submit the "old" plan properly.
 
@@ -168,6 +166,6 @@ If a TTS employees has two performance plans of record for FY20, both plans need
   * No action required by employee
   * Supervisor will need to [follow these instructions](https://docs.google.com/document/d/10WP9J0MeH-PovXlZqXvkAH_ePQuHaPnXZnou2FEq0_I/edit)
 
-### Selecting Time Off Award in lieu of cash performance award
+## Selecting Time Off Award in lieu of cash performance award
 
 Information will be updated pending guidance from GSA.

--- a/_pages/performance-management/performance-management-supervisor-resources.md
+++ b/_pages/performance-management/performance-management-supervisor-resources.md
@@ -13,16 +13,14 @@ questions:
 
 This page contains additional resources and trainings for supervisors who are going through the performance management process.  Visit the Quick Links section of the [Performance Management Overview]({{site.baseurl}}/performance-management/) page for additional resources, including the [Performance Management Employee Checklist](https://docs.google.com/spreadsheets/d/1nhV-jGGygdNgKfYJEamKAVux5eBW5rf5Lj1maXFUt08/edit#gid=160010559) which Supervisors can use to track the progress of their own performance reviews.  
 
-## Supervisor resources
-
-### Supervisor performance management checklist
+## Supervisor performance management checklist
 
 * Use the [Supervisor performance management checklist](https://docs.google.com/spreadsheets/d/1FkdV6FNOxDAZLuFBYJKK-3hgVE5lvIVQ31PKe3dZ628/edit#gid=884911250) to guide you through end of FY20 performance reviews and to help establish FY21 performance plans.
   * *NOTE: Items highlighted in green are particularly important steps*
 
-### GSA Performance Management Resources
+## GSA Performance Management Resources
 
-#### [InSite](https://insite.gsa.gov)
+### [InSite](https://insite.gsa.gov)
 
 * [InSite Performance Plan FAQ](https://insite.gsa.gov/topics/hr-pay-and-leave/performance-management/policies/associate-performance-plan-and-appraisal-system-appas-faqs)
 
@@ -39,13 +37,13 @@ This page contains additional resources and trainings for supervisors who are go
     * Supervisors Award Guide
     * A Guide To Provide Meaningful Recognition
 
-#### [HR Links](https://hrlinks.gsa.gov/)
+### [HR Links](https://hrlinks.gsa.gov/)
 
 * [Technical HR Links assistance](https://corporateapps.gsa.gov/hr-links/support/)
   * Instructions if you receive the error message "The document could not be created as the employee is not hired yet. Please contact your system administrator to check the Job record to make sure employee is hired before period begin date of the document."
     * *Note: The rating period begin must be set after the hire date in HR Links.  It is recommended that the supervisor copy the overall performance comments into HR Links because the comments will then populate on Form 3440 to support the overall rating*
 
-#### Discussing performance expectations with a new direct report
+### Discussing performance expectations with a new direct report
 
 When an employee joins TTS or changes supervisors within TTS, it is important that the supervisor establish new performance expectations with the employee through dialogue and ultimately in the official [performance plan]({{site.baseurl}}/performance-management-hrlinks-steps/#creating-a-new-performance-plan). Performance expectations must be developed to describe the expected level of performance at a Level 3 rating; supervisors are encouraged to establish performance expectations for other levels if deemed appropriate.
 
@@ -63,25 +61,25 @@ When an employee joins TTS or changes supervisors within TTS, it is important th
 * [InSite Performance Management Guide](https://insite.gsa.gov/topics/hr-pay-and-leave/performance-management/planning-performance)
   * Page 19 - Managers Guide End of Year Review & Establishing Expectations
 
-#### Performance improvement and performance action plans
+### Performance improvement and performance action plans
 
 Performance not at Level 3 in any Critical Element needs to be addressed formally. While this can be issued at any time, an employee who will be rated at Level 1 or 2 in any category on their FY20 Performance Plan *must be issued* either a Performance Improvement Plan (PIP) for a Level 1 rating or a Performance Action Plan (PAP) for a Level 2 rating.  
 
 To initiate either plan, reach out to [Mei Goon](mailto:mei.goon@gsa.gov), TTS’s Employee & Labor Relations Specialist. Mei will work directly with you to create the PIP/PAP for your team member; supporting documentation will need to be submitted to Jim for review when creating the PIP/PAP.
 
-#### Verifying your direct reports
+### Verifying your direct reports
 
 In preparation for the FY20 End-of-Year Employee Performance Review Cycle, please conduct an audit of your Direct Reports in HR Links by following the instructions in the [FY20 Direct Report Audit Survey](https://forms.gle/oLtit3o2MLsSUonx5).
 
 All supervisors should complete the FY20 audit by COB September 25th, so please fill out the above survey if you have not yet.
 
-#### 1 on 1 performance conversation
+### 1 on 1 performance conversation
 
 This meeting is an opportunity to rate, recognize and give your direct report constructive feedback (formal or informal) regarding the results of their work within the established expectations, goals, and objectives outlined in the performance plan.  
 
 ***See below for how to prepare for this meeting.***
 
-#### Preparing for 1 on 1 performance conversation
+### Preparing for 1 on 1 performance conversation
 
 Gather emails, written performance counseling, customer feedback, survey results, supervisory notes, database/spreadsheets, and/or work samples about the employee’s performance that you observed within the current rating cycle. Prepare feedback for your direct reports that's backed with specific data points and examples, regardless of whether it will be constructive criticism or praise. When providing constructive criticism, it is recommended that you have clear examples of the desired behavior.
 
@@ -96,7 +94,7 @@ Here’s a pre-feedback checklist you may want to consider:
 * Are your comments straightforward without adding caveats?
 * Do you have a plan for regular check-ins to ensure consistent and ongoing development and improvement?
 
-#### Submitting an evaluation for a direct report who isn't assigned to their supervisor in HR Links
+### Submitting an evaluation for a direct report who isn't assigned to their supervisor in HR Links
 
 For instances when a direct report is not assigned to their first line supervisor in HR Links or their supervisor doesn't have HR Links manager access, there are two primary options for the first line supervisor to be able to contribute to the evaluation:
 
@@ -106,35 +104,35 @@ For instances when a direct report is not assigned to their first line superviso
 1. The second line supervisor can [nominate the first line supervisor as a participant reviewer]({{site.baseurl}}/performance-management-hrlinks-steps/#nominating-participant-reviewers) so that the first line supervisor can submit an evaluation for their direct report in HR Links after the 1:1 conversation.
   * ***NOTE: The nominated supervisor's feedback is not automatically included as a comment in the employees performance review. HR Links creates a separate document, so it is recommended that the second line supervisor cuts and paste the feedback into the summary comments.***  
 
-#### Approving/Denying a level 1 or level 5 summary performance rating
+### Approving/Denying a level 1 or level 5 summary performance rating
 
 If an employee has received a Summary Rating of Level 1 or 5, the evaluation will automatically be routed to the employee’s 2nd level supervisor (the supervisor of the employee’s supervisor) for approval. To approve or deny a Summary Rating of Level 1 or 5, the employee’s 2nd Level Supervisor must follow the instructions below:
 
 * HR Links in-depth guide (with screenshots):
   * [Supervisor (Section 4, Topic 4.1)](https://drive.google.com/open?id=15Xm9NF_KfcWN-ZxPomooowEAq51073Xi)
 
-#### Cancelling an HR Links evaluation
+### Cancelling an HR Links evaluation
 
 The only time a supervisor may want to cancel an evaluation is when an employee separates and evaluation cannot be completed or it’s not necessary.  Only and HR Admin can cancel “submitted” evaluations.  Please reach out to [Jim Mulvaney](mailto:james.mulvaney@gsa.gov) to initiate this process.
 
-#### Overriding an HR Links employee acknowledgement
+### Overriding an HR Links employee acknowledgement
 
 A supervisor may need to approve an employee performance plan or employee evaluation on behalf of their employee if the employee is unable to (i.e. on vacation) or refuses to do so (i.e. does not agree with the evaluation).
 
   * [Overriding an employee performance plan approval step-by-step instructions](https://docs.google.com/document/d/1TM7PPr1rSRRdot92uguf_bJJ5HWdAAqKyhcI2BqlCBs/edit#heading=h.hf3nfjxrhb8h)
   * [Overriding an employee evaluation acknowledgment step-by-step instructions](https://docs.google.com/document/d/1TM7PPr1rSRRdot92uguf_bJJ5HWdAAqKyhcI2BqlCBs/edit#heading=h.u17jlta6re6m)
 
-#### Leveraging diversity performance measure
+### Leveraging diversity performance measure
 
 All FY21 **supervisory performance plans** must include the “Leveraging Diversity” measure. For guidance on adding this to supervisory plans [click here](https://docs.google.com/document/d/1LPe6rKUze_tA3OfHhRLUfLSQtY4m8d4J3k4OZq2oFcY/edit#heading=h.7ki5n23m5zhy).
 
-### Additional training
+## Additional training
 
-#### Supervisors’ Lounge Question and Answer Sessions
+### Supervisors’ Lounge Question and Answer Sessions
 
 Information will be updated when sessions are set.
 
-#### [HR Links Online Training and Guidance](https://insite.gsa.gov/topics/hr-pay-and-leave/performance-management/performance-management-systems)
+### [HR Links Online Training and Guidance](https://insite.gsa.gov/topics/hr-pay-and-leave/performance-management/performance-management-systems)
 
 Courses include, but is not limited to the following:
 
@@ -143,7 +141,7 @@ Courses include, but is not limited to the following:
   * Complete a Mid-Year Progress Review
   * Submit Employee Evaluation
 
-#### [OLU Performance Management Program](https://hcm03.ns2cloud.com/sf/learning?destUrl=https%3a%2f%2fgsa%2dhcm03%2ens2cloud%2ecom%2flearning%2fuser%2fdeeplink%5fredirect%2ejsp%3flinkId%3dPROGRAM%5fDETAILS%26programID%3dGSA%2dPERFORMANCE%5fMANAGEMENT%26fromSF%3dY&company=GSAHCM03)
+### [OLU Performance Management Program](https://hcm03.ns2cloud.com/sf/learning?destUrl=https%3a%2f%2fgsa%2dhcm03%2ens2cloud%2ecom%2flearning%2fuser%2fdeeplink%5fredirect%2ejsp%3flinkId%3dPROGRAM%5fDETAILS%26programID%3dGSA%2dPERFORMANCE%5fMANAGEMENT%26fromSF%3dY&company=GSAHCM03)
 
 Courses include, but is not limited to the following:
 


### PR DESCRIPTION
Minor: The `<h2>`s were redundant with the overall page titles, and having everything else at `<h3>`s or below made the navigation more crowded than it needs to be.