### PR TITLE
add page on contractors

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -320,6 +320,9 @@ primary:
           - text: Overview of OA
             url: oa/
             internal: true
+          - text: Contractors
+            url: contractors/
+            internal: true
       - text: 18F
         children:
           - text: About 18F

--- a/_pages/how-we-work/contractors.md
+++ b/_pages/how-we-work/contractors.md
@@ -1,0 +1,30 @@
+---
+title: Contractors
+questions:
+  - tts-oa
+---
+
+In general, contractors "embedded" in TTS (working on TTS projects most or full-time) can be given the same equipment and access as federal staff performing the same duties. The main exceptions are conversations/materials that are acquisition-sensitive.
+
+## Policy highlights
+
+> Contractors with system access must utilize a gsa.gov e-mail account to conduct business with GSA.
+
+[GSA Information Technology (IT) Security Policy](https://www.gsa.gov/cdnstatic/CIO_2100.1J_CHGE_1_GSA_Information_Technology_%28IT%29_Security_Policy_%28Posted_Version_4-28-2016%29.pdf#page=65)
+
+> Authorized users are employees of GSA and other Government organizations and those contractors, consultants, or other third parties who are specifically granted access to conduct business on behalf of or with GSA or other Government organizations supported by GSA. Compliance with this policy should be addressed in Statements of Work (SOWs) for contractors.
+>
+> …
+>
+> All…authorized users are expected to utilize standard equipment unless an exception has been approved by appropriate authorities.
+
+[Provisioning of Information Technology (IT) Devices](<https://www.gsa.gov/directive/provisioning-of-information-technology-(it)-devices>)
+
+> [Homeland Security Presidential Directive 12 (HSPD-12)](https://www.dhs.gov/homeland-security-presidential-directive-12)…requires all Federal Executive departments and agencies to conduct personnel investigations, adjudicate the results, and issue identity credentials to all Federal employees and contractors who require routine access to their building facilities and information technology (IT) systems.
+
+[GSA HSPD-12 Personal Identity Verification and Credentialing Handbook](https://www.gsa.gov/cdnstatic/CIO_P_2181.1_Homeland_Security_Presidential_Directive-12_Personal_Identity_Verification_and_Credentialing_-_10-20-08%29_%28Revised_10-5-2015%29.pdf#page=5)
+
+## See also
+
+- [Region 10's information on Contractor Onboarding](https://insite.gsa.gov/locations/region-10/about-us/regional-staff-offices/office-of-mission-assurance-oma/contractor-hspd12-processing/contractor-onboarding-oma-r10)
+- [How Contractors Obtain a GSA Access Card](https://www.gsa.gov/technology/government-it-initiatives/identity-credentials-and-access-manage/how-contractors-obtain-a-gsa-access-card)

--- a/_pages/how-we-work/contractors.md
+++ b/_pages/how-we-work/contractors.md
@@ -26,6 +26,9 @@ In general, contractors "embedded" in TTS (working on TTS projects most or full-
 
 ## See also
 
+- TTS-specific materials:
+  - [Contracting Officer's Representative (COR) Playbook](https://docs.google.com/document/d/14xOFvIGwlG0Gbd52o1D4AyJ52RqzHpX91nfEYJKu5qQ/edit)
+  - [Contractor onboarding checklist](https://docs.google.com/spreadsheets/d/1w0WSTUT0l7q19mAI6c2QCIpCFs0Cei4eukaiiRBTbRA/edit#gid=710529923)
 - [Region 10's information on Contractor Onboarding](https://insite.gsa.gov/locations/region-10/about-us/regional-staff-offices/office-of-mission-assurance-oma/contractor-hspd12-processing/contractor-onboarding-oma-r10)
 - [Requesting Officials Roles & Responsibilities](https://insite.gsa.gov/employee-resources/safety-and-security/background-investigation-access-card-process/requesting-officials-roles-responsibilities)
 - [How Contractors Obtain a GSA Access Card](https://www.gsa.gov/technology/government-it-initiatives/identity-credentials-and-access-manage/how-contractors-obtain-a-gsa-access-card)

--- a/_pages/how-we-work/contractors.md
+++ b/_pages/how-we-work/contractors.md
@@ -28,7 +28,8 @@ In general, contractors "embedded" in TTS (working on TTS projects most or full-
 
 - TTS-specific materials:
   - [Contracting Officer's Representative (COR) Playbook](https://docs.google.com/document/d/14xOFvIGwlG0Gbd52o1D4AyJ52RqzHpX91nfEYJKu5qQ/edit)
-  - [Contractor onboarding checklist](https://docs.google.com/spreadsheets/d/1w0WSTUT0l7q19mAI6c2QCIpCFs0Cei4eukaiiRBTbRA/edit#gid=710529923)
+  - [BizOps' onboarding checklist](https://docs.google.com/spreadsheets/d/1w0WSTUT0l7q19mAI6c2QCIpCFs0Cei4eukaiiRBTbRA/edit#gid=710529923)
+  - [Office of Acquisitions' onboarding and offboarding checklist](https://docs.google.com/spreadsheets/d/1-RHrM2K-oupQ-wdQp5dhU6M1UtbiM2fj9kY3fGikQSg/edit#gid=0)
 - [Region 10's information on Contractor Onboarding](https://insite.gsa.gov/locations/region-10/about-us/regional-staff-offices/office-of-mission-assurance-oma/contractor-hspd12-processing/contractor-onboarding-oma-r10)
 - [Requesting Officials Roles & Responsibilities](https://insite.gsa.gov/employee-resources/safety-and-security/background-investigation-access-card-process/requesting-officials-roles-responsibilities)
 - [How Contractors Obtain a GSA Access Card](https://www.gsa.gov/technology/government-it-initiatives/identity-credentials-and-access-manage/how-contractors-obtain-a-gsa-access-card)

--- a/_pages/how-we-work/contractors.md
+++ b/_pages/how-we-work/contractors.md
@@ -27,4 +27,5 @@ In general, contractors "embedded" in TTS (working on TTS projects most or full-
 ## See also
 
 - [Region 10's information on Contractor Onboarding](https://insite.gsa.gov/locations/region-10/about-us/regional-staff-offices/office-of-mission-assurance-oma/contractor-hspd12-processing/contractor-onboarding-oma-r10)
+- [Requesting Officials Roles & Responsibilities](https://insite.gsa.gov/employee-resources/safety-and-security/background-investigation-access-card-process/requesting-officials-roles-responsibilities)
 - [How Contractors Obtain a GSA Access Card](https://www.gsa.gov/technology/government-it-initiatives/identity-credentials-and-access-manage/how-contractors-obtain-a-gsa-access-card)

--- a/tools/slack/external-collaboration.md
+++ b/tools/slack/external-collaboration.md
@@ -26,7 +26,7 @@ Note this does _not_ include:
 - The general public, for which we have [dedicated channels](#the-public)
 - Other feds who we are not working with directly
 
-Contractors' level of access will be determined by the Contracting Officer (CO). By default, **contractors who are "embedded" in TTS (working on TTS projects most or full-time) can be added as full members, while other collaborators should be added as single or multi-channel guests**, as appropriate.
+Contractors' level of access will be determined by the Contracting Officer (CO). By default, **contractors who are "embedded" in TTS (working on TTS projects most or full-time) can be added as full members using their GSA emails, while other collaborators should be added as single or multi-channel guests**, as appropriate. See [contractors]({{site.baseurl}}/contractors/) for general information.
 
 <a href="https://goo.gl/forms/mKATdB9QuNo7AXVY2" class="usa-button">Request guest access</a>
 


### PR DESCRIPTION
[**Preview**](https://federalist-cf8341ad-ca07-488c-bd96-0738014c79ca.app.cloud.gov/preview/18f/handbook/contractors/contractors/)

Part of https://github.com/18F/tts-tech-portfolio/issues/1340.

Questions about whether contractors should have ENT accounts, GSA-issued machines, etc. kept coming up recently. Did some digging, found relevant policy, and added as a new contractor-focused page.

Sounds like [the Office of Acquisition is working on some related materials](https://gsa-tts.slack.com/archives/CD4F3TGB1/p1621458057017900?thread_ts=1621457742.017600&cid=CD4F3TGB1), so will defer to them about whether this information makes sense to keep here or move elsewhere.