### PR TITLE
Add Consulting Guild across Handbook

### DIFF
--- a/_pages/18f/projects-partners/consulting-engineering-guide.md
+++ b/_pages/18f/projects-partners/consulting-engineering-guide.md
@@ -70,10 +70,10 @@ On a consulting engagement, you may often find yourself operating on the edges o
 
 Everyone at 18F who works with partners can consider themselves “in consulting.” This means there’s a lot of value to be found in project or chapter discussions across the whole organization. Don’t hesitate to join Slack channels or attend meetings that will help you broaden your experience with 18F projects. The below resources will offer a lot of context for the partner-facing and organizational challenges of consulting projects:
 
+- The [Consulting Guild (#g-consulting)](https://gsa-tts.slack.com/archives/C02GTJ5DT9A) provides opportunities for developing consulting skills like education workshops and pairing sessions, as well as support for partner engagements.
 - [#path-analysis](https://app.slack.com/client/T025AQGAN/C3J7P5MMK) (archived, but still has valuable history)
 - [Project Artifacts repo](https://github.com/18F/path-analysis)
 - [#c-project-resources](https://app.slack.com/client/T025AQGAN/CHZLJBWCV)
-- [#c-consulting](https://app.slack.com/client/T025AQGAN/CDVJ9U4K1) (and its regular meeting)
 
 ### Technical support
 

--- a/_pages/18f/projects-partners/how-we-relate-to-partners.md
+++ b/_pages/18f/projects-partners/how-we-relate-to-partners.md
@@ -35,4 +35,4 @@ We want to help them work in new ways and succeed beyond our time together. In c
 - [Collaborating: we don't do this work alone](https://docs.google.com/presentation/d/1Lm4YbE4yfvn5qfMy7oGNCd1w4pUhMl_I-_EVSQWNFPQ/edit#): overview of 18F's approach to collaborating with partners
 - [Introduction to Consulting Foundations](https://docs.google.com/document/d/1it5-GDhOVk3g6mRfW_6_WaiOJzAfylA3umQebmlBDqs/edit#): in-depth exploration of the animating values of good consultants and a framework for thinking about consulting work
 - [Consulting engineering guide]({{site.baseurl}}/consulting-engineering-guide/): overview of consulting from an engineer's viewpoint
-- [#c-consulting](https://slack.com/app_redirect?channel=c-consulting): an 18F community of practice focused on improving our skills as consultants
+- The [Consulting Guild (#g-consulting)](https://gsa-tts.slack.com/archives/C02GTJ5DT9A): a TTS-wide Guild dedicated to supporting and developing the practice of consulting across TTS

--- a/_pages/18f/projects-partners/leading-projects.md
+++ b/_pages/18f/projects-partners/leading-projects.md
@@ -144,9 +144,10 @@ Your first lines of support are the folks you have 1:1s with weekly: the project
 - If you need documentation, look to this handbook and our [guides](https://18f.gsa.gov/guides/).
 - If you need support in a specific skill set, help with deliverables, or would like to have someone facilitate a session, get help by using [#microrequests](https://gsa-tts.slack.com/archives/CNFHBCXDW).
 - If your project is part of a portfolio, the portfolio director and your colleagues in the portfolio can be a great resource.
-- If you need advice or coaching, look to the chapters ([#product](https://gsa-tts.slack.com/archives/C02ABDXUN), [#design](https://gsa-tts.slack.com/archives/C02AUUQ8R), [#acquisition](https://gsa-tts.slack.com/archives/C054NH1FW), and [#dev](https://gsa-tts.slack.com/archives/C02CD5VUQ) as well as our [guilds and working groups]({{site.baseurl}}/working-groups-and-guilds-101/). Each of them have a corresponding Slack channel you can jump into any time. There's also:
+- If you need advice or coaching, look to the chapters ([#product](https://gsa-tts.slack.com/archives/C02ABDXUN), [#design](https://gsa-tts.slack.com/archives/C02AUUQ8R), [#acquisition](https://gsa-tts.slack.com/archives/C054NH1FW), and [#dev](https://gsa-tts.slack.com/archives/C02CD5VUQ) as well as our [guilds and working groups]({{site.baseurl}}/working-groups-and-guilds-101/). Each of them have a corresponding Slack channel you can jump into any time.
+- The [Consulting Guild (#g-consulting)](https://gsa-tts.slack.com/archives/C02GTJ5DT9A) may be able to pair you with another TTS consultant to provide support, including but not limited to observing meetings with the partner and providing feedback and advice. Request help in the [#g-consulting](https://gsa-tts.slack.com/archives/C02GTJ5DT9A) channel.
+- There's also:
   - [#workshop-facilitation](https://gsa-tts.slack.com/archives/C0RBCPRM5)
-  - [#c-consulting](https://gsa-tts.slack.com/archives/CDVJ9U4K1)
   - [#c-project-resources](https://gsa-tts.slack.com/archives/CHZLJBWCV)
   - [#c-18f-project-leadership](https://gsa-tts.slack.com/archives/C01JFUE1Y58)
 

--- a/_pages/18f/projects-partners/projects-in-distress.md
+++ b/_pages/18f/projects-partners/projects-in-distress.md
@@ -19,7 +19,7 @@ The **project health tracker** provides insight into some of the common areas wh
 1. Your **Account Manager** (AM) has seen a broad range of projects at 18F and can provide useful calibration and insight into 18F standards. Your AM also understands the context of your project and your team, and knows the players at the partner agency.
 2. Your **Supervisor** or **Facilitator/Lead** knows a great deal about your discipline or domain, and they know you and your professional goals. They can be a great person to bounce ideas off of and offer a second opinion on an approach to your project work.
 3. **Guilds, crit groups, and chapter/portfolio meetings** - these are all great avenues for soliciting peer feedback and troubleshooting challenges on your project.
-4. The **[#c-consulting channel](https://gsa-tts.slack.com/archives/CDVJ9U4K1) and office hours** - get peer feedback on topics related to consulting.
+4. The **[Consulting Guild (#g-consulting)](https://gsa-tts.slack.com/archives/C02GTJ5DT9A)** - get first-line project support from experienced TTS consultants.
 5. The **[#c-18f-project-leadership channel](https://gsa-tts.slack.com/archives/C01JFUE1Y58)** is another great source for peer feedback and troubleshooting for project leads and those interested in becoming project leads.
 
 18F doesn’t really have “typical” projects; each of our consulting engagements is tailored to the partner, their needs, and their constraints. We encourage team members to bring their unique skills, experiences, and perspectives to each project.

--- a/_pages/training-and-development/working-groups-and-guilds-101.md
+++ b/_pages/training-and-development/working-groups-and-guilds-101.md
@@ -29,13 +29,13 @@ Most working groups will create a Slack channel to coordinate efforts. These cha
   <table class="table-existing-grouplets">
     <tbody>
       <tr>
-        <th class="col-grouplet" id="consulting">TTS Hiring</th>
+        <th class="col-grouplet" id="tts-hiring">TTS Hiring</th>
         <td class="col-description">Improving hiring practices and materials for all of TTS.<br />
           <a href="https://gsa-tts.slack.com/archives/CEHSLF4LB">#wg-tts-hiring</a>
         </td>
       </tr>
       <tr>
-        <th class="col-grouplet" id="consulting">Project Impact</th>
+        <th class="col-grouplet" id="project-impact">Project Impact</th>
         <td class="col-description">Design and test a project/initiative impact assessment that teams would be able to complete at the end of an engagement or between large phases on a project.<br />
           <a href="https://gsa-tts.slack.com/archives/CQLRCVA4Q">#wg-project-health</a>
         </td>
@@ -96,6 +96,15 @@ Remember, you're asking for a substantial commitment of organizational resources
         </td>
       </tr>
       <tr>
+        <th class="col-grouplet" id="consulting">Consulting</th>
+        <td class="col-description">
+          Develop and support the practice of consulting at TTS<br /> <a href="https://gsa-tts.slack.com/archives/C02GTJ5DT9A">#g-consulting</a>
+        </td>
+        <td>
+          Matt Cloyd - 18F
+        </td>
+      </tr>
+      <tr>
         <th class="col-grouplet" id="content">Content</th>
         <td class="col-description">
           We promote concise, elegant, user-centered writing. We plan for the creation, publication, and governance of useful, usable content. <br />
@@ -104,26 +113,6 @@ Remember, you're asking for a substantial commitment of organizational resources
         <td>
           Jeff Durland - 18F<br>
           Ryan Johnson - 18F
-        </td>
-      </tr>
-      <tr>
-        <th id="design-research">Research</th>
-        <td class="col-description">
-          We envision a world where government agencies use research to shape their decision making processes. <br />
-          <a href="https://github.com/18F/g-research/">Homepage</a> &bull; <a href="https://gsa-tts.slack.com/messages/g-research">#g-research</a>
-        </td>
-        <td>
-          Ben Peterson - 18F<br>
-          Dave Luetger - 18F
-        </td>
-      </tr>
-      <tr>
-        <th class="col-grouplet" id="consulting">Consulting</th>
-        <td class="col-description">
-          Develop and support the practice of consulting at TTS<br /> <a href="https://gsa-tts.slack.com/archives/CDVJ9U4K1">#c-consulting</a>
-        </td>
-        <td>
-          Matt Cloyd - 18F
         </td>
       </tr>
       <tr>
@@ -146,6 +135,17 @@ Remember, you're asking for a substantial commitment of organizational resources
         <td>
           Davida Marion - 18F<br>
           Eleni Chappen - 18F
+        </td>
+      </tr>
+      <tr>
+        <th id="design-research">Research</th>
+        <td class="col-description">
+          We envision a world where government agencies use research to shape their decision making processes. <br />
+          <a href="https://github.com/18F/g-research/">Homepage</a> &bull; <a href="https://gsa-tts.slack.com/messages/g-research">#g-research</a>
+        </td>
+        <td>
+          Ben Peterson - 18F<br>
+          Dave Luetger - 18F
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
- Replaces the mentions of the 18F Consulting Community of Practice with the new TTS-wide Consulting Guild. Adds brief mentions of service offerings.
- Also alphabetizes the Guild list