### PR TITLE
Proposal: using USWDS alerts for highlighting known issues on pages

### DIFF
--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -5,21 +5,21 @@ on: [pull_request]
 
 jobs:
   lint:
-    name: format code
+    name: Format code
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v1
+
       - uses: actions/setup-node@v1
         with:
           node-version: 12
 
-      - uses: actions/checkout@v1
+      - name: Install dependencies
+        run: npm install
 
-      - name: Install prettier
-        run: npm install -g prettier
-
-      - name: format sources files
+      - name: Format sources files
         run: |
-          prettier --write "**/*.md"
+          npm run lint
           git add "*.md"
 
       - name: Check that all the code is formatted.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For internal links, use `{{site.baseurl}}` in the URL (in place of `https://http
 
 ### Linting
 
-We use prettier to format markdown. You can fix your files locally with:
+We use [Prettier](https://prettier.io/) to format Markdown. You can fix your files locally with:
 
     $ npm run lint
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ For internal links, use `{{site.baseurl}}` in the URL (in place of `https://http
 
 :no_entry_sign: **Instead of:** `(/code-of-conduct/)`
 
+### Linting
+
+We use prettier to format markdown. You can fix your files locally with:
+
+    $ npm run lint
+
 ### Public domain
 
 This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](https://handbook.tts.gsa.gov/contributing/):

--- a/_includes/alert.html
+++ b/_includes/alert.html
@@ -1,0 +1,17 @@
+{% comment %}
+
+https://designsystem.digital.gov/components/alert/
+
+level: the severity of the alert (default info)
+heading: heading of the alert
+content: markdown body of the alert
+
+{% endcomment %}
+<div class="usa-alert usa-alert--{{ include.level | default: 'info' }}">
+  <div class="usa-alert__body">
+    <h3 class="usa-alert__heading">{{ include.heading | escape }}</h3>
+    <div class="usa-alert__text">
+      {{ include.content | markdownify }}
+    </div>
+  </div>
+</div>

--- a/_includes/software-warning.html
+++ b/_includes/software-warning.html
@@ -1,6 +1,4 @@
-<div class="usa-alert usa-alert--warning">
-  <div class="usa-alert__body">
-    <h3 class="usa-alert__heading">Software must be approved</h3>
-    <p class="usa-alert__text">It is safest to assume that you cannot use any software/sites/apps that require installation or an account until you know it's <a href="{{site.baseurl}}/software/#approvals">approved</a>. Ask in <a href="https://gsa-tts.slack.com/messages/infrastructure">#infrastructure</a> if you're not sure.</p>
-  </div>
-</div>
+{% capture alert_content %}
+It is safest to assume that you cannot use any software/sites/apps that require installation or an account until you know it's [approved]({{site.baseurl}}/software/#approvals). Ask in [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure) if you're not sure.
+{% endcapture %}
+{% include alert.html level="warning" heading="Software must be approved" content=alert_content %}

--- a/_pages/policies/tech-policies/responding-to-public-disclosure-vulnerabilities.md
+++ b/_pages/policies/tech-policies/responding-to-public-disclosure-vulnerabilities.md
@@ -4,6 +4,11 @@ questions:
   - vuln-disclosure
 ---
 
+{% capture alert_content %}
+This content is not reflective of how individual programs administer the TTS Bug Bounty. See [#2584](https://github.com/18F/handbook/issues/2584) and [#2585](https://github.com/18F/handbook/issues/2585).
+{% endcapture %}
+{% include alert.html heading="Needs review" content=alert_content %}
+
 When someone in the public alerts TTS to a potential vulnerability in our systems, we need to act quickly.
 
 This document outlines TTS' Vulnerability Disclosure triage process, and provides operational instructions for TTS staff reviewing reports that come through the vulnerability disclosure platform (VDP) or other means.

--- a/javascripts/application.js
+++ b/javascripts/application.js
@@ -93,7 +93,7 @@ $(document).ready(function() {
       if ($table.length > 0){
         $table.after(inlineNavigation);
       } else {
-        $("main p").first().after(inlineNavigation);
+        $("main > p").first().after(inlineNavigation);
       }
 
     }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "prettier": "2.3.1"
   },
   "scripts": {
+    "lint": "prettier --write \"**/*.md\"",
     "test": "jest"
   }
 }


### PR DESCRIPTION
Use a [USWDS alert](https://designsystem.digital.gov/components/alert/) to highlight known issues for discussion on a particular page. This might also entice readers to help address the issues as they're reading handbook content.

- adds the alert component
- adds a "Needs Review" alert to the Responding to Public Disclosure Vulnerabilities page
- npm script to run prettier
- fix a rare issue with the sidenav injection


[Preview here](https://federalist-cf8341ad-ca07-488c-bd96-0738014c79ca.app.cloud.gov/preview/18f/handbook/feature/bug-bounty/responding-to-public-disclosure-vulnerabilities/)

![Screen Shot 2021-06-25 at 3 10 21 PM](https://user-images.githubusercontent.com/509703/124303991-f3720a00-db17-11eb-9bad-01b8709b6e1d.png)

