### PR TITLE
Require consent for personal images in emoji

### DIFF
--- a/_pages/tools/slack/guidelines.md
+++ b/_pages/tools/slack/guidelines.md
@@ -91,6 +91,10 @@ to add custom emoji. Keep in mind that interactions in Slack are covered by our
 including emoji. Please be thoughtful and mindful about emoji submissions
 and ensure they're in line with our values of diversity and inclusion.
 
+Before requesting emoji featuring TTS members' faces, family, pets, etc., please
+**request consent** from those featured. Emoji reviewers are required to check
+that consent was obtained.
+
 To create custom emoji:
 
 1. Open [\#emoji-showcase](https://gsa-tts.slack.com/archives/C0X2T36AY) in Slack

--- a/_pages/tools/slack/user-management.md
+++ b/_pages/tools/slack/user-management.md
@@ -79,8 +79,19 @@ Behavior](<https://www.gsa.gov/directive/gsa-information-technology-(it)-general
 Non-sexual](<https://www.gsa.gov/directive/general-services-administration-(gsa)-policy-statement-on-harassment,-including-sexual-and-non-sexual->),
 [TTS Code of Conduct]({{site.baseurl}}/code-of-conduct/), and ethics
 rules. TTS staff should review emoji requests with these rules in mind.
+
 Submitters should be thoughtful and mindful about emoji submissions, and try to
 ensure they're in line with our values of diversity and inclusion. Inclusion Bot will automatically flag emoji submissions where the emoji name may contain exclusionary language as a quick aid to reviewers.
+
+**Emoji of TTS members' faces, family, pets, etc**: When reviewing, emoji approvers
+**MUST** ask for clear, affirmative consent from the person whose image is being used.
+Ideally, submitters will check before requesting, but it's the approver's
+responsibility to verify.
+
+**Emoji of TTS members' faces, family, pets, etc**: When reviewing, emoji approvers
+**MUST** ask for clear, affirmative consent from the person whose image is being used.
+Ideally, submitters will check before requesting, but it's the approver's
+responsibility to verify.
 
 If you'd like to help review emoji requests, please reach out to
 [\#tts-tech-portfolio](https://gsa-tts.slack.com/archives/CNW3GL70S).


### PR DESCRIPTION
Adds instructions for emoji submitters and reviewers to confirm consent if emoji images include TTS members, pets, family, etc.

Duplicate of #2763, this is a clean PR after a rebase gone wrong.