### PR TITLE
Stubs for offboarding

### DIFF
--- a/_pages/software-and-tools/docker-hub.md
+++ b/_pages/software-and-tools/docker-hub.md
@@ -14,7 +14,7 @@ You may use your personal Docker Hub account for work. Ask
 the [TTS-wide account](https://hub.docker.com/u/18fgsa).
 
 Alternatively, you can create a Docker Hub Organization for your program and use a [micropurchase
-request]({{ site.baseurl }}/purchase-requests/) for payment. Please start the
+request]({{site.baseurl}}/purchase-requests/) for payment. Please start the
 request in [#infrastructure][slack-infrastructure].
 
 ## For admins

--- a/_pages/software-and-tools/docker-hub.md
+++ b/_pages/software-and-tools/docker-hub.md
@@ -1,0 +1,25 @@
+---
+title: Docker Hub
+questions:
+  - infrastructure
+---
+
+[Docker Hub](https://hub.docker.com/) is a cloud-based container registry for
+use with [Docker](https://www.docker.com/) and other container technologies.
+
+## How do I get access to Docker Hub?
+
+You may use your personal Docker Hub account for work. Ask
+[#infrastructure][slack-infrastructure] for access to
+the [TTS-wide account](https://hub.docker.com/u/18fgsa).
+
+Alternatively, you can create a Docker Hub Organization for your program and use a [micropurchase
+request]({{ site.baseurl }}/purchase-requests/) for payment. Please start the
+request in [#infrastructure][slack-infrastructure].
+
+## For admins
+
+Ensure the user has been removed from the [Members
+list](https://hub.docker.com/orgs/18fgsa).
+
+[slack-infrastructure]: https://gsa-tts.slack.com/archives/C039MHHF8

--- a/_pages/software-and-tools/new-relic.md
+++ b/_pages/software-and-tools/new-relic.md
@@ -1,0 +1,25 @@
+---
+title: New Relic
+questions:
+  - admins-newrelic
+---
+
+[New Relic](https://newrelic.com/) is a cloud-based application performance
+monitoring and observability platform for use in application development. New
+Relic includes several products, each of which is available to TTS systems:
+
+- **APM:** application performance monitoring
+- **Infrastructure:** host- and operating system-level monitoring
+- **Logs:** log management, monitoring, and alerting
+- **Synthetics:** endpoint uptime and availability monitoring
+- etc.
+
+## How do I get access to New Relic?
+
+Ask in [#admins-newrelic](https://gsa-tts.slack.com/archives/C14EF2XEC) and
+include the name to use for the New Relic account and which Business Unit where costs
+will be billed.
+
+## For admins
+
+See our [private documentation for New Relic onboarding/offboarding](https://docs.google.com/document/d/1hJrZqNkaLkv6dcD2QIckYe9CzvuHAWVpmI2iNImyMrI/edit).

--- a/_pages/software-and-tools/npm.md
+++ b/_pages/software-and-tools/npm.md
@@ -1,0 +1,21 @@
+---
+title: npm
+questions:
+  - javascript
+---
+
+[npm](https://www.npmjs.com/) is a package manager and cloud-based registry for
+[Node.js](https://nodejs.org/en/). The npm registry can be used to package and
+distribute JavaScript libraries and programs for software development.
+
+## How do I publish npm packages for TTS?
+
+Any npm packages published for work should be published under the
+[18f](https://www.npmjs.com/org/18f) npm organization. You may use your personal
+npm account for membership to the 18f organization. Ask
+[#javascript](https://gsa-tts.slack.com/archives/C032KSPPQ) for how to get
+membership or a token for publishing.
+
+## For admins
+
+Log into the 18f-devops account. Remove the user from the group.

--- a/_pages/software-and-tools/npm.md
+++ b/_pages/software-and-tools/npm.md
@@ -18,4 +18,4 @@ membership or a token for publishing.
 
 ## For admins
 
-Log into the 18f-devops account. Remove the user from the group.
+Login with your npm account and remove the user from the [18f organization](https://www.npmjs.com/settings/18f/members).


### PR DESCRIPTION
https://github.com/18F/handbook/issues/2641

Add pages for tools to document onboarding/offboarding procedures.

- [Preview: New Relic](https://federalist-cf8341ad-ca07-488c-bd96-0738014c79ca.app.cloud.gov/preview/18f/handbook/feature/admin-offboarding/new-relic/)
- [Preview: npm](https://federalist-cf8341ad-ca07-488c-bd96-0738014c79ca.app.cloud.gov/preview/18f/handbook/feature/admin-offboarding/npm/)
- [Preview: Docker Hub](https://federalist-cf8341ad-ca07-488c-bd96-0738014c79ca.app.cloud.gov/preview/18f/handbook/feature/admin-offboarding/docker-hub/)