### PR TITLE
Clarify when to email hspd12.security for GCIMS info for iPhone 2FA

### DIFF
--- a/_pages/getting-started/equipment.md
+++ b/_pages/getting-started/equipment.md
@@ -81,9 +81,9 @@ TTS employees are issued an Apple iPhone. The TTS Talent Team will already have 
 - **Activate [Find My iPhone](https://support.apple.com/kb/PH2697?locale=en_US).** If you're on an Android phone, activate [Android Device Manager](https://www.google.com/android/devicemanager).
 
 - After GSA IT provisions your phone, set up two-factor verification:
-  - To get started, email [hspd12.security@gsa.gov](mailto:hspd12.security@gsa.gov) and ask them to add your work cell phone number (which you may or may not have) and your personal cell phone number to your GCIMS profile.
-  - Once you have access to [HR Links]({{site.baseurl}}/getting-started/classes/gsa-internal-tools/#hr-links), you can update your contact information there. You'll find it under **Navigator > Self Service > Personal Information > Phone Number Change (USF)**; make sure to set the phone type as "Business Mobile" so it correctly populates GCIMS and works for 2FA.
-  - You can learn more about using your phone for two-factor authentication in our [Slack]({{site.baseurl}}/tools/slack), [GitHub]({{site.baseurl}}/github), and [Gmail]({{site.baseurl}}/gmail) guides. For two-factor authentication with this applications, you can use SMS, [Authy](https://www.authy.com/), or [Google Authenticator](https://support.google.com/accounts/answer/1066447?hl=en).
+  - If you don't have access to [HR Links]({{site.baseurl}}/getting-started/classes/gsa-internal-tools/#hr-links), email [hspd12.security@gsa.gov](mailto:hspd12.security@gsa.gov) and ask them to add your work cell phone number (which you may or may not have) and your personal cell phone number to your GSA Credential and Identity Management System (GCIMS) profile.
+  - Once you have access to [HR Links]({{site.baseurl}}/getting-started/classes/gsa-internal-tools/#hr-links), you can update your contact information there. You'll find it under **Navigator > Employee Self Service > View/Update My Personal Info > Phone Number Change (USF)**; make sure to set the phone type as "Business Mobile" so it correctly populates in the GCIMS and works for 2FA.
+  - You can learn more about using your phone for two-factor authentication in our [Slack]({{site.baseurl}}/tools/slack), [GitHub]({{site.baseurl}}/github), and [Gmail]({{site.baseurl}}/gmail) guides. For two-factor authentication with these applications, you can use SMS, [Authy](https://www.authy.com/), or [Google Authenticator](https://support.google.com/accounts/answer/1066447?hl=en).
 
 ### Tips
 


### PR DESCRIPTION
The previous wording sounds like you always need to email security to update your 2FA email when you really only need to do it if you're not in HRLinks yet. I wanted to clarify the wording around this to make it a bit easier for new hires to understand it. (As in you don't _always_ have to email security.)