### PR TITLE
Update cloud.gov guidance on Tock page

### DIFF
--- a/_pages/tools/tock.md
+++ b/_pages/tools/tock.md
@@ -20,7 +20,7 @@ redirect_from:
 
 **Cloud.gov**
 
-- Tock your usual 40 hours to the cloud.gov P&L (#955) generally unless you’re doing billable work for something in 18F.  More specific Tock instructions for Cloud team members can be found [here](https://docs.google.com/document/d/16wGnM2vD9y5nrD3Jhufjc-G1r1cs3lkX2Ny-opYk9do/edit#heading=h.2uuhlgoi43ro).
+- cloud.gov is not currently using Tock to record regular work. An exception is billable work performed for 18F.  More specific Tock instructions for Cloud team members can be found [here](https://docs.google.com/document/d/16wGnM2vD9y5nrD3Jhufjc-G1r1cs3lkX2Ny-opYk9do/edit#heading=h.2uuhlgoi43ro).
 
 **Centers of Excellence**
 


### PR DESCRIPTION
I am advised (tag, @amirbey) that cloud.gov folks should _not_ Tock their normal forty hours to cloud.gov P&L #955 or anything else at present, so I have removed that instruction. This change does, however, leave the link to a Google doc providing additional guidance, but I can't attest to the currency of that document's contents.