### PR TITLE
update rules around Slack profiles

### DIFF
--- a/_pages/getting-started/getting-started.md
+++ b/_pages/getting-started/getting-started.md
@@ -234,7 +234,7 @@ TTS strives to thoughtfully and intentionally represent the broad American popul
 
 To that end, we strongly encourage reading over the [Diversity, equity, and inclusion]({{site.baseurl}}/diversity) materials in the handbook, and consider joining the #diversity and #accessibility guilds.
 
-We also strive to be intentional when interacting with one another and with partners. One useful tip to start with today is to be sure that your location, agency and pronouns are [represented in your Slack profile]({{site.baseurl}}/tools/slack/rules/#getting-started).
+We also strive to be intentional when interacting with one another and with partners. One useful tip to start with today is to [fill out your Slack profile]({{site.baseurl}}/tools/slack/rules/#profile).
 
 ## Terming out
 

--- a/_pages/how-we-work/changing-your-name.md
+++ b/_pages/how-we-work/changing-your-name.md
@@ -9,15 +9,8 @@ TTS does our best to make everyone feel welcome. During the onboarding process, 
 You can change your name by following these steps:
 
 1. Log in to the [GSA network or a VPN]({{ site.baseurl }}/how-to-log-in/)
-1. Ensure your PIV is connected to your computer.
-1. Go to [HR Links](https://hrlinks.gsa.gov/)
-1. Once logged in, click the HR Self-Service drop down at the top.
-1. In the upper right corner of your HR Links screen is a compass icon. That is your NavBar. Click that.
-1. Select Navigator > Self Service > Personal Information
-1. Select Name Change (USF)
-1. Enter your preferred name and attach the necessary document.
+1. Follow [these steps](https://corporateapps.gsa.gov/files/HR-Links-Guide_-Changing-Your-Name_Final-Oct-2020docx.pdf).
 1. Wait up to 5 business days for the changes to take effect. You will receive an automated email from HR links stating that it has been submitted.
 1. Once your name has been updated in GCIMS via HRLinks, you can submit a GSA IT Help Desk to update your google account.
 
-If you have trouble with this process, you can open a [GSA IT Help Desk]({{ site.baseurl }}/gsa-internal-tools/#it-service-desk) ticket for assistance.
-
+If you have trouble with this process, [contact HRLinks support](https://corporateapps.gsa.gov/hr-links/hr-links-support/).

--- a/tools/slack.md
+++ b/tools/slack.md
@@ -6,7 +6,7 @@ questions:
   - admins-slack
 ---
 
-See the following sub-pages for information about Slack at TTS:
+To get started, **sign in at [gsa-tts.slack.com](https://gsa-tts.slack.com)**. See the [official documentation](https://slack.com/help/articles/218080037-Getting-started-for-new-members) for how to use Slack generally, and the following sub-pages for information about Slack at TTS:
 
 - [Getting started & rules](rules/)
 - [Guidelines](guidelines/)

--- a/tools/slack/rules.md
+++ b/tools/slack/rules.md
@@ -11,7 +11,7 @@ questions:
 **[Fill in your profile](https://gsa-tts.slack.com/account/profile).** A complete profile gives everyone a better chance of knowing who you are. **For the `Display name`, use the format `<name> (<team>, <location>, <pronouns>)`.**
 
 - Example: `Aidan Feldman (Tech Portfolio, NYC, he/him)`
-- Name, team, and location are required. [Personal pronouns](https://pronoun.is/) are optional but strongly encouraged. Having these visible helps be TTS gender inclusive.
+- Name, team, and location are required. [Personal pronouns](https://pronoun.is/) are optional but strongly encouraged. Having these visible helps TTS be gender inclusive.
 - For people with GSA emails, the `Full name` and `Phone number` are overwritten with [your information from GCIMS]({{site.baseurl}}/changing-your-name/) every time you sign in, so don't bother changing those.
 
 ## Usage

--- a/tools/slack/rules.md
+++ b/tools/slack/rules.md
@@ -11,7 +11,7 @@ questions:
 **[Fill in your profile](https://gsa-tts.slack.com/account/profile).** A complete profile gives everyone a better chance of knowing who you are. **For the `Display name`, use the format `<name> (<team>, <location>, <pronouns>)`.**
 
 - Example: `Aidan Feldman (Tech Portfolio, NYC, he/him)`
-- Name, team, and location are required. [Personal pronouns](https://pronoun.is/) are optional but strongly encouraged. Having these visible helps TTS be gender inclusive.
+- Name, team, and location are required. [Personal pronouns](https://pronoun.is/) are optional but strongly encouraged. Having these visible helps TTS be gender inclusive. They're not required because we want to ensure people who might change their pronouns don’t feel pressure to have an answer at all times.
 - For people with GSA emails, the `Full name` and `Phone number` are overwritten with [your information from GCIMS]({{site.baseurl}}/changing-your-name/) every time you sign in, so don't bother changing those.
 
 ## Usage

--- a/tools/slack/rules.md
+++ b/tools/slack/rules.md
@@ -10,8 +10,14 @@ questions:
 
 - Sign in at [gsa-tts.slack.com](https://gsa-tts.slack.com).
 - See the [**official Slack documentation**](https://slack.com/help/articles/218080037-Getting-started-for-new-members) for how to use Slack
-- **Complete [your profile](https://gsa-tts.slack.com/account/profile).** A complete profile gives everyone a better chance of knowing who you are. Add your location and [personal pronouns](https://pronoun.is/) to the `Display name` field (example: `Aidan Feldman (NYC, he/him`) so they appear alongside your messages, keeping TTS remote-friendly and gender inclusive.
-  - For people with GSA emails, the `Full name` and `Phone number` are overwritten with your information from HRLinks every time you sign in, so don't bother changing those.
+
+## Profile
+
+**[Fill in your profile](https://gsa-tts.slack.com/account/profile).** A complete profile gives everyone a better chance of knowing who you are. **For the `Display name`, use the format `<name> (<team>, <location>, <pronouns>)`.**
+
+- Example: `Aidan Feldman (Tech Portfolio, NYC, he/him)`
+- Name, team, and location are required. [Personal pronouns](https://pronoun.is/) are optional but strongly encouraged. Having these visible helps be TTS gender inclusive.
+- For people with GSA emails, the `Full name` and `Phone number` are overwritten with your information from HRLinks every time you sign in, so don't bother changing those.
 
 ## Usage
 

--- a/tools/slack/rules.md
+++ b/tools/slack/rules.md
@@ -12,7 +12,7 @@ questions:
 
 - Example: `Aidan Feldman (Tech Portfolio, NYC, he/him)`
 - Name, team, and location are required. [Personal pronouns](https://pronoun.is/) are optional but strongly encouraged. Having these visible helps be TTS gender inclusive.
-- For people with GSA emails, the `Full name` and `Phone number` are overwritten with your information from HRLinks every time you sign in, so don't bother changing those.
+- For people with GSA emails, the `Full name` and `Phone number` are overwritten with [your information from GCIMS]({{site.baseurl}}/changing-your-name/) every time you sign in, so don't bother changing those.
 
 ## Usage
 

--- a/tools/slack/rules.md
+++ b/tools/slack/rules.md
@@ -6,11 +6,6 @@ questions:
 
 [_Back to Slack page_](../)
 
-## Getting started
-
-- Sign in at [gsa-tts.slack.com](https://gsa-tts.slack.com).
-- See the [**official Slack documentation**](https://slack.com/help/articles/218080037-Getting-started-for-new-members) for how to use Slack
-
 ## Profile
 
 **[Fill in your profile](https://gsa-tts.slack.com/account/profile).** A complete profile gives everyone a better chance of knowing who you are. **For the `Display name`, use the format `<name> (<team>, <location>, <pronouns>)`.**


### PR DESCRIPTION
Notably, make the pronouns encouraged but not required. Open to any suggestions around wording. Also moved the Getting Started info to the top-level Slack page.