### PR TITLE
Update working-groups-and-guilds-101.md

### DIFF
--- a/_pages/training-and-development/working-groups-and-guilds-101.md
+++ b/_pages/training-and-development/working-groups-and-guilds-101.md
@@ -264,12 +264,6 @@ Digital.gov [hosts the Communities of Practice](https://digital.gov/communities/
 
 There are a number of groups that are good for collaborating across government. If any of these topics interest you, consider joining---even if you prefer to lurk. (Consider [filtering messages like these](https://support.google.com/mail/answer/6579?hl=en) so they appear in their own Gmail label.)
 
-#### Digital Service
-
-**About:** This listserv is used for cross-team announcements and conversation between USDS HQ, agency digital service teams, 18F etc.
-
-**To join:** Email listserv@listserv.gsa.gov with no subject and `subscribe digitalservice` in the body.
-
 #### GSA Press Clips
 
 **About:** This is an internal GSA google group we set up to bring together the various press clips that are sent out by the Communications office.


### PR DESCRIPTION
This PR removes content about a digital service listserv which is no longer active.

I know that this listserv is inactive because when I followed the steps to subscribe to this listserv, I got this response in my email: 

> subscribe digitalservice
There is no DIGITALSERVICE list on this server. Try sending a "LIST" command
to    get   a    description    of   all    the    lists   available    from
LISTSERV@LISTSERV.GSA.GOV.

And then when I sent a `LIST` command, I got this response, which indeed implies that there is no `digitalservice` listserv:

> LIST
FAHP-UTILITIES  FAHP Utilities
ITBCOP          IT Buyers Community of Practice