### PR TITLE
Set up Netlify CMS

### DIFF
--- a/_pages/business-units/solutions/office-of-solutions.md
+++ b/_pages/business-units/solutions/office-of-solutions.md
@@ -18,7 +18,7 @@ Our mission is to help the public use and understand government, and help agenci
 
 ## What We Do
 
-We offer cross-government products and programs that help agencies deliver modern services to the public. And we maintain the front door to the federal government via USA.gov, GobiernoUSA.gov, and the USAGov Contact Center.
+We offer cross-government products and programs that help agencies deliver modern services to the public. And we maintain the front door to the federal government via USA.gov, USA.gov en Español, and the USAGov Contact Center.
 
 ## Our Initiatives
 
@@ -33,22 +33,21 @@ We offer cross-government products and programs that help agencies deliver moder
 - [Digital Analytics Program (DAP)](https://www.digital.gov/guide/dap/): government-wide analytics tracking for agency websites
 - [Digital.gov](https://digital.gov/): a website that provides resources for agencies to create digital services
 - [DigitalGov University (DGU)](https://digital.gov/digitalgov-university/): hosts trainings and other events about agencies’ digital efforts.
-- [Emerging Citizen Technology Office (ECTO)](https://emerging.digital.gov/): coordinates interagency initiatives that evaluate, test, and develop emerging technologies including artificial intelligence, blockchain, virtual/augmented reality, and social technologies
 - [Federal Risk and Authorization Management Program (FedRAMP)](https://www.fedramp.gov/): provides a standardized approach to security assessment, authorization, and continuous monitoring for cloud products and services
 - [Go.USA.gov](https://go.usa.gov/): a URL shortening service for government agencies
-- [GobiernoUSA.gov](https://gobierno.usa.gov/): the “front door” to the federal government, offering government information and services by topic (in Spanish)
 - [Login.gov](https://login.gov): offers the public secure and private online access to participating government programs
 - [Mobile Testing Program](https://digital.gov/services/mobile-application-testing-program/): a compatibility testing service that agencies can use to test their websites for mobile-friendliness
 - [Search.gov](https://search.gov/): a service that powers search boxes on agency websites
 - [U.S. Digital Registry](https://digital.gov/services/u-s-digital-registry/): an inventory of official government social media accounts, mobile websites and apps
 - [U.S. Web Design System](https://designsystem.digital.gov/): set of guidelines and code for agencies to create fast, accessible, mobile-friendly websites
 - [USA.gov](https://www.usa.gov/): the “front door” to the federal government, offering government information and services by topic (in English)
+- [USA.gov en Español](https://usa.gov/espanol/): USA.gov in Spanish
 - [USAGov Contact Center](https://www.usa.gov/contact): where the public can ask questions about any government agency
 - [USAGov Partnership Toolkit](https://usa.gov/partnerships): how agencies can partner with USAGov for outreach and engagement efforts
 
 ## Our History
 
-Check out our [brief history]({{site.baseurl}}/solutions-history/) and learn how our work spans nearly 5 decades!
+Check out our [brief history]({{site.baseurl}}/solutions-history/) and learn how our work spans nearly six decades!
 
 ## Our Org Structure
 

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,4 +1,7 @@
 backend:
   name: github
   repo: 18f/handbook
-  branch: main # Branch to update (optional; defaults to master)
+  base_url: https://federalist.18f.gov
+  auth_endpoint: external/auth/github
+  preview_context: federalist/build
+  branch: main

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,0 +1,4 @@
+backend:
+  name: github
+  repo: 18f/handbook
+  branch: main # Branch to update (optional; defaults to master)

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,7 +1,26 @@
 backend:
   name: github
   repo: 18f/handbook
-  base_url: https://federalist.18f.gov
+  base_url: https://federalistapp.18f.gov
   auth_endpoint: external/auth/github
   preview_context: federalist/build
   branch: main
+  open_authoring: true
+
+media_folder: images/
+public_folder: /images/uploads
+publish_mode: editorial_workflow
+logo_url: https://federalist.18f.gov/assets/images/federalist-logo.png
+
+collections:
+    - name: "pages"
+      label: "Pages"
+      label_singular: "Page"
+      description: "Basic Handbook page"
+      folder: "_pages/netlifycms"
+      create: true
+      slug: "{{slug}}"
+      fields: 
+        - {label: "Title", name: "title", widget: "string"}
+        - {label: "Questions", name: "questions", widget: "list"}
+        - {label: "Body", name: "body", widget: "markdown"}

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Content Manager</title>
+</head>
+<body>
+  <!-- Include the script that builds the page and powers Netlify CMS -->
+  <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+</body>
+</html>

--- a/admin/index.html
+++ b/admin/index.html
@@ -7,6 +7,6 @@
 </head>
 <body>
   <!-- Include the script that builds the page and powers Netlify CMS -->
-  <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+  <script src="/javascripts/netlify-cms.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #2644 (partially)

This PR initializes Netlify CMS for the Handbook. More research into its features and, if we move forward with the tool, some documentation about how to use it is still necessary. I'd like to get this merged in sooner rather than later since local testing is fairly limited, and there is little to no downside of optimistically merging this tool.

NetlifyCMS running locally:
<img width="1440" alt="Screen Shot 2021-07-07 at 10 20 01 AM" src="https://user-images.githubusercontent.com/35497479/124785926-e59ff880-df0c-11eb-9e4b-bcc29d36b23a.png">
