### PR TITLE
Add guidance about TTS-wide vs internal-only content publishing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ It is optional, and can contain one or more Slack channel name, email address, a
 - This handbook website and repository are public
 - We're careful about publishing [information collected during research](https://handbook.tts.gsa.gov/research-guidelines/); [learn more](https://docs.google.com/document/d/1Xp4LxbW6cx61rXrsnnfIPCz6cglovHzZeEjCcnpIeaM/edit) and ask [#g-research](https://gsa-tts.slack.com/archives/g-research) for guidance first
 - Try to avoid "click here" links. If necessary, be sure to follow the [A11Y Project Anchor Link Patterns](https://a11yproject.com/patterns/#anchors-links).
-- TTS-wide information should be public by default, and link to Google Docs for anything that shouldn't be publicly visible.
+- TTS-wide information should be public by default and link to Google Docs for anything that shouldn't be publicly visible.
 
 ## Fork or branch?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ It is optional, and can contain one or more Slack channel name, email address, a
 - This handbook website and repository are public
 - We're careful about publishing [information collected during research](https://handbook.tts.gsa.gov/research-guidelines/); [learn more](https://docs.google.com/document/d/1Xp4LxbW6cx61rXrsnnfIPCz6cglovHzZeEjCcnpIeaM/edit) and ask [#g-research](https://gsa-tts.slack.com/archives/g-research) for guidance first
 - Try to avoid "click here" links. If necessary, be sure to follow the [A11Y Project Anchor Link Patterns](https://a11yproject.com/patterns/#anchors-links).
+- TTS-wide information should be public by default, and link to Google Docs for anything that shouldn't be publicly visible.
 
 ## Fork or branch?
 


### PR DESCRIPTION
Inspired by https://gsa-tts.slack.com/archives/C0DCAMLQH/p1624390644008700

@afeld If you think more context is needed, then please let me know. 