### PR TITLE
Update Sketch admin docs

### DIFF
--- a/_pages/software-tools/sketch.md
+++ b/_pages/software-tools/sketch.md
@@ -22,16 +22,13 @@ Once you get the email above:
 
 1. [Share the license key](https://docs.google.com/document/d/1Qrn4J7mOcpGv51krZOyxpz93mBDp22hzl2wtVLulhUU/edit) with the requester.
 
-
 ## Plugins
 
 [**List**](https://docs.google.com/spreadsheets/d/1NDA19R_j3WpueXNCedY1gAdL-mDhUyL7kWBhpIQrK7g/edit#gid=0)
 
 One thing that's different about using Sketch at GSA is that Sketch plugins are not impossible to obtain, but might be more time-consuming than time-saving. Each Sketch plugin is treated like a [new software request]({{site.baseurl}}/software/), and must undergo review by GSA IT review. So far, we haven't found much that we can't accomplish without plugins.
 
-
 ## For admins
-
 
 ### Sketch license admin
 

--- a/_pages/software-tools/sketch.md
+++ b/_pages/software-tools/sketch.md
@@ -1,5 +1,7 @@
 ---
 title: Sketch
+questions:
+  - sketch
 ---
 
 You can get started with a trial version [immediately](https://www.sketch.com/). Upgrade to the full version whenever you get the license. Visit [#sketch](https://gsa-tts.slack.com/messages/sketch) on Slack for help and sharing tips.
@@ -18,14 +20,23 @@ Note Sketch is registered to the machine, so this needs to be done if you get a 
 
 Once you get the email above:
 
-1. [Request an access code](https://www.sketch.com/support/license-manager/) for [tts-software@gsa.gov](mailto:tts-software@gsa.gov).
-1. You should get an email from Sketch. Click through to log into the License Manager.
-   - If it doesn't come through, check [pending messages](https://groups.google.com/a/gsa.gov/forum/#!pendingmsg/18fsoftware), because [reasons](https://www.sketch.com/support/licensing-and-sales/license-manager-email-issue/).
-1. Add to the [user list](https://docs.google.com/spreadsheets/d/1SCkLr0GXgoeqmIMPLic8QnX1INkyoP1YCNp17Sarx9s/edit?usp=drive_web&ouid=110177769858789799592). Delete their old one, if it’s in there.
-1. Use the last 7 numbers/letters to locate their Sketch number in the console.
+1. [Share the license key](https://docs.google.com/document/d/1Qrn4J7mOcpGv51krZOyxpz93mBDp22hzl2wtVLulhUU/edit) with the requester.
+
 
 ## Plugins
 
 [**List**](https://docs.google.com/spreadsheets/d/1NDA19R_j3WpueXNCedY1gAdL-mDhUyL7kWBhpIQrK7g/edit#gid=0)
 
 One thing that's different about using Sketch at GSA is that Sketch plugins are not impossible to obtain, but might be more time-consuming than time-saving. Each Sketch plugin is treated like a [new software request]({{site.baseurl}}/software/), and must undergo review by GSA IT review. So far, we haven't found much that we can't accomplish without plugins.
+
+
+## For admins
+
+
+### Sketch license admin
+
+You can log into the Sketch license admin to view the list of active licenses.
+
+1. [Request an access code](https://www.sketch.com/support/license-manager/) for [tts-software@gsa.gov](mailto:tts-software@gsa.gov).
+1. You should get an email from Sketch. Click through to log into the License Manager.
+   - If it doesn't come through, ask an admin to [review pending messages](https://groups.google.com/a/gsa.gov/forum/#!pendingmsg/18fsoftware).


### PR DESCRIPTION
- Remove broken link
- Remove the spreadsheet workflow
- Clarify Sketch admin might not be Google Group admin
- Share the license key with the requester
- Move license admin steps to new section

Clarified the process with @JJediny, we are using the permissions on the Sketch License doc to track active users. 

