### PR TITLE
clarify that operating system upgrades should only be done with go-ahead from GSA IT

### DIFF
--- a/_pages/getting-started/equipment.md
+++ b/_pages/getting-started/equipment.md
@@ -17,7 +17,7 @@ TTS employees are issued an Apple MacBook Air/Pro computer. Note that this is no
 
 ### Operating System
 
-Your laptop will come preloaded with the latest, GSA-approved Mac operating system. At this time, GSA is not ready to upgrade to the [Catalina macOS](https://www.apple.com/macos/catalina/). The TTS Tech Portfolio will send out a TTS-wide email and update the most recent [notification](https://gsa-tts.slack.com/files/T025AQGAN/FP49NEXMY?origin_team=T025AQGAN) in Slack when it is appropriate to upgrade.
+Your laptop will come preloaded with the latest, GSA-approved/supported Mac operating system. Please wait to do any operating system upgrades (including patches) until notified by GSA IT.
 
 ### Rules
 


### PR DESCRIPTION
Just got clarification in the Mac Working Group.