### PR TITLE
Fix YAML error in frontmatter

### DIFF
--- a/_pages/general-information-and-resources/business-and-ops-policies/billing_policy.md
+++ b/_pages/general-information-and-resources/business-and-ops-policies/billing_policy.md
@@ -1,4 +1,4 @@
 ---
 title: Billing policy
-redirect_to: {{site.baseurl}}/tock/#time-tracking-and-billing
+redirect_to: /tock/#time-tracking-and-billing
 ---


### PR DESCRIPTION
Fixes error when building locally.

> Error: YAML Exception reading _pages/general-information-and-resources/business-and-ops-policies/billing_policy.md: (<unknown>): did not find expected key while parsing a block mapping at line 2 column 1
