### PR TITLE
Fix JavaScript error on software search page with embedded search parameter

### DIFF
--- a/javascripts/software-search.js
+++ b/javascripts/software-search.js
@@ -135,12 +135,15 @@ const init = async () => {
     // use the search value from the URL
     const hash = location.hash.replace(/^#/, "");
     input.value = decodeURIComponent(hash);
-    doSearch(input.value, index, softwareByName);
   }
 
   const software = await getSoftware();
   const index = buildIndex(software);
   const softwareByName = arrayToObject(software, "Standard Name");
+
+  if (location.hash) {
+    doSearch(input.value, index, softwareByName);
+  }
 
   form.addEventListener("submit", (event) => {
     doSearch(input.value, index, softwareByName);


### PR DESCRIPTION
Resolves an issue where an uncaught error is thrown when a search query is embedded into the software search URL.

**Steps to Reproduce:**

1. Go to: https://handbook.tts.gsa.gov/software/search/
2. Enter a search term
3. Press <kbd>Enter</kbd> to submit the form
4. Refresh the page

Expected: The same search results that were shown after Step 3 are shown, and I can search for a new search term.
Actual: No search results are shown, search no longer works, and an error is logged in the browser console.

**Implementation Notes:**

Error:

>"Uncaught (in promise) ReferenceError: Cannot access 'index' before initialization"

`index` and `softwareByName` aren't yet assigned when location hash is first considered. Building the software index requires a network request to fetch the software CSV file, so there may be a brief delay. Splitting to two conditions allows input field update to happen sooner, to avoid sudden (and possibly destructive) page changes.