### PR TITLE
BYS: Remove 'Before you ship' bullet

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -412,8 +412,6 @@ primary:
                 url: leadership-selection/
               - text: Leadership Candidate Guide
                 url: leadership-candidate-guide/
-              - text: Before you ship
-                url: https://before-you-ship.18f.gov
               - text: Doing research at 18F
                 url: research-guidelines/
                 internal: true


### PR DESCRIPTION
Now that the content is merged, it doesn't make sense to have `Before you ship` listed as a resource. This PR removes that reference.