### PR TITLE
Make top-level collections nested

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -36,6 +36,7 @@ collections:
     - name: "performance-management"
       label: "Performance management"
       label_singular: "Performance management page"
+      nested: { depth: 4 }
       folder: "performance-management/"
       create: true
       fields: 
@@ -45,6 +46,7 @@ collections:
     - name: "tools"
       label: "Tools"
       label_singular: "Tools page"
+      nested: { depth: 4 }
       folder: "tools/"
       create: true
       fields: 


### PR DESCRIPTION
Fixes bug with top-level collections not allowing nesting. This is a temporary fix -- once the top-level folders get merged into `_pages`, we will only need one folder collection in total.

Addresses [Alyssa's comment](https://gsa-tts.slack.com/archives/C0DCAMLQH/p1626724232001800?thread_ts=1626275059.000500&cid=C0DCAMLQH) in Slack.