### PR TITLE
Add most visited section

### DIFF
--- a/_includes/most-visited.html
+++ b/_includes/most-visited.html
@@ -6,7 +6,7 @@
 >
   <div class="usa-summary-box__body">
     <h3 class="usa-summary-box__heading" id="summary-box-key-information">
-      Quick links
+      Most visited
     </h3>
     <div class="usa-summary-box__text">
       <ol class="usa-list">

--- a/_includes/quick-links.html
+++ b/_includes/quick-links.html
@@ -1,0 +1,39 @@
+<!-- This code was adapted from the USWDS Summary box component. Source: https://designsystem.digital.gov/components/summary-box/ -->
+<div
+  class="usa-summary-box"
+  role="region"
+  aria-labelledby="summary-box-key-information"
+>
+  <div class="usa-summary-box__body">
+    <h3 class="usa-summary-box__heading" id="summary-box-key-information">
+      Quick links
+    </h3>
+    <div class="usa-summary-box__text">
+      <ol class="usa-list">
+        <li>
+        <a class="usa-summary-box__link" href="{{site.baseurl}}/top-secret/"
+            >Top Secret / Sensitive Compartmented Information (TS/SCI) Clearance</a>
+          </li>
+        <li>
+        <a class="usa-summary-box__link" href="{{site.baseurl}}/google-meet/"
+            >Google Meet</a
+          >
+        </li>
+        <li>
+        <a class="usa-summary-box__link"
+          href="{{site.baseurl}}/travel-guide-email-templates/"
+            >Travel Guide Email Templates</a
+          >
+        </li>
+        <li>
+        <a class="usa-summary-box__link"
+        href="{{site.baseurl}}/writing-lab/">Writing Lab</a>
+        </li>
+         <li>
+        <a class="usa-summary-box__link"
+        href="{{site.baseurl}}/blogging/">Blogging</a>
+        </li>
+      </ol>
+    </div>
+  </div>
+</div>

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -4,7 +4,7 @@ permalink: "/"
 ---
 
 <p>{{ site.description }}</p>
-{% include quick-links.html %}
+{% include most-visited.html %}
 <div class="layout-table-of-contents">
   <div class="wrapper usa-prose">
     {% include nav.html level=1 nav=site.data.navigation.primary %}

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -4,6 +4,7 @@ permalink: "/"
 ---
 
 <p>{{ site.description }}</p>
+{% include quick-links.html %}
 <div class="layout-table-of-contents">
   <div class="wrapper usa-prose">
     {% include nav.html level=1 nav=site.data.navigation.primary %}


### PR DESCRIPTION
Fixes #2618

This PR adds a "Most-visited" box to the top of the homepage. The chosen links were the five most-visited links for the past week, and are hard-coded into the component. 

In an ideal world, this component would be updated every week/month with the most visited links, but for now it will have to be a manual process.

<img width="1058" alt="Screen Shot 2021-07-02 at 4 49 22 PM" src="https://user-images.githubusercontent.com/35497479/124331740-75ccef00-db55-11eb-830f-c86acc161d0a.png">
