### PR TITLE
remove <hr> tag and reword paragraph about Eng Guide

### DIFF
--- a/_pages/18f/chapters/engineering.md
+++ b/_pages/18f/chapters/engineering.md
@@ -10,11 +10,9 @@ redirect_from:
 
 Collectively, we’re experienced in a wide variety of technologies including Python, Ruby, server and client-side JavaScript, Go, C, relational and schema-less databases, ETL pipelines, version control, testing frameworks, machine learning, and more.
 
-### Documentation
+## Documentation
 
-Our [Engineering Best Practices guide](https://github.com/18F/development-guide#18f-development-guide) has details about Git, code reviews, and more. You might also enjoy the [open source](https://18f.gsa.gov/tags/open-source/) archives on the blog.
-
----
+Our [Engineering Best Practices guide](https://engineering.18f.gov) ([git repo](https://github.com/18F/development-guide#18f-development-guide)) has details about our approach, tools, languages, and more. You might also enjoy the [open source](https://18f.gsa.gov/tags/open-source/) archives on the blog.
 
 # Joining the Engineering team
 


### PR DESCRIPTION
Proposed changes to the 18F Engineering Chapter page
* There is an `<hr>` tag that bleeds into the inline-navigation box on the right. I removed the `<hr>` to fix that which is also consistent with other chapter pages style.
* There is an `<h3>` that needs to be an `<h2>` to comply with a11y
* The paragraph pointing to the Eng Guide points to the git repo not the published website. I changed the wording to include both, and the rest of the sentence to read less awkwardly.