### PR TITLE
Add NetlifyCMS Collections

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -13,13 +13,88 @@ publish_mode: editorial_workflow
 logo_url: https://federalist.18f.gov/assets/images/federalist-logo.png
 
 collections:
-    - name: "pages"
-      label: "Pages"
-      label_singular: "Page"
-      description: "Basic Handbook page"
-      folder: "_pages/netlifycms"
+    - name: "about-us"
+      label: "About us"
+      label_singular: "About page"
+      folder: "_pages/about-us"
       create: true
-      slug: "{{slug}}"
+      fields: 
+        - {label: "Title", name: "title", widget: "string"}
+        - {label: "Questions", name: "questions", widget: "list"}
+        - {label: "Body", name: "body", widget: "markdown"}
+    - name: "getting-started"
+      label: "Getting started"
+      folder: "_pages/getting-started"
+      create: true
+      fields: 
+        - {label: "Title", name: "title", widget: "string"}
+        - {label: "Questions", name: "questions", widget: "list"}
+        - {label: "Body", name: "body", widget: "markdown"}
+    - name: "classes"
+      label: "Classes"
+      folder: "_pages/getting-started/classes"
+      create: true
+      fields: 
+        - {label: "Title", name: "title", widget: "string"}
+        - {label: "Questions", name: "questions", widget: "list"}
+        - {label: "Body", name: "body", widget: "markdown"}
+    - name: "hiring-staying-or-changing-jobs"
+      label: "Hiring, staying, or changing jobs"
+      label_singular: "Hiring page"
+      folder: "_pages/hiring-staying-or-changing-jobs"
+      create: true
+      fields: 
+        - {label: "Title", name: "title", widget: "string"}
+        - {label: "Questions", name: "questions", widget: "list"}
+        - {label: "Body", name: "body", widget: "markdown"}
+    - name: "locations"
+      label: "Locations"
+      label_singular: "Location page"
+      folder: "_pages/general-information-and-resources/locations"
+      create: true
+      fields: 
+        - {label: "Title", name: "title", widget: "string"}
+        - {label: "Questions", name: "questions", widget: "list"}
+        - {label: "Body", name: "body", widget: "markdown"}
+    - name: "outreach"
+      label: "Outreach"
+      label_singular: "Outreach page"
+      folder: "_pages/tts-offices/operations/outreach" create: true fields: 
+        - {label: "Title", name: "title", widget: "string"}
+        - {label: "Questions", name: "questions", widget: "list"}
+        - {label: "Body", name: "body", widget: "markdown"}
+    - name: "software-and-tools"
+      label: "Software and tools"
+      label_singular: "Software page"
+      folder: "_pages/software-and-tools"
+      create: true
+      fields: 
+        - {label: "Title", name: "title", widget: "string"}
+        - {label: "Questions", name: "questions", widget: "list"}
+        - {label: "Body", name: "body", widget: "markdown"}
+    - name: "solutions"
+      label: "Solutions"
+      label_singular: "Solutions page"
+      folder: "_pages/tts-offices/solutions"
+      create: true
+      fields: 
+        - {label: "Title", name: "title", widget: "string"}
+        - {label: "Questions", name: "questions", widget: "list"}
+        - {label: "Body", name: "body", widget: "markdown"}
+    - name: "training-and-development"
+      label: "Training and development"
+      label_singular: "Training page"
+      folder: "_pages/training-and-development"
+      create: true
+      fields: 
+        - {label: "Title", name: "title", widget: "string"}
+        - {label: "Questions", name: "questions", widget: "list"}
+        - {label: "Body", name: "body", widget: "markdown"}
+    - name: "travel-and-leave-policies"
+      label: "Travel and leave policies"
+      label_singular: "Travel policy"
+      folder: "_pages/travel-leave/travel-and-leave-policies"
+      create: true
       fields: 
         - {label: "Title", name: "title", widget: "string"}
         - {label: "Questions", name: "questions", widget: "list"}

--- a/admin/index.html
+++ b/admin/index.html
@@ -8,5 +8,8 @@
 <body>
   <!-- Include the script that builds the page and powers Netlify CMS -->
   <script src="/javascripts/netlify-cms.js"></script>
+  <script>
+CMS.registerPreviewStyle("/assets/css/uswds-theme.css");
+</script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #2651 

Adds a bunch of Collections to the NetlifyCMS configuration. I couldn't reasonably cover all the current content in this PR, so #2665 has been created as a follow-up issue.

Specifically, this PR enables users to _actually_ edit and create content. There is quite a bit of duplication because of how the Handbook is currently set up, but my prioritization in this PR is usability over aesthetics. I'll revisit to see if there is a more succinct `config.yml` file later.

Demo of the new tool:
![netlifycms-part1](https://user-images.githubusercontent.com/35497479/125349247-ed073d80-e322-11eb-9142-69bb4e50772a.gif)