### PR TITLE
documentation changes for new TTS-wide SaaS onboarding procedures

### DIFF
--- a/_pages/software-tools/github.md
+++ b/_pages/software-tools/github.md
@@ -3,7 +3,6 @@ title: GitHub
 tag:
   - Git
 questions:
-  - git
   - admins-github
   - dev
 ---
@@ -35,11 +34,6 @@ Include the following:
 Take a look at [your notification settings](https://github.com/settings/notifications). In particular, it's suggested that you turn off `Automatically watch repositories`. You may also want to take a look at [tips for filtering GitHub notifications in email](https://help.github.com/en/github/managing-subscriptions-and-notifications-on-github/configuring-notifications#filtering-email-notifications).
 
 ### 4. Join the 18F organization
-
-All TTS staff should be added here. Ask in [#admins-github](https://gsa-tts.slack.com/messages/admins-github/) to "please add me (`https://github.com/username`) to [team]," which will be one of the following:
-
-- [`18f-staff`](https://github.com/orgs/18F/teams/18f-staff)
-- One of the [TTS teams](https://github.com/orgs/18F/teams/tts-gsa-partners/teams)
 
 An admin will add you, after which you'll need to accept their invite from the email or by going [here](https://github.com/orgs/18F/invitation?via_email=1).
 
@@ -201,6 +195,19 @@ TTS is heavily involved in the following GitHub organizations:
 <sup>2</sup>: For the ones that are TTS-managed, get help in [#admins-github](https://gsa-tts.slack.com/messages/admins-github).
 
 We automate some administration of our repositories - see [`ghad`](https://github.com/18F/ghad) for more info.
+
+### Onboarding
+
+When people join TTS, they get added to [the 18F org](https://github.com/18F), and possibly others (in list above). Not everyone will end up using GitHub, but they are granted access by default. The following GitHub teams correspond to the different business units:
+
+- [18f-staff](https://github.com/orgs/18F/teams/18f-staff/members)
+- [COEs](https://github.com/orgs/18F/teams/coes/members) (Centers of Excellence)
+- [Outreach](https://github.com/orgs/18F/teams/outreach/members)
+- [PIF](https://github.com/orgs/18F/teams/pif/members) (Presidential Innovation Fellows)
+- [OA](https://github.com/orgs/18F/teams/oa/members) (Office of Acquisition)
+- [solutions](https://github.com/orgs/18F/teams/solutions/members) - portfolios will handle adding them to the appropriate team(s) within there
+- [strategic-partnerships](https://github.com/orgs/18F/teams/strategic-partnerships/members)
+- [tts-bizops](https://github.com/orgs/18F/teams/tts-bizops/members)
 
 ## Resources
 

--- a/_pages/software-tools/trello.md
+++ b/_pages/software-tools/trello.md
@@ -8,11 +8,7 @@ questions:
 
 ## Setup
 
-To get access to [the TTS Trello Team](https://trello.com/18f3/):
-
-1. Ask for an invite in [#admins-trello](https://gsa-tts.slack.com/messages/admins-trello) with the following script: "Please invite me to https://trello.com/18f3/members."
-1. You will get an invite to your GSA email address.
-1. [Set up two-factor authentication](https://trello.com/2fa)
+You should have gotten an invite to [the TTS Trello Team](https://trello.com/18f3/). Once your account is created, please [set up two-factor authentication](https://trello.com/2fa).
 
 There are some other Trello Teams in TTS; speak with your office to find out if there's one you should be added to.
 

--- a/tools/mural.md
+++ b/tools/mural.md
@@ -2,13 +2,15 @@
 title: Mural
 redirect_from:
   - /murally/
+questions:
+  - admins-mural
 ---
 
 [Mural](https://mural.co/) is a collaborative whiteboard and sticky note tool. Formerly known as Mural.ly.
 
 ## Setup
 
-Because Mural is a web application, there’s no installation necessary. You will need to set up an account, however. If you don’t already have a Mural account, ask in Slack in the [#admins-mural](https://gsa-tts.slack.com/messages/admins-mural) channel for the invitation link, and from there, create an account with your GSA email address. In order to have access to all TTS public rooms and create your own rooms, you need an admin to give you those permissions. Post a link the [#admins-mural](https://gsa-tts.slack.com/messages/admins-mural) channel to get access.
+Because Mural is a web application, there’s no installation necessary. You will need to set up an account, however. If you don’t already have a Mural account, ask in Slack in the [#admins-mural](https://gsa-tts.slack.com/messages/admins-mural) channel for an invite, and from there, create an account with your GSA email address. In order to have access to all TTS public rooms and create your own rooms, you need an admin to give you those permissions.
 
 ## Usage
 


### PR DESCRIPTION
New staff will be added to the appropriate place by the Onboarding Lead, so they no longer need to ask. The new GitHub instructions are for the Onboarding Lead.