### PR TITLE
Update ISSUE template to remove default title

### DIFF
--- a/.github/ISSUE_TEMPLATE/page-update.md
+++ b/.github/ISSUE_TEMPLATE/page-update.md
@@ -1,7 +1,6 @@
 ---
 name: Page update
 about: For general updates to existing Handbook pages
-title: "X page: [Outdated/inaccurate/typos/confusing]"
 labels: page update
 assignees: ""
 ---


### PR DESCRIPTION
People are already opting for custom titles on issues, so I think I'd rather just reduce the extra deletion step.