### PR TITLE
Update Solutions history

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -441,7 +441,7 @@ primary:
                 internal: true
               - text: Solutions org chart
                 url: solutions-org-chart/
-                internal: true
+                internal: false
           - text: Portfolios
             children:
               - text: Data

--- a/_pages/business-units/solutions/solutions-history.md
+++ b/_pages/business-units/solutions/solutions-history.md
@@ -82,9 +82,10 @@ Following the expansion of our web presence and digital knowledge, we've remaine
 ### OPP --> Solutions: 2019
 
 In 2019, we got a bit bigger. OPP was renamed to Solutions during a [TTS-wide re-organization](https://www.fedscoop.com/gsa-tts-restructuring-anil-cheriyan/). And as part of this change, a number of projects moved from 18F to Solutions, including:
-  - [Cloud.gov](https://cloud.gov/): a Platform as a Service built specifically for government work. Created by 18F in 2015.
-  - [Federalist](https://federalist.18f.gov/): a publishing platform for modern government websites. Created by 18F in 2015.
-  - [Login.gov](https://login.gov/): a shared service that provides secure and private online access to participating government programs. Launched by 18F and the U.S. Digital Service in 2017.
-  - [U.S. Web Design System](https://designsystem.digital.gov/): set of guidelines and code for agencies to create fast, accessible, mobile-friendly websites. Created by 18F and the U.S. Digital Service in 2015.
+
+- [Cloud.gov](https://cloud.gov/): a Platform as a Service built specifically for government work. Created by 18F in 2015.
+- [Federalist](https://federalist.18f.gov/): a publishing platform for modern government websites. Created by 18F in 2015.
+- [Login.gov](https://login.gov/): a shared service that provides secure and private online access to participating government programs. Launched by 18F and the U.S. Digital Service in 2017.
+- [U.S. Web Design System](https://designsystem.digital.gov/): set of guidelines and code for agencies to create fast, accessible, mobile-friendly websites. Created by 18F and the U.S. Digital Service in 2015.
 
 Over the past 50 years, TTS Solutions has grown, expanded, and renamed all while remaining true to our mission. We’ll continue to evolve as we anticipate and meet future needs. We look forward to the next 50 years of serving the public and our partners!

--- a/_pages/business-units/solutions/solutions-history.md
+++ b/_pages/business-units/solutions/solutions-history.md
@@ -6,7 +6,7 @@ questions:
   - solutions
 ---
 
-A brief history of TTS Solutions is hard to write: our work spans six decades and ten administrations! Moreover, we haven't even always been Solutions: pre-2019 we were known as the _Office of Products and Programs (OPP)_.
+A brief history of TTS Solutions is hard to write: our work spans six decades and ten administrations! Moreover, we haven't always been Solutions: pre-2016, we were known as the Office of Citizen Services and Innovative Technologies (OCSIT), and from 2016-2019 we were known as the Office of Products and Programs (OPP).
 
 What was established in 1970 as a place to coordinate and deliver information to consumers has evolved tremendously. Our audience has expanded to include every federal agency, government employees at all levels, the private sector, and people all over the world.
 
@@ -42,7 +42,7 @@ In 1997, the White House gave us responsibility for one of the most helpful and 
 
 In 2001 we added [Kids.gov](https://web.archive.org/web/20160327075216/https://kids.usa.gov/), filled with children’s content and lesson plans. And in 2003 we launched the official Spanish language portal, FirstGov en español. The FirstGov sites got more memorable names in 2007: USA.gov and GobiernoUSA.gov (now known as [USAGov en Español](https://gobierno.usa.gov/)). Both continue as the official guides to government information, benefits, and services.
 
-Starting in 2002, we managed WebContent.gov, a one-stop resource for government web professionals who needed information about requirements, best practices, usability, and new technologies. Its training program, Web Manager University, offered practical training for managers of federal, state, and local government websites. These two services are the predecessors of today’s [DigitalGov](https://digital.gov/) and [DigitalGov University](https://digital.gov/digitalgov-university/).
+Starting in 2002, we managed WebContent.gov, a one-stop resource for government web professionals who needed information about requirements, best practices, usability, and new technologies. Its training program, Web Manager University, offered practical training for managers of federal, state, and local government websites. These two services are the predecessors of today’s [Digital.gov](https://digital.gov/) and [Digital.gov University](https://digital.gov/digitalgov-university/).
 
 The home of the U.S. government’s open data, [Data.gov](https://www.data.gov/), launched in 2009, as did [Go.USA.gov](https://go.usa.gov/), a URL shortening service for government agencies.
 
@@ -52,7 +52,7 @@ At the turn of the decade, our efforts began expanding beyond web content and in
 
 [Challenge.gov](https://www.challenge.gov/), the official site for federal prize and challenge competitions, launched in 2010. The same year, [Search.gov](https://search.gov/) expanded from powering the USA.gov search box to being offered as a government-wide shared service.
 
-In 2011, [FedRAMP](https://www.fedramp.gov/) began providing government a standardized approach to security assessment, authorization, and continuous monitoring for cloud products and services.
+In 2011, the [Federal Risk and Authorization Management Program](https://www.fedramp.gov/)(FedRAMP) began providing government a standardized approach to security assessment, authorization, and continuous monitoring for cloud products and services.
 
 The 2012 [Digital Government Strategy](https://obamawhitehouse.archives.gov/sites/default/files/omb/egov/digital-government/digital-government.html) asked agencies to “use modern tools and technologies to seize the digital opportunity and fundamentally change how the Federal Government serves both its internal and external customers – building a 21st century platform to better serve the American People.” This presidential strategy spurred the creation of more products and services.
 
@@ -64,11 +64,11 @@ And, we kept pace with the rise of smartphones: the [Mobile Testing Program](htt
 
 ### 2016: TTS is born
 
-In 2016, [18F]({{site.baseurl}}/18f-history-and-values/), [PIF](https://presidentialinnovationfellows.gov/), and the Office of Products and Programs (OPP, aka us) [came together](https://www.fedscoop.com/gsa-launches-technology-service-line/) under the newly-formed Technology Transformation Service (TTS) office. Ever since we became an office within TTS, we have played an essential role in helping it modernize and digitize the federal government.
+In 2016, [18F]({{site.baseurl}}/18f-history-and-values/), [PIF](https://presidentialinnovationfellows.gov/), and the Office of Citizen Services and Innovative Technologies (OCSIT, aka us) [came together](https://www.fedscoop.com/gsa-launches-technology-service-line/) under the newly-formed Technology Transformation Service (TTS) office. Following this merge, we were renamed to the Office of Products and Programs (OPP). Ever since we became an office within TTS, we have played an essential role in helping it modernize and digitize the federal government.
 
 ### 2016 - 2019: Ramping up our portfolio
 
-Following the expansion of our web presence and digital knowledge, we've remained hard at work. In the years since, we've built, grown, and maintained crucial government-wide products and programs:
+Following the expansion of our web presence and digital knowledge, OPP remained hard at work. In the years after, we built, grew, and maintained crucial government-wide products and programs:
 
 - [10x](https://10x.gsa.gov/): provides start-up funding for new technology projects and products across government (2016)
 - [Artificial Intelligence Portfolio](https://digital.gov/communities/artificial-intelligence/): supporting and coordinating the use of artificial intelligence technologies in federal agencies (2019)
@@ -81,7 +81,7 @@ Following the expansion of our web presence and digital knowledge, we've remaine
 
 ### 2019: OPP --> Solutions
 
-In 2019, we got a bit bigger. OPP was renamed to Solutions during a [TTS-wide re-organization](https://www.fedscoop.com/gsa-tts-restructuring-anil-cheriyan/). And as part of this change, a number of projects moved from 18F to Solutions, including:
+In 2019, we got a bit bigger. OPP was renamed to Solutions during a [TTS-wide re-organization](https://www.fedscoop.com/gsa-tts-restructuring-anil-cheriyan/). And as part of this change, we became responsible for a number of 18F projects, including:
 
 - [Cloud.gov](https://cloud.gov/): a Platform as a Service built specifically for government work. Created by 18F in 2015.
 - [Federalist](https://federalist.18f.gov/): a publishing platform for modern government websites. Created by 18F in 2015.

--- a/_pages/business-units/solutions/solutions-history.md
+++ b/_pages/business-units/solutions/solutions-history.md
@@ -6,17 +6,17 @@ questions:
   - solutions
 ---
 
-A brief history of TTS Solutions is hard to write: our work spans five decades and nine administrations!
+A brief history of TTS Solutions is hard to write: our work spans five decades and nine administrations! Moreover, before 2019 we weren't even called Solutions! Instead, we were known as the Office of Products and Programs (OPP).
 
 What was established in 1970 as a place to coordinate and deliver information to consumers has evolved tremendously. Our audience has expanded to include every federal agency, government employees at all levels, the private sector, and people all over the world.
 
 Today, our [mission](https://docs.google.com/presentation/d/1DCtxpQgv89SRV_lpeXHNNOo1boIHmD2UpbsnV46WEik/edit#slide=id.g2fcf36f393_0_8) is to **help the public use and understand government**, and **help agencies understand and serve the public**. To achieve this, we **create, discover, connect and share practical solutions and products that transform government**.
 
-We offer cross-government products and programs that help agencies deliver modern services to the public. And we maintain the front door to the federal government via USA.gov, GobiernoUSA.gov, and the USAGov Contact Center.
+We offer cross-government products and programs that help agencies deliver modern services to the public. And we maintain the front door to the federal government via USA.gov, USAGov en Español, and the USAGov Contact Center.
 
 What we do today builds on the efforts of many dedicated employees who served before us. While we can only offer a glimpse of their work below, we appreciate all the ways in which they built the foundation.
 
-## Walk-In, Order, or Call: Providing Gov Information 1966 - 1990
+## Walk-In, Order, or Call -- Providing Information: 1966 - 1990
 
 In 1970, President Nixon’s [Executive Order 11566](https://www.archives.gov/federal-register/codification/executive-order/11566.html) created the Consumer Product Information Coordinating Center. The office was tasked with helping federal agencies get their consumer-friendly information in print and into the hands of the public.
 
@@ -62,19 +62,29 @@ And, we kept pace with the rise of smartphones: the [Mobile Testing Program](htt
 
 ## An Eye to the Future: 2015 - present
 
-In recent years, we’ve established and grown many crucial government-wide products and programs:
+### TTS is born: 2016
+
+In 2016, [18F]({{site.baseurl}}/18f-history-and-values/), [PIF](https://presidentialinnovationfellows.gov/), and the Office of Products and Programs (OPP, aka us) [came together](https://www.fedscoop.com/gsa-launches-technology-service-line/) under the newly-formed Technology Transformation Service (TTS) office. Ever since we became an office within TTS, we have played an essential role in helping it modernize and digitize the federal government.
+
+### Ramping up our portfolio: 2016-2019
+
+Following the expansion of our web presence and digital knowledge, we've remained hard at work. In the years since, we've built, grown, and maintained crucial government-wide products and programs:
 
 - [10x](https://10x.gsa.gov/): provides start-up funding for new technology projects and products across government (2016)
 - [Artificial Intelligence Portfolio](https://digital.gov/communities/artificial-intelligence/): supporting and coordinating the use of artificial intelligence technologies in federal agencies (2019)
 - [CitizenScience.gov](https://www.citizenscience.gov/): a hub for accelerating crowdsourcing and citizen science across the U.S. government (2016)
 - [Code.gov](https://code.gov/): a catalog of government developed code (2016)
-- [Cloud.gov](https://cloud.gov/): a Platform as a Service built specifically for government work. Created by 18F in 2015. Part of TTS Solutions since 2019.
 - [Communities of Practice](https://digital.gov/communities/): where people in government come together to learn, share and collaborate to build solutions to common problems and challenges. The longest running community, the Web Content Managers Forum, dates back to 2000. New communities are created as new technologies and opportunities arise.
 - [Emerging Citizen Technology Office](https://emerging.digital.gov/): coordinates interagency initiatives that evaluate, test, and develop emerging technologies including artificial intelligence, blockchain, virtual/augmented reality, and social technologies (2017)
-- [Federalist](https://federalist.18f.gov/): a publishing platform for modern government websites. Created by 18F in 2015. Part of TTS Solutions since 2019.
 - Identity Program Management Office: supporting and promoting the use of secure identity management practices and tools (2019)
-- [Login.gov](https://login.gov/): a shared service that provides secure and private online access to participating government programs. Launched by 18F and the U.S. Digital Service in 2017. Part of TTS Solutions since 2019.
 - [U.S. Digital Registry](https://digital.gov/services/u-s-digital-registry/): an inventory of official government social media accounts, mobile websites and apps (2016)
-- [U.S. Web Design System](https://designsystem.digital.gov/): set of guidelines and code for agencies to create fast, accessible, mobile-friendly websites. Created by 18F and the U.S. Digital Service in 2015. Part of TTS Solutions since 2019.
 
-Over the past 50 years, we’ve grown and expanded while remaining true to our mission. We’ll continue to evolve as we anticipate and meet future needs. We look forward to the next 50 years of serving the public and our partners!
+### OPP --> Solutions: 2019
+
+In 2019, we got a bit bigger. OPP was renamed to Solutions during a [TTS-wide re-organization](https://www.fedscoop.com/gsa-tts-restructuring-anil-cheriyan/). And as part of this change, a number of projects moved from 18F to Solutions, including:
+  - [Cloud.gov](https://cloud.gov/): a Platform as a Service built specifically for government work. Created by 18F in 2015.
+  - [Federalist](https://federalist.18f.gov/): a publishing platform for modern government websites. Created by 18F in 2015.
+  - [Login.gov](https://login.gov/): a shared service that provides secure and private online access to participating government programs. Launched by 18F and the U.S. Digital Service in 2017.
+  - [U.S. Web Design System](https://designsystem.digital.gov/): set of guidelines and code for agencies to create fast, accessible, mobile-friendly websites. Created by 18F and the U.S. Digital Service in 2015.
+
+Over the past 50 years, TTS Solutions has grown, expanded, and renamed all while remaining true to our mission. We’ll continue to evolve as we anticipate and meet future needs. We look forward to the next 50 years of serving the public and our partners!

--- a/_pages/business-units/solutions/solutions-history.md
+++ b/_pages/business-units/solutions/solutions-history.md
@@ -75,7 +75,6 @@ Following the expansion of our web presence and digital knowledge, we've remaine
 - [CitizenScience.gov](https://www.citizenscience.gov/): a hub for accelerating crowdsourcing and citizen science across the U.S. government (2016)
 - [Code.gov](https://code.gov/): a catalog of government developed code (2016)
 - [Communities of Practice](https://digital.gov/communities/): where people in government come together to learn, share and collaborate to build solutions to common problems and challenges. The longest running community, the Web Content Managers Forum, dates back to 2000. New communities are created as new technologies and opportunities arise.
-- [Emerging Citizen Technology Office](https://emerging.digital.gov/): coordinates interagency initiatives that evaluate, test, and develop emerging technologies including artificial intelligence, blockchain, virtual/augmented reality, and social technologies (2017)
 - Identity Program Management Office: supporting and promoting the use of secure identity management practices and tools (2019)
 - [U.S. Digital Registry](https://digital.gov/services/u-s-digital-registry/): an inventory of official government social media accounts, mobile websites and apps (2016)
 

--- a/_pages/business-units/solutions/solutions-history.md
+++ b/_pages/business-units/solutions/solutions-history.md
@@ -6,7 +6,7 @@ questions:
   - solutions
 ---
 
-A brief history of TTS Solutions is hard to write: our work spans five decades and nine administrations! Moreover, before 2019 we weren't even called Solutions! Instead, we were known as the Office of Products and Programs (OPP).
+A brief history of TTS Solutions is hard to write: our work spans five decades and nine administrations! Moreover, we haven't even always been Solutions: pre-2019 we were known as the *Office of Products and Programs (OPP)*.
 
 What was established in 1970 as a place to coordinate and deliver information to consumers has evolved tremendously. Our audience has expanded to include every federal agency, government employees at all levels, the private sector, and people all over the world.
 

--- a/_pages/business-units/solutions/solutions-history.md
+++ b/_pages/business-units/solutions/solutions-history.md
@@ -88,5 +88,4 @@ In 2019, we got a bit bigger. OPP was renamed to Solutions during a [TTS-wide re
 - [Login.gov](https://login.gov/): a shared service that provides secure and private online access to participating government programs. Launched by 18F and the U.S. Digital Service in 2017.
 - [U.S. Web Design System](https://designsystem.digital.gov/): set of guidelines and code for agencies to create fast, accessible, mobile-friendly websites. Created by 18F and the U.S. Digital Service in 2015.
 
-
 Over the past 50 years, TTS Solutions has grown, expanded, and renamed all while remaining true to our mission. We’ll continue to evolve as we anticipate and meet future needs. We look forward to the next 50 years of serving the public and our partners!

--- a/_pages/business-units/solutions/solutions-history.md
+++ b/_pages/business-units/solutions/solutions-history.md
@@ -77,6 +77,7 @@ Following the expansion of our web presence and digital knowledge, we've remaine
 - [Communities of Practice](https://digital.gov/communities/): where people in government come together to learn, share and collaborate to build solutions to common problems and challenges. The longest running community, the Web Content Managers Forum, dates back to 2000. New communities are created as new technologies and opportunities arise.
 - Identity Program Management Office: supporting and promoting the use of secure identity management practices and tools (2019)
 - [U.S. Digital Registry](https://digital.gov/services/u-s-digital-registry/): an inventory of official government social media accounts, mobile websites and apps (2016)
+- [Vote.gov](https://vote.gov): USAGov’s voter registration and election information website (2016)
 
 ### 2019: OPP --> Solutions
 
@@ -86,5 +87,6 @@ In 2019, we got a bit bigger. OPP was renamed to Solutions during a [TTS-wide re
 - [Federalist](https://federalist.18f.gov/): a publishing platform for modern government websites. Created by 18F in 2015.
 - [Login.gov](https://login.gov/): a shared service that provides secure and private online access to participating government programs. Launched by 18F and the U.S. Digital Service in 2017.
 - [U.S. Web Design System](https://designsystem.digital.gov/): set of guidelines and code for agencies to create fast, accessible, mobile-friendly websites. Created by 18F and the U.S. Digital Service in 2015.
+
 
 Over the past 50 years, TTS Solutions has grown, expanded, and renamed all while remaining true to our mission. We’ll continue to evolve as we anticipate and meet future needs. We look forward to the next 50 years of serving the public and our partners!

--- a/_pages/business-units/solutions/solutions-history.md
+++ b/_pages/business-units/solutions/solutions-history.md
@@ -6,13 +6,13 @@ questions:
   - solutions
 ---
 
-A brief history of TTS Solutions is hard to write: our work spans five decades and nine administrations! Moreover, we haven't even always been Solutions: pre-2019 we were known as the _Office of Products and Programs (OPP)_.
+A brief history of TTS Solutions is hard to write: our work spans six decades and ten administrations! Moreover, we haven't even always been Solutions: pre-2019 we were known as the _Office of Products and Programs (OPP)_.
 
 What was established in 1970 as a place to coordinate and deliver information to consumers has evolved tremendously. Our audience has expanded to include every federal agency, government employees at all levels, the private sector, and people all over the world.
 
-Today, our [mission](https://docs.google.com/presentation/d/1DCtxpQgv89SRV_lpeXHNNOo1boIHmD2UpbsnV46WEik/edit#slide=id.g2fcf36f393_0_8) is to **help the public use and understand government**, and **help agencies understand and serve the public**. To achieve this, we **create, discover, connect and share practical solutions and products that transform government**.
+Today, our [mission]({{site.baseurl}}/office-of-solutions/#our-mission-and-purpose) is to **help the public use and understand government**, and **help agencies understand and serve the public**. To achieve this, we **create, discover, connect and share practical solutions and products that transform government**.
 
-We offer cross-government products and programs that help agencies deliver modern services to the public. And we maintain the front door to the federal government via USA.gov, USAGov en Español, and the USAGov Contact Center.
+We offer cross-government products and programs that help agencies deliver modern services to the public. And as we maintain the front door to the federal government via USA.gov, USAGov en Español, and the USAGov Contact Center, we equalize the government, making it inclusive and accessible for everyone.
 
 What we do today builds on the efforts of many dedicated employees who served before us. While we can only offer a glimpse of their work below, we appreciate all the ways in which they built the foundation.
 
@@ -22,7 +22,7 @@ In 1970, President Nixon’s [Executive Order 11566](https://www.archives.gov/fe
 
 But the roots of our work reach even further back. GSA was already the administrative home of a nationwide network of 26 Federal Information Centers which people could visit in person. These centers, generally located in the lobbies of federal buildings, answered government questions from the public. (Yes, you’ve read this correctly: once upon a time, you could show up to an assortment of government buildings to get your questions answered!)
 
-The centers were first established in 1966, were [formalized in 1978](https://www.gpo.gov/fdsys/pkg/STATUTE-92/pdf/STATUTE-92-Pg1641.pdf), and were merged with our office in 2000. They gradually moved from providing in-person service locally to [answering questions by telephone](https://www.usa.gov/phone) nationally—a bilingual service which still exists today as the USAGov Contact Center at 1-844-USA-GOV1 and via [chat and email](https://www.usa.gov/contact).
+The centers were first established in 1966, were [formalized in 1978](https://www.gpo.gov/fdsys/pkg/STATUTE-92/pdf/STATUTE-92-Pg1641.pdf), and were merged with our office in 2000. They gradually moved from providing in-person service locally to [answering questions by telephone](https://www.usa.gov/phone) nationally—a bilingual service which still exists today as the USAGov Contact Center at 1-844-USA-GOV1 and via [chat](https://www.usa.gov/chat).
 
 Another primary vehicle to connect the public and government was the _Consumer Information Catalog_. It listed more than 200 popular publications from across the federal government on diverse topics that are still relevant today: saving for college and retirement, avoiding fraud, staying healthy, and learning about federal laws and regulations that affect daily lives.
 
@@ -32,15 +32,15 @@ The _Catalog_ was crucial: imagine getting quality government information on tho
 
 The _Catalog_ was our first foray into the online world: in 1992, we created an electronic bulletin board system to allow anyone with a modem to dial up and download the publications listed in the _Catalog_.
 
-We launched our first website in 1994, also based on the _Catalog_: Pueblo.gsa.gov (which later became Publications.USA.gov). It was one of the first consumer information websites and received more than one million visits during its first year.
+We launched our first website in 1994, also based on the _Catalog_: [Pueblo.gsa.gov](https://web.archive.org/web/19970214004105/http://www.pueblo.gsa.gov/) (which later became Publications.USA.gov). It was one of the first consumer information websites and received more than one million visits during its first year.
 
-In 1997, the White House gave us responsibility for one of the most helpful and popular federal publications: the _Consumer’s Resource Handbook_. Released biannually since 1979, it was renamed the [Consumer Action Handbook](https://www.usa.gov/handbook) in 2000 and was later joined by a Spanish version, the [Guía del Consumidor](https://gobierno.usa.gov/ordene-guia-consumidor). Both publications empower people to resolve their own consumer complaints.
+In 1997, the White House gave us responsibility for one of the most helpful and popular federal publications: the _Consumer’s Resource Handbook_. Released biannually since 1979, it was renamed the [Consumer Action Handbook](https://web.archive.org/web/20190810233837/https://app_usa_prod_eqffnyamdzrb.s3.amazonaws.com/Consumer_Action_Handbook_2017.pdf?Rc37jX4tB8.5H.5oHzSSu_LcEYFcjzpC) in 2000 and was later joined by a Spanish version, the [Guía del Consumidor](https://drive.google.com/file/d/0B64-A1A3hX29ZERrV3cxQUhZcEE/view?usp=sharing&resourcekey=0-9P0D8xh9vdnsxBiRU4YO7w). Both publications empowered people to resolve their own consumer complaints.
 
 ## 2000 - 2010: Expanding Our Digital Presence
 
 [USA.gov](https://www.usa.gov/) got its start as FirstGov.gov in June 2000 when President Clinton announced the gift of a powerful search engine from internet entrepreneur Eric Brewer. Clinton called for us to use it to create and launch an official U.S. web portal within 90 days.
 
-In 2001 we added Kids.gov, filled with children’s content and lesson plans. And in 2003 we launched the official Spanish language portal, FirstGov en español. The FirstGov sites got more memorable names in 2007: USA.gov and [GobiernoUSA.gov](https://gobierno.usa.gov/). Both continue as the official guides to government information, benefits, and services.
+In 2001 we added [Kids.gov](https://web.archive.org/web/20160327075216/https://kids.usa.gov/), filled with children’s content and lesson plans. And in 2003 we launched the official Spanish language portal, FirstGov en español. The FirstGov sites got more memorable names in 2007: USA.gov and GobiernoUSA.gov (now known as [USAGov en Español](https://gobierno.usa.gov/)). Both continue as the official guides to government information, benefits, and services.
 
 Starting in 2002, we managed WebContent.gov, a one-stop resource for government web professionals who needed information about requirements, best practices, usability, and new technologies. Its training program, Web Manager University, offered practical training for managers of federal, state, and local government websites. These two services are the predecessors of today’s [DigitalGov](https://digital.gov/) and [DigitalGov University](https://digital.gov/digitalgov-university/).
 

--- a/_pages/business-units/solutions/solutions-history.md
+++ b/_pages/business-units/solutions/solutions-history.md
@@ -16,7 +16,7 @@ We offer cross-government products and programs that help agencies deliver moder
 
 What we do today builds on the efforts of many dedicated employees who served before us. While we can only offer a glimpse of their work below, we appreciate all the ways in which they built the foundation.
 
-## Walk-In, Order, or Call -- Providing Information: 1966 - 1990
+## 1966-1990: Walk-In, Order, or Call -- Providing Information
 
 In 1970, President Nixon’s [Executive Order 11566](https://www.archives.gov/federal-register/codification/executive-order/11566.html) created the Consumer Product Information Coordinating Center. The office was tasked with helping federal agencies get their consumer-friendly information in print and into the hands of the public.
 
@@ -28,7 +28,7 @@ Another primary vehicle to connect the public and government was the _Consumer I
 
 The _Catalog_ was crucial: imagine getting quality government information on those topics in the pre-Internet age! We published the first edition of the _Catalog_ in 1971, and the [final edition](https://drive.google.com/file/d/0B812FdtUF1KxbXVLakIzeHlYUVk/view) in 2016. In 45 years, we filled more than 76 million orders and distributed more than 1.2 billion publications.
 
-## Entering the Digital Age: 1990s - 2000
+## 1990s - 2000: Entering the Digital Age
 
 The _Catalog_ was our first foray into the online world: in 1992, we created an electronic bulletin board system to allow anyone with a modem to dial up and download the publications listed in the _Catalog_.
 
@@ -36,7 +36,7 @@ We launched our first website in 1994, also based on the _Catalog_: Pueblo.gsa.g
 
 In 1997, the White House gave us responsibility for one of the most helpful and popular federal publications: the _Consumer’s Resource Handbook_. Released biannually since 1979, it was renamed the [Consumer Action Handbook](https://www.usa.gov/handbook) in 2000 and was later joined by a Spanish version, the [Guía del Consumidor](https://gobierno.usa.gov/ordene-guia-consumidor). Both publications empower people to resolve their own consumer complaints.
 
-## Expanding Our Digital Presence: 2000 - 2010
+## 2000 - 2010: Expanding Our Digital Presence
 
 [USA.gov](https://www.usa.gov/) got its start as FirstGov.gov in June 2000 when President Clinton announced the gift of a powerful search engine from internet entrepreneur Eric Brewer. Clinton called for us to use it to create and launch an official U.S. web portal within 90 days.
 
@@ -46,7 +46,7 @@ Starting in 2002, we managed WebContent.gov, a one-stop resource for government 
 
 The home of the U.S. government’s open data, [Data.gov](https://www.data.gov/), launched in 2009, as did [Go.USA.gov](https://go.usa.gov/), a URL shortening service for government agencies.
 
-## Hitting 40 and Looking Beyond the Web: 2010 - 2015
+## 2010 - 2015: Hitting 40 and Looking Beyond the Web
 
 At the turn of the decade, our efforts began expanding beyond web content and information dissemination.
 
@@ -60,13 +60,13 @@ In 2012, the [Digital Analytics Program](https://digital.gov/dap/)’s website a
 
 And, we kept pace with the rise of smartphones: the [Mobile Testing Program](https://digital.gov/services/mobile-application-testing-program/), a compatibility testing service that agencies can use to test their websites for mobile-friendliness, began in 2013.
 
-## An Eye to the Future: 2015 - present
+## 2015 - present: An Eye to the Future
 
-### TTS is born: 2016
+### 2016: TTS is born
 
 In 2016, [18F]({{site.baseurl}}/18f-history-and-values/), [PIF](https://presidentialinnovationfellows.gov/), and the Office of Products and Programs (OPP, aka us) [came together](https://www.fedscoop.com/gsa-launches-technology-service-line/) under the newly-formed Technology Transformation Service (TTS) office. Ever since we became an office within TTS, we have played an essential role in helping it modernize and digitize the federal government.
 
-### Ramping up our portfolio: 2016-2019
+### 2016 - 2019: Ramping up our portfolio
 
 Following the expansion of our web presence and digital knowledge, we've remained hard at work. In the years since, we've built, grown, and maintained crucial government-wide products and programs:
 
@@ -79,7 +79,7 @@ Following the expansion of our web presence and digital knowledge, we've remaine
 - Identity Program Management Office: supporting and promoting the use of secure identity management practices and tools (2019)
 - [U.S. Digital Registry](https://digital.gov/services/u-s-digital-registry/): an inventory of official government social media accounts, mobile websites and apps (2016)
 
-### OPP --> Solutions: 2019
+### 2019: OPP --> Solutions
 
 In 2019, we got a bit bigger. OPP was renamed to Solutions during a [TTS-wide re-organization](https://www.fedscoop.com/gsa-tts-restructuring-anil-cheriyan/). And as part of this change, a number of projects moved from 18F to Solutions, including:
 

--- a/_pages/business-units/solutions/solutions-history.md
+++ b/_pages/business-units/solutions/solutions-history.md
@@ -6,7 +6,7 @@ questions:
   - solutions
 ---
 
-A brief history of TTS Solutions is hard to write: our work spans five decades and nine administrations! Moreover, we haven't even always been Solutions: pre-2019 we were known as the *Office of Products and Programs (OPP)*.
+A brief history of TTS Solutions is hard to write: our work spans five decades and nine administrations! Moreover, we haven't even always been Solutions: pre-2019 we were known as the _Office of Products and Programs (OPP)_.
 
 What was established in 1970 as a place to coordinate and deliver information to consumers has evolved tremendously. Our audience has expanded to include every federal agency, government employees at all levels, the private sector, and people all over the world.
 


### PR DESCRIPTION
Part of #2608 

This PR updates the TTS Solutions History page. Specifically I:
* Included more information around the re-orgs, and addressed when/how OPP became Solutions.
* Split up the 2015-present timeline to present a more accurate history of how certain projects moved from 18F to Solutions.
* Minor formatting changes.

I could really use feedback on the proposed updates, especially if they are inaccurate (hopefully not)!