### PR TITLE
removes broken link to federal agency acronyms

### DIFF
--- a/_pages/general/who-we-are/glossary.md
+++ b/_pages/general/who-we-are/glossary.md
@@ -142,6 +142,5 @@ questions:
 ## More
 
 * [This Ars Technica article](https://arstechnica.com/uncategorized/2012/03/cracking-the-cloud-an-amazon-web-services-primer/) is a good primer on Amazon Web Services jargon.
-* [See a list of federal agency name acronyms](https://api.data.gov/docs/regulations/federalagencies/).
 * [Here's an additional library of government acronyms](https://github.com/unitedstates/acronym).
 * [This is GitHub's glossary](https://help.github.com/articles/github-glossary/)


### PR DESCRIPTION
The link to https://api.data.gov/docs/regulations/federalagencies/ results in "The page you are looking for is currently unavailable to view."
Removed link after consultation with @keithrwilson