### PR TITLE
add Low system warning to relevant tool pages

### DIFF
--- a/_includes/low-system.html
+++ b/_includes/low-system.html
@@ -1,0 +1,11 @@
+<div class="usa-alert usa-alert--info">
+  <div class="usa-alert__body">
+    <h3 class="usa-alert__heading">This is a <a href="https://atos.open-control.org/categorization/">Low</a> system</h3>
+    <p class="usa-alert__text">This means:
+      <ul>
+        <li>You cannot use it to store any <a href="{{site.baseurl}}/sensitive-information/">sensitive information</a></li>
+        <li>It generally can't have write access to any <a href="https://atos.open-control.org/categorization/">Moderate</a> systems</li>
+      </ul>
+      Reach out in <a href="https://gsa-tts.slack.com/messages/infrastructure">#infrastructure</a> if you have questions.</p>
+  </div>
+</div>

--- a/_pages/software-and-tools/github.md
+++ b/_pages/software-and-tools/github.md
@@ -9,6 +9,8 @@ questions:
 
 GitHub is a closed-source platform for [open-source](https://github.com/18F/open-source-policy) communities. It allows us to collaborate on documentation and code, both internally and with a broader audience. If you're not familiar with how to use GitHub, see the [introduction]({{site.baseurl}}/intro-to-github/).
 
+{% include low-system.html %}
+
 ## Setup
 
 GitHub is a web application, and you may be able to do all of your work within the [github.com](https://github.com) website. Optionally, you may also install [GitHub Desktop](https://desktop.github.com/) through [Self Service]({{site.baseurl}}/gsa-internal-tools/#self-service).

--- a/_pages/software-and-tools/invision.md
+++ b/_pages/software-and-tools/invision.md
@@ -6,6 +6,8 @@ title: InVision
 
 If you are a member of the 18F Design team, once you have requested and received an InVision license, tell your supervisor that you have an account and are ready to be added to the "18F Design Team" [group](https://gsa.invisionapp.com/d/main?origin=v7#/company/teams) in InVision. This will enable you to see prototypes from all of our projects. When making your own prototypes in the future, always add this team as a collaborator.
 
+{% include low-system.html %}
+
 ## Offboarding
 
 [Transfer ownership of your prototypes](https://support.invisionapp.com/hc/en-us/articles/203730565-How-do-I-transfer-my-prototype-to-another-account-) to your supervisor or to another project team member so that they won't be lost once your account is deactivated.

--- a/tools/airtable.md
+++ b/tools/airtable.md
@@ -5,3 +5,5 @@ questions:
 ---
 
 You can sign up for [Airtable](https://airtable.com/)'s free plan with your GSA email. For an [upgraded license](https://airtable.com/pricing), put in a [micropurchase request]({{site.baseurl}}/purchase-requests/).
+
+{% include low-system.html %}

--- a/tools/eventbrite.md
+++ b/tools/eventbrite.md
@@ -31,6 +31,8 @@ The following are required for accessibility and other compliance reasons:
 
   - If attendees need to be federal employees, a question about whether they are federal or not
 
+{% include low-system.html %}
+
 ## See also
 
 - [Meetings and meeting tools]({{site.baseurl}}/meetings-and-meeting-tools/)

--- a/tools/mural.md
+++ b/tools/mural.md
@@ -28,6 +28,8 @@ The number of active Mural members needs to stay under 240. In order to accompli
 - The benefit of adding your partner as a guest and not an anonymous user is that you will be able to see what contributions they are making to a Mural. They will be called by name in the Mural, whereas anonymous users will be shown as an animal, not their name.
 - If you have any questions, please ask in [#admins-mural](https://gsa-tts.slack.com/messages/admins-mural).
 
+{% include low-system.html %}
+
 ## Offboarding
 
 When someone [leaves TTS]({{site.baseurl}}/leaving-tts/), an admin will [deactivate](https://support.mural.co/en/articles/2145569-activate-and-deactivate-members) them from [the Members page](https://app.mural.co/t/gsa6/settings/members).


### PR DESCRIPTION
Closes https://github.com/18F/handbook/issues/2335.

Had this idea while investigating a security incident, where I was being asked to confirm that none of a handful of Mural boards contained sensitive information. Since it's a Low system, there _shouldn't_ be any in there, but I'm also not sure that is widely known. This alert tries to make it much more clear.

<img width="675" alt="Screen Shot 2021-07-02 at 7 16 24 PM" src="https://user-images.githubusercontent.com/86842/124335930-0f060080-db6a-11eb-818c-52a68e871fab.png">

Too scary? Could the wording be better?