### PR TITLE
update information about TTS-wide announcements

### DIFF
--- a/_pages/business-units/operations/outreach/outreach.md
+++ b/_pages/business-units/operations/outreach/outreach.md
@@ -44,3 +44,22 @@ You can also reach the whole team at tts-outreach@gsa.gov.
 - [#tweet-this](https://gsa-tts.slack.com/archives/tweet-this) is where we coordinate activity for TTS Twitter accounts. Hop in here if you’d like an official account to tweet something or respond to a tweet.
 - [#press](https://gsa-tts.slack.com/archives/press) is for collecting press mentions of TTS. If you see something inaccurate in a story posted in press, you can contact the Outreach team to see if we can get it corrected.
 - [#training-conferences](https://gsa-tts.slack.com/archives/training-conferences): This channel is not managed by the Outreach team, but this is where you go if you’ve been asked to speak at an event, or if you want to speak at an event and may need approval. Outreach can help you with content for a talk, but the Governance and Compliance team handles approvals.
+
+## How to make TTS-wide announcements
+
+You might have a need to get a message to all of TTS, such as:
+
+- Major events impacting all of TTS or a TTS Business unit
+- Required trainings
+- Necessary security and compliance actions
+- Policy changes or reminders
+- All-team events
+- Senior management team meeting notes
+- Changes or actions that impact the entire team
+
+To send, **reach out to us in [#outreach](https://gsa-tts.slack.com/archives/news)**. We will:
+
+1. Copyedit the message
+1. Get approvals (if needed)
+1. Email to all of TTS
+1. Cross-post in [#news](https://gsa-tts.slack.com/archives/news)

--- a/_pages/business-units/operations/outreach/outreach.md
+++ b/_pages/business-units/operations/outreach/outreach.md
@@ -57,7 +57,7 @@ You might have a need to get a message to all of TTS, such as:
 - Senior management team meeting notes
 - Changes or actions that impact the entire team
 
-To send, **reach out to us in [#outreach](https://gsa-tts.slack.com/archives/news)**. We will:
+To send, **reach out to us in [#outreach](https://gsa-tts.slack.com/archives/outreach)**. We will:
 
 1. Copyedit the message
 1. Get approvals (if needed)

--- a/tools/slack/guidelines.md
+++ b/tools/slack/guidelines.md
@@ -12,6 +12,7 @@ See the [Slack @ TTS](https://docs.google.com/document/d/1Hm42cg61S7FPhaLrRIJxl-
 
 ## Channels
 
+- [#news](https://gsa-tts.slack.com/messages/news/) - [TTS-wide announcements]({{site.baseurl}}/outreach/#how-to-make-tts-wide-announcements)
 - Teams
   - 18F - [#news-18f](https://gsa-tts.slack.com/messages/news-18f/) for all 18F-level announcements
   - [Solutions](https://gsa-tts.slack.com/messages/solutions/)
@@ -25,20 +26,6 @@ See the [Slack @ TTS](https://docs.google.com/document/d/1Hm42cg61S7FPhaLrRIJxl-
   - [distributed](https://gsa-tts.slack.com/messages/distributed/)
 
 See a list of other popular channels in the [Slack @ TTS](https://docs.google.com/document/d/1Hm42cg61S7FPhaLrRIJxl-LXQCcwGvJTKX_wG0Jz4aU/edit#heading=h.b0dsxkh3r8wi) guide.
-
-## How to make an announcement in #news
-
-Use #news for vital team announcements. [#news](https://gsa-tts.slack.com/archives/news) is an announcement-only channel where only administrators can post. If you have a post you'd like to go up in #news, ask in [#outreach](https://gsa-tts.slack.com/archives/news).
-
-Please keep #news posts limited to information that the entire team needs to know. This includes things like:
-
-- Major events impacting all of TTS or a TTS Business unit
-- Required trainings
-- Necessary security and compliance actions
-- Policy changes or reminders
-- All-team events
-- Senior management team meeting notes
-- Changes or actions that impact the entire team
 
 ## Frequently-used emoji
 


### PR DESCRIPTION
There seems to be a new procedure that is less Slack-centric, so moved that information to the Outreach page (for lack of a better place).

@AndreaSigz This may be worth expanding to a more general "How we decide what goes in #news/newsletters/TTS-wide email etc." Just a thought!