### PR TITLE
Remove outdated statement about only AWS

### DIFF
--- a/launching-software/infrastructure.md
+++ b/launching-software/infrastructure.md
@@ -170,7 +170,7 @@ service](https://en.wikipedia.org/wiki/Cloud_computing##Infrastructure_as_a_serv
 (IaaS). We have separate AWS accounts for our production systems and
 [sandboxes](#sandbox-accounts) for development and testing. If you're used to
 developing locally, you should feel empowered to do everything you'd like in
-an AWS [sandbox account](#sandbox-accounts).  You're free to
+an AWS [sandbox account](#sandbox-accounts). You're free to
 develop purely locally as long as you'd like, but _if you want to get a system
 online, AWS and cloud.gov are your only options_, of which cloud.gov is
 preferred.

--- a/launching-software/infrastructure.md
+++ b/launching-software/infrastructure.md
@@ -164,7 +164,16 @@ If you are unfamiliar with how to protect these credentials, please consult with
 
 ## Amazon Web Services
 
-At TTS, we use [Amazon Web Services](https://aws.amazon.com/) (AWS) as our [infrastructure as a service](https://en.wikipedia.org/wiki/Cloud_computing##Infrastructure_as_a_service_.28IaaS.29) (IaaS). We have separate AWS accounts for our production systems and [sandboxes](#sandbox-accounts) for development and testing. If you're used to developing locally, you should feel empowered to do everything you'd like in an AWS [sandbox account](#sandbox-accounts). Note that AWS is currently the **only** IaaS provider we are able to use in TTS right now. You're free to develop purely locally as long as you'd like, but _if you want to get a system online, AWS and cloud.gov are your only options_, of which cloud.gov is preferred.
+At TTS, we use [Amazon Web Services](https://aws.amazon.com/) (AWS) as our
+[infrastructure as a
+service](https://en.wikipedia.org/wiki/Cloud_computing##Infrastructure_as_a_service_.28IaaS.29)
+(IaaS). We have separate AWS accounts for our production systems and
+[sandboxes](#sandbox-accounts) for development and testing. If you're used to
+developing locally, you should feel empowered to do everything you'd like in
+an AWS [sandbox account](#sandbox-accounts).  You're free to
+develop purely locally as long as you'd like, but _if you want to get a system
+online, AWS and cloud.gov are your only options_, of which cloud.gov is
+preferred.
 
 In particular, you _cannot_ send traffic from the internet to your local machine - you _must_ use a sandbox account for this purpose.
 


### PR DESCRIPTION
#2689 asks for clarification on some language about AWS being the only cloud service provider (CSP) available. This PR removes the outdated statement that is no longer accurate, without attempting to update other parts of this page for multiple CSPs.