### PR TITLE
Change "Before you ship" link to navigate to guide homepage

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -393,7 +393,7 @@ primary:
               - text: Leadership Candidate Guide
                 url: leadership-candidate-guide/
               - text: Before you ship
-                url: https://before-you-ship.18f.gov/infrastructure/aws/
+                url: https://before-you-ship.18f.gov/
                 internal: false
               - text: Doing research at 18F
                 url: research-guidelines/


### PR DESCRIPTION
Prior to these changes, the "Before you ship" link shown on the handbook index would navigate directly to the "Amazon Web Services" subpage of the Before You Ship guide. These changes propose to link to the root page of the Before You Ship guide, as this is where one might expect to be directed to learn all there is about launching software.