### PR TITLE
Update links for sensitive information

### DIFF
--- a/_pages/how-we-work/sensitive-information.md
+++ b/_pages/how-we-work/sensitive-information.md
@@ -8,7 +8,7 @@ Here's what you need to know about sensitive information at TTS.
 
 ## What is considered sensitive?
 
-Anything that would make our systems vulnerable or would impact the privacy of others if it fell into the wrong hands. To learn what information we consider sensitive, see [our Open Source Policy practices guide](https://github.com/18F/open-source-policy/blob/master/practice.md#protecting-sensitive-information). See also: [the GSA Controlled Unclassified Information (CUI) Guide](https://insite.gsa.gov/employee-resources/information-technology/security-and-privacy/controlled-unclassified-information-cui/cui-guide).
+Anything that would make our systems vulnerable or would impact the privacy of others if it fell into the wrong hands. See also: [the GSA Controlled Unclassified Information (CUI) Guide](https://insite.gsa.gov/employee-resources/information-technology/security-and-privacy/controlled-unclassified-information-cui/cui-guide).
 
 Here are some [examples of sensitive information](https://github.com/18F/aws-admin/issues/92#issuecomment-768332113):
 

--- a/_pages/how-we-work/sensitive-information.md
+++ b/_pages/how-we-work/sensitive-information.md
@@ -40,7 +40,7 @@ information.
 in source code repositories. Instead, use [alternative secret
 management](#tools) approaches and solutions.
 
-**Privacy** information, like PII, has [its own guidance](https://before-you-ship.18f.gov/privacy/).
+**Privacy** information, like PII, has [its own guidance]({% link launching-software/privacy.md %}).
 
 **Other** sensitive information, like IP addresses, subnets, and AWS account
 IDs, may be kept in a _private_ repository.
@@ -55,7 +55,7 @@ _first_. Please don't include the potentially sensitive information in Slack.
 
 If you inadvertently come into the possession of classified information (Secret,
 Top Secret, etc.), you should immediately follow our [security incident
-process](https://handbook.tts.gsa.gov/security-incidents/).
+process]({% link _pages/policies/tech-policies/security-incidents.md %}).
 
 ## What to do if you find or expose sensitive information
 


### PR DESCRIPTION
https://github.com/18F/aws-admin/issues/92

- Remove link to Open Source Policy
- Update URLs

Some updates since we removed the sensitive information guidance from the Open
Source Policy practices.
