### PR TITLE
Use v2 checkout action

### DIFF
--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -8,7 +8,11 @@ jobs:
     name: Format code
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          # Use the branch commit instead of the PR merge commit
+          ref: ${{ github.event.pull_request.head.sha }}
+
 
       - uses: actions/setup-node@v1
         with:
@@ -28,10 +32,9 @@ jobs:
       - name: Push if it is not
         if: failure()
         run: |
-          git remote set-url --push origin https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY
           git config user.name "Github Runner"
           git config user.email "runner@runner.github.com"
-          git commit -am "Format code"
+          git commit -m "Format code"
           git status
           git push origin HEAD:$GITHUB_HEAD_REF
         env:

--- a/tools/slack.md
+++ b/tools/slack.md
@@ -6,6 +6,7 @@ questions:
   - admins-slack
 ---
 
+
 To get started, **sign in at [gsa-tts.slack.com](https://gsa-tts.slack.com)**. See the [official documentation](https://slack.com/help/articles/218080037-Getting-started-for-new-members) for how to use Slack generally, and the following sub-pages for information about Slack at TTS:
 
 - [Getting started & rules](rules/)

--- a/tools/slack.md
+++ b/tools/slack.md
@@ -6,7 +6,6 @@ questions:
   - admins-slack
 ---
 
-
 To get started, **sign in at [gsa-tts.slack.com](https://gsa-tts.slack.com)**. See the [official documentation](https://slack.com/help/articles/218080037-Getting-started-for-new-members) for how to use Slack generally, and the following sub-pages for information about Slack at TTS:
 
 - [Getting started & rules](rules/)


### PR DESCRIPTION
- Use v2 for GH checkout action
- [Use the pull request HEAD commit instead of merge commit](https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit)
- Introduce lint error

By using the PR HEAD, we remove the extra merge commit which sometimes confuses the GH diff.
