### PR TITLE
Minor CODEOWNERS changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,7 @@ CODEOWNERS                                        @18F/tts-tech-portfolio
 # Portfolio. If it is a small change, then an approval from Tech Portfolio is
 # sufficient for merging. If the change is more structural, then an approval is
 # _required_ from the owning team.
-_pages/*                                          @18F/tts-tech-portfolio
+*.md                                              @18F/tts-tech-portfolio
 
 ##################################################
 # Business units
@@ -27,7 +27,7 @@ _pages/*                                          @18F/tts-tech-portfolio
 
 ## Office of Operations
 #_pages/business-units/operations/*               @18F/operations-handbook-reviewers
-_pages/business-units/operations/outreach*        @18F/outreach
+_pages/business-units/operations/outreach/*       @18F/outreach
 
 ## Office of Acquisition
 #_pages/business-units/oa/*                       @18F/oa-handbook-reviewers


### PR DESCRIPTION
Following up on #2597, this PR fixes some minor typos in the new CODEOWNERS file. It also changes the top-level rule so as to align with the comment: only Markdown files should be covered in the CODEOWNERS file at this time.