### PR TITLE
Fixed typo for "alot" and updated it to "a lot"

### DIFF
--- a/_pages/general-information-and-resources/employee-resources-policies/deaf-hoh.md
+++ b/_pages/general-information-and-resources/employee-resources-policies/deaf-hoh.md
@@ -91,7 +91,7 @@ In order to use video relay services in combination with video meeting tools lik
 - For the Federal Agency Name field, GSA is **4700**
 - Join the meeting early if you can so that you can make sure the captioner is set up properly.
 - Include a good description of the event so they know what words or acryonms to expect. For example, if you're giving a technical talk the captioner might not be familiar with some of the words you expect to use, so including them will help the captions be more accurate.
-- Consider also including the phonetic pronunciation for words or you expect to use alot. (Use your judgement, you don't want to overwhelm them either!)
+- Consider also including the phonetic pronunciation for words or you expect to use a lot. (Use your judgement, you don't want to overwhelm them either!)
 - You are also able to chat through the captioning interface. You can use this to correct or supplement captions if necessary.
 
 ### Other software


### PR DESCRIPTION
Updated the 4th bullet in the "Relay Conference captioning tips" section for changing "alot" to "a lot"

![Screen Shot 2021-07-20 at 4 17 07 PM](https://user-images.githubusercontent.com/21222704/126407017-5bb277db-6028-470f-b0a1-0f831b70e76e.png)
