### PR TITLE
Update Slack integrations page

### DIFF
--- a/_pages/tools/slack/integrations.md
+++ b/_pages/tools/slack/integrations.md
@@ -8,10 +8,9 @@ questions:
 
 We have a few different Slack Apps and bots you'll see in Slack:
 
-- [Angry Tock](https://gsa-tts.slack.com/team/angrytock): our fierce timesheet reminder.
-- [Charlie](https://app.slack.com/client/T025AQGAN/D01NBG7T3PF): our [Slack app](https://api.slack.com/). Knows all kinds of tricks. [Visit the repo](https://github.com/18F/charlie) to see what it can do.
-- [coffeemate](https://gsa-tts.slack.com/team/charlie): send a message with `coffee me` in a public channel or direct message @Charlie (El Hubot Real) with `coffee me` to set up a virtual coffee/tea with a random coworker.
-- [Slackbot](https://get.slack.help/hc/en-us/articles/202026038-Slackbot-your-assistant-notepad-programmable-bot): We automate responses to frequently asked questions with a Slackbot. You can update or customize responses [here](https://gsa-tts.slack.com/customize/slackbot). (You can also [add emoji](https://gsa-tts.slack.com/customize/emoji)). **Do not include private or sensitive information in Slackbot automatic responses.**
+- [Charlie](https://app.slack.com/client/T025AQGAN/D01NBG7T3PF): our [Slack app](https://api.slack.com/). Knows all kinds of tricks! Check out [its repo on GitHub](https://github.com/18F/charlie) to learn more.
+- [coffeemate](https://gsa-tts.slack.com/team/charlie): send a message with `coffee me` in a public channel or direct message [@Charlie](https://app.slack.com/client/T025AQGAN/D01NBG7T3PF) with `coffee me` to set up a virtual coffee/tea with a random coworker.
+- [Slackbot](https://get.slack.help/hc/en-us/articles/202026038-Slackbot-your-assistant-notepad-programmable-bot): We automate responses to frequently asked questions with a Slackbot. You can update or customize responses [here](https://gsa-tts.slack.com/customize/slackbot). (You can also [request new emoji]({{site.baseurl}}/tools/slack/guidelines#custom-emoji). **Do not include private or sensitive information in Slackbot automatic responses.**
 - [TTS Inspector](https://github.com/18F/tts-tech-portfolio/tree/main/inspector): Our auditing bot
 
 Learn more about some of our unique channel customizations and auto-responses in the [Slack @ TTS](https://docs.google.com/document/d/1Hm42cg61S7FPhaLrRIJxl-LXQCcwGvJTKX_wG0Jz4aU/edit#heading=h.4l9k8pqdjzh1) guide.


### PR DESCRIPTION
There are some outdated things in here, so... update them!

- Removes the reference to Angry Tock, which is now part of Charlie and not really applicable (for now) outside of 18F
- Tweaks the language about Charlie. I had intended to do more here, but I realized the current method of linking to Charlie's repo was the better approach
- Updates the DM target for Coffeemate to just Charlie instead of the legacy bot, and includes a link to Charlie's DM channel
- Updates the custom emoji section to point to the request/review process page instead of to the emoji upload page which is unaccessible to most users