### PR TITLE
Add contact link to vulnerability disclosure

### DIFF
--- a/_pages/policies/tech-policies/responding-to-public-disclosure-vulnerabilities.md
+++ b/_pages/policies/tech-policies/responding-to-public-disclosure-vulnerabilities.md
@@ -1,5 +1,7 @@
 ---
 title: Public disclosures of vulnerabilities
+questions:
+  - vuln-disclosure
 ---
 
 When someone in the public alerts TTS to a potential vulnerability in our systems, we need to act quickly.


### PR DESCRIPTION
Direct readers to #vuln-disclosure for questions or contact of the Vulnerability
Disclosure team.
