### PR TITLE
Update Zoom signin instructions for app

### DIFF
--- a/_pages/software-tools/zoom.md
+++ b/_pages/software-tools/zoom.md
@@ -9,8 +9,9 @@ GSA offers [Zoom for Government](https://zoomgov.com/).
 ## Setup
 
 1. Install the Zoom application through [Self Service]({{site.baseurl}}/gsa-internal-tools/#self-service).
-1. When signing in, select `gsa.zoomgov.com`.
 1. Click `Sign in with SSO`.
+1. Click `I don't know the company domain.`
+1. Enter your GSA email and click `Continue`.
 1. Consider [adding a profile picture and your location and pronouns to your display name](https://www.zoomgov.com/profile).
 
 ## How to host a meeting

--- a/_pages/software-tools/zoom.md
+++ b/_pages/software-tools/zoom.md
@@ -10,8 +10,7 @@ GSA offers [Zoom for Government](https://zoomgov.com/).
 
 1. Install the Zoom application through [Self Service]({{site.baseurl}}/gsa-internal-tools/#self-service).
 1. Click `Sign in with SSO`.
-1. Click `I don't know the company domain.`
-1. Enter your GSA email and click `Continue`.
+1. Enter `gsa.zoomgov.com`. If the domain is set to `.zoom.us`, click `I don't know the company domain` and enter your GSA email.
 1. Consider [adding a profile picture and your location and pronouns to your display name](https://www.zoomgov.com/profile).
 
 ## How to host a meeting


### PR DESCRIPTION
The Zoom app (installed through Self-Service) doesn't allow you to select a `.zoomgov.com`, since the app's signin URL is fixed at `{text field}.zoom.us`. I'm proposing this edit to reflect what I did to successfully sign in through the app.

This is only my second day, so my proposed edit could be incorrect, and should be reviewed by someone who knows more about Zoom security.