### PR TITLE
link to org chart directly from navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -17,8 +17,8 @@ primary:
         url: code-of-conduct/
         internal: true
       - text: Org chart
-        url: org-chart/
-        internal: true
+        url: https://docs.google.com/presentation/d/1otRbhoGRN4LfDnWpN6zZ0ymjPpTBW3t79pIiuBREkCY/edit
+        internal: false
       - text: 2020 Strategy
         url: https://docs.google.com/document/d/1uidmcUfdxOeCt23nJ4VI1M10HV3W44ImMPLgwbx1QJM/edit
         internal: false


### PR DESCRIPTION
This will make the navigation show the lock icon, meaning that it's only visible to staff.

<img width="203" alt="Screen Shot 2021-01-11 at 4 13 00 PM" src="https://user-images.githubusercontent.com/86842/104239051-e3f6eb80-5427-11eb-92e2-ebcde54b610d.png">
