### PR TITLE
Fixes NetlifyCMS config, makes all pages available

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -13,36 +13,13 @@ publish_mode: editorial_workflow
 logo_url: https://federalist.18f.gov/assets/images/federalist-logo.png
 
 collections:
-    - name: "about-us"
-      label: "About us"
-      label_singular: "About page"
-      folder: "_pages/about-us"
+    - name: "_pages"
+      label: "Pages"
+      label_singular: "page"
+      nested: { depth: 5 }
+      folder: "_pages/"
       create: true
-      fields: 
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Questions", name: "questions", widget: "list"}
-        - {label: "Body", name: "body", widget: "markdown"}
-    - name: "getting-started"
-      label: "Getting started"
-      folder: "_pages/getting-started"
-      create: true
-      fields: 
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Questions", name: "questions", widget: "list"}
-        - {label: "Body", name: "body", widget: "markdown"}
-    - name: "classes"
-      label: "Classes"
-      folder: "_pages/getting-started/classes"
-      create: true
-      fields: 
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Questions", name: "questions", widget: "list"}
-        - {label: "Body", name: "body", widget: "markdown"}
-    - name: "hiring-staying-or-changing-jobs"
-      label: "Hiring, staying, or changing jobs"
-      label_singular: "Hiring page"
-      folder: "_pages/hiring-staying-or-changing-jobs"
-      create: true
+      meta: { path: { widget: string, label: 'Path', index_file: 'index' } }
       fields: 
         - {label: "Title", name: "title", widget: "string"}
         - {label: "Questions", name: "questions", widget: "list"}
@@ -56,55 +33,19 @@ collections:
         - {label: "Title", name: "title", widget: "string"}
         - {label: "Questions", name: "questions", widget: "list"}
         - {label: "Body", name: "body", widget: "markdown"}
-    - name: "locations"
-      label: "Locations"
-      label_singular: "Location page"
-      folder: "_pages/general-information-and-resources/locations"
+    - name: "performance-management"
+      label: "Performance management"
+      label_singular: "Performance management page"
+      folder: "performance-management/"
       create: true
       fields: 
         - {label: "Title", name: "title", widget: "string"}
         - {label: "Questions", name: "questions", widget: "list"}
         - {label: "Body", name: "body", widget: "markdown"}
-    - name: "outreach"
-      label: "Outreach"
-      label_singular: "Outreach page"
-      folder: "_pages/tts-offices/operations/outreach"
-      create: true 
-      fields: 
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Questions", name: "questions", widget: "list"}
-        - {label: "Body", name: "body", widget: "markdown"}
-    - name: "software-and-tools"
-      label: "Software and tools"
-      label_singular: "Software page"
-      folder: "_pages/software-and-tools"
-      create: true
-      fields: 
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Questions", name: "questions", widget: "list"}
-        - {label: "Body", name: "body", widget: "markdown"}
-    - name: "solutions"
-      label: "Solutions"
-      label_singular: "Solutions page"
-      folder: "_pages/tts-offices/solutions"
-      create: true
-      fields: 
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Questions", name: "questions", widget: "list"}
-        - {label: "Body", name: "body", widget: "markdown"}
-    - name: "training-and-development"
-      label: "Training and development"
-      label_singular: "Training page"
-      folder: "_pages/training-and-development"
-      create: true
-      fields: 
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Questions", name: "questions", widget: "list"}
-        - {label: "Body", name: "body", widget: "markdown"}
-    - name: "travel-and-leave-policies"
-      label: "Travel and leave policies"
-      label_singular: "Travel policy"
-      folder: "_pages/travel-leave/travel-and-leave-policies"
+    - name: "tools"
+      label: "Tools"
+      label_singular: "Tools page"
+      folder: "tools/"
       create: true
       fields: 
         - {label: "Title", name: "title", widget: "string"}


### PR DESCRIPTION
Actually fixes #2644 

Although cleanup is required -- there are some folders that show up in the CMS but are empty -- this PR makes every Handbook page available for edit. I made use of the [nested collections beta feature](https://www.netlifycms.org/docs/beta-features/#nested-collections) -- thanks to @afeld for this find.

I will still have the folder structure make more sense since it should align with the URLs, but that will come in a subsequent PR. 

![handbook_demo_allfiles](https://user-images.githubusercontent.com/35497479/126006464-5c52c4b8-bf3b-4b3f-acc9-c4e56eb8039f.gif)
