### PR TITLE
insert the inline nav box just above the first p tag

### DIFF
--- a/javascripts/application.js
+++ b/javascripts/application.js
@@ -88,14 +88,10 @@ $(document).ready(function() {
           "</ul>" +
         "</nav>";
 
+      // support inline-nav css with a class in the <body> tag
       $('body').addClass('with-inline-navigation');
-      var $table = $(".usa-layout-docs-main_content h1:first-child+.table-wrapper");
-      if ($table.length > 0){
-        $table.after(inlineNavigation);
-      } else {
-        $("main > p").first().after(inlineNavigation);
-      }
-
+      // add inlineNavigation after the first <h1></h1>
+      $("main > p").first().before(inlineNavigation);
     }
 
   }

--- a/javascripts/application.js
+++ b/javascripts/application.js
@@ -91,7 +91,7 @@ $(document).ready(function() {
       // support inline-nav css with a class in the <body> tag
       $('body').addClass('with-inline-navigation');
       // add inlineNavigation after the first <h1></h1>
-      $("main > p").first().before(inlineNavigation);
+      $("main h2").first().before(inlineNavigation);
     }
 
   }


### PR DESCRIPTION
Very open to pushback on this. :) Saw something not working quite right and this is my proposal to fix.

In doing the work for PR #2908 , I noticed that the inline navigation box on the right side does not behave well responsively. On a narrow screen, e.g. smartphone, the nav box shows up incongruously below the first blurb of text, often breaking up connected pieces of information. Also, as currently placed the nav box sits further down the page than I'd expect, given its function. 

I made a change to `application.js` to insert the inline-navigation component above the first `<p>` tag in the body of the page. I also removed special code put in place for pages with tables at the top (e.g., https://engineering.18f.gov/general-information-and-resources/chicago/), as this change renders the special code unnecessary.

I manually inspected as many pages as I could and in all cases the new placement appears as intended and has better  responsive behavior.