### PR TITLE
add page around Eventbrite

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -505,6 +505,9 @@ primary:
           - text: DocuSign (digital signatures; replaced eSign)
             url: digital-signatures/
             internal: true
+          - text: Eventbrite
+            url: tools/eventbrite/
+            internal: true
           - text: GitHub (code repos and versioning)
             url: github/
             internal: true

--- a/tools/eventbrite.md
+++ b/tools/eventbrite.md
@@ -1,0 +1,28 @@
+---
+title: Eventbrite
+questions:
+  - event-management
+---
+
+TTS uses [Eventbrite](https://www.eventbrite.com/) to manage registrations for events we host.
+
+## Rules
+
+The following are required for accessibility reasons:
+
+- Include the following in the [event description](https://www.eventbrite.com/support/articles/en_US/Multi_Group_How_To/how-to-create-an-event?lg=en_US#2-2):
+
+  > Thank you for your interest in this event. Please contact us directly at [email] if you need accessible accommodations to be able to attend or assistance with registering for the event.
+
+- [Set the time limit to complete an order](https://www.eventbrite.com/support/articles/en_US/How_To/how-to-increase-or-decrease-the-amount-of-time-to-complete-an-order) to 20 minutes
+
+## See also
+
+- [Meetings and meeting tools]({{site.baseurl}}/meetings-and-meeting-tools/)
+- [Listing events on gsa.gov](https://insite.gsa.gov/employee-resources/communications/digital-website-communication/gsagov-and-gsa-insite/using-the-content-management-platform-cmp/gsagov-and-gsa-insite-events)
+- digital.gov's:
+  - [Organizer profile](https://www.eventbrite.com/o/digitalgov-events-5601281415)
+  - [Event Process](https://github.com/GSA/digitalgov.gov/wiki/Our-Typical-Event-Process)
+  - [Event Best Practices](https://github.com/GSA/digitalgov.gov/wiki/Event-Best-Practices)
+  - [Event Brief Template](https://docs.google.com/document/d/19nWpoa-v61MrqXWjI7U1aNdm0e7d1MPNEHhRx6TRJ2s/edit)
+- [FedRAMP's organizer profile](https://www.eventbrite.com/o/fedramp-pmo-13413630716)


### PR DESCRIPTION
Wanted to make sure to capture [this determination](https://gsa-tts.slack.com/archives/CNW3GL70S/p1604591826350800?thread_ts=1604588662.348800&cid=CNW3GL70S) around use of Eventbrite somewhere more permanent.