### PR TITLE
cutting "personal" from "personal pronouns"

### DIFF
--- a/tools/slack/rules.md
+++ b/tools/slack/rules.md
@@ -11,7 +11,7 @@ questions:
 **[Fill in your profile](https://gsa-tts.slack.com/account/profile).** A complete profile gives everyone a better chance of knowing who you are. **For the `Display name`, use the format `<name> (<team>, <location>, <pronouns>)`.**
 
 - Example: `Aidan Feldman (Tech Portfolio, NYC, he/him)`
-- Name, team, and location are required. [Personal pronouns](https://pronoun.is/) are optional but strongly encouraged. Having these visible helps TTS be gender inclusive. They're not required because we want to ensure people who might change their pronouns don’t feel pressure to have an answer at all times.
+- Name, team, and location are required. Your [pronouns](https://pronoun.is/) are optional but strongly encouraged. Having these visible helps TTS be gender inclusive. They're not required because we want to ensure people who might change their pronouns don’t feel pressure to have an answer at all times.
 - For people with GSA emails, the `Full name` and `Phone number` are overwritten with [your information from GCIMS]({{site.baseurl}}/changing-your-name/) every time you sign in, so don't bother changing those.
 
 ## Usage


### PR DESCRIPTION
Having thought about this some more: my pronouns are not personal or preferred, they're my pronouns. Modifying the word makes it seem like it's a favor. It's not.