### PR TITLE
Fix an issue with preview builds and 404s

### DIFF
--- a/_plugins/siteurl.rb
+++ b/_plugins/siteurl.rb
@@ -1,0 +1,17 @@
+Jekyll::Hooks.register :site, :after_init do |site|
+  # Federalist will set the BRANCH environment variable when it's building a
+  # preview deployment. If the branch is nil (unset) or "main", do nothing. But
+  # for preview builds, set site.url to nil. If we don't do that, then site.url
+  # will be used by the jekyll-redirect-from plugin when it rewrites redirects,
+  # which will link AWAY from the preview site and to the production site,
+  # making it functionally impossible to preview the redirected page. Further,
+  # because the production and preview sites have different site.baseurl values,
+  # the redirect will go to a location that does not exist in production, so
+  # it'll just cause a 404.
+  #
+  # We can avoid all that by just emptying the site.url value on preview builds.
+  branch = ENV['BRANCH']
+  if !(branch.nil? || branch == 'main')
+    site.config['url'] = nil
+  end
+end


### PR DESCRIPTION
The Handbook uses the `jekyll-redirect-from` plugin to handle page redirects. This plugin uses the `site.url` and `site.baseurl` values, if set, to compute the redirect path. If `site.url` is not set, it is omitted. Easy enough.

The Handbook configures `site.url` in the `_config.yml` file, so it is always set. For preview builds, the `site.url` is not the same as the preview URL, so redirects end up pointing to the production Handbook site, but the redirect URLs still use the `site.baseurl` set by Federalist to point to the preview site path, so the corresponding path on the production site doesn't exist, resulting in a 404 error.

The fix here checks if the build is a Federalist preview build by adding a post-config build hook that looks at the `BRANCH` environment variable. If it is set and is anything other than `main`, then the hook removes the `site.url` value.

To test:

- open the preview site from the link below in the list of checks
- find the Zoom link
   - hover over it and see that it goes to `.../zoom/`
   - click the link
   - see that it loads the Zoom page, not a 404
   - verify that the URL begins with `https://federalist-` and ends with `/tools/zoom/`