### PR TITLE
changes link to inclusive pillars/fixes formatting 

### DIFF
--- a/_pages/training-and-development/conferences-events-training.md
+++ b/_pages/training-and-development/conferences-events-training.md
@@ -24,7 +24,7 @@ TTS encourages all staff to attend conferences, speak at events, and focus on pr
 
 Any media requests (like news or podcast interviews) are a separate process — please forward the email or reach out to [press@gsa.gov](mailto:press@gsa.gov) and CC [your team's Outreach liaison]({{site.baseurl}}/office-of-operations/outreach/#team).
 
-At TTS, the work of diversity, equity, inclusion, and accessibility (DEIA) is a collective effort: every employee makes a difference. DEIA should be a part of everything we do. When creating, hosting, or participating in an event, we ask that you consider the [TTS Inclusive Event Pillars](https://docs.google.com/document/d/1-w6I46qJCsZsLJOavNPPSxDCY8klKSQz4DidOwRzpZ4/edit).
+At TTS, the work of diversity, equity, inclusion, and accessibility (DEIA) is a collective effort: every employee makes a difference. DEIA should be a part of everything we do. When creating, hosting, or participating in an event, we ask that you consider the [TTS Inclusive Event Pillars]({{site.baseurl}}/training-and-development/conferences-events-training/tts-inclusive-event-pillars/).
 
 These inclusive event pillars are designed to help TTS:
 

--- a/_pages/training-and-development/conferences-events-training/tts-inclusive-event-pillars.md
+++ b/_pages/training-and-development/conferences-events-training/tts-inclusive-event-pillars.md
@@ -27,7 +27,7 @@ TTS engages in events to recruit and build awareness about TTS products and serv
 2. **Speakers from underrepresented groups are invited to speak on their subject matter expertise.** Frequently, folks from underrepresented groups are invited to speak about their identities, rather than their area of technical expertise. Speakers may opt to share their lived experiences - but it should not be an expectation.
 3. **If there is an identity-based topic, the featured speakers have that identity.** A good mindset is the disability rights slogan “nothing about us, without us.”
 4. **There is a code of conduct with an incident response plan.** Event organizers should clearly state what is expected of attendees and speakers, and how they will respond when problems arise. Link to the [TTS Code of Conduct]({{site.baseurl}}/about-us/code-of-conduct/).
-5. **The event space is accessible - both virtual and physical spaces. **Accessible events offer: closed captioning, American Sign Language interpretation, reserved front row seating for people who need to sit closer to the stage, and wheelchair accessible spaces. Social events should have places to sit down throughout the space.
+5. **The event space is accessible - both virtual and physical spaces.** Accessible events offer: closed captioning, American Sign Language interpretation, reserved front row seating for people who need to sit closer to the stage, and wheelchair accessible spaces. Social events should have places to sit down throughout the space.
 6. **Participants have a place to share their pronouns.** For in-person events, include a space on name tags. For virtual, share instructions on how a person can modify their display name to include pronouns.
 
    ### If you are invited to speak at an event where attendees pay to attend:
@@ -37,9 +37,9 @@ TTS engages in events to recruit and build awareness about TTS products and serv
 9. **What if I’ve been invited to speak, and the event is not inclusive?**
    Depending on both the event circumstances and your identities, you could:
 
-- Suggest the name of someone else who might be able to speak on the topic and/or join you in speaking.
-- Recommend that the organizers modify the event - for example, if they cannot find an accessible venue, could the event be moved to a virtual setting?
-- Decline the invitation, stating the reasons why.
+   - Suggest the name of someone else who might be able to speak on the topic and/or join you in speaking.
+   - Recommend that the organizers modify the event - for example, if they cannot find an accessible venue, could the event be moved to a virtual setting?
+   - Decline the invitation, stating the reasons why.
 
 Ultimately, the choice for accepting or declining an invitation rests with the TTS employee who has been invited to speak. We hope our external engagements reflect what we strive for within our organization.
 


### PR DESCRIPTION
This PR updates the link to the inclusive events pillars on [this page](https://handbook.tts.gsa.gov/training-and-development/conferences-events-training/), and fixes a couple of formatting issues on the pillars page.  