### PR TITLE
embed the Teams access diagram

### DIFF
--- a/tools/teams.md
+++ b/tools/teams.md
@@ -4,7 +4,7 @@ questions:
   - infrastructure
 ---
 
-**See [this diagram](https://docs.google.com/drawings/d/1umlAP1Tr2C8NHHdd8JsJgEY3cZJbbY_d2aWXkoAknds/edit) for how to access.**
+[![How to access Teams](https://docs.google.com/drawings/d/e/2PACX-1vRUfwfLa4y4Fc4EqymMzJk4cECAdffFyi6_rbmzstYlunQ0mJ60L_IG2PfpJEYJ-Wyz1cr7z6N6rlMG/pub?w=890&h=1047)](https://docs.google.com/drawings/d/1umlAP1Tr2C8NHHdd8JsJgEY3cZJbbY_d2aWXkoAknds/edit)
 
 [Microsoft Teams](https://www.microsoft.com/en-us/microsoft-365/microsoft-teams/group-chat-software) provides chat capabilities similar to Slack, with the ability to collaborate around themed channels, direct messaging to multiple individuals, etc. Microsoft Teams may be the collaborative tool of choice for partners that have adopted Microsoft services.
 


### PR DESCRIPTION
Just realized this is possible; occurred to me because we had someone not see that first link and be confused about how to access.

## When signed in

<img src="https://user-images.githubusercontent.com/86842/105917470-56f38b00-6000-11eb-9604-2d9033af734c.png" width="500">

## When not signed in

<img src="https://user-images.githubusercontent.com/86842/105917466-565af480-6000-11eb-9d45-f9ad4fd87326.png" width="500">

---

Pros of embedding:

- Visible without clicking through
- Stays in sync with any changes to source diagram

Cons (none of which are a regression, since you had to click through for all of this before anyway):

- Links aren't clickable
- Not publicly visible
  - Not sensitive
  - Could be useful to people trying to use Teams at other agencies
- Text is a bit small
  - Trimmed as much width as I could
- Not accessible