### PR TITLE
Update Slack Display Name Guidance

### DIFF
--- a/_pages/tools/slack/getting-started.md
+++ b/_pages/tools/slack/getting-started.md
@@ -10,10 +10,10 @@ _[Back to Slack page](../)_
 
 **[Fill in your profile](https://gsa-tts.slack.com/account/profile).** A complete profile gives everyone a better chance of knowing who you are.
 
-- **Display name**: You can use your name or a short handle like `@example` or `@first.last`
+- **Display name**: You can use your name or a short handle like  `@example (they)` or `@first.last (they/them)`
+    - Your [pronouns](https://pronoun.is/) are optional but strongly encouraged. Having these visible helps TTS be gender inclusive. They're not required because we want to ensure people who might change their pronouns don’t feel pressure to have an answer at all times.
 - **What I do**: Include your team here (required)
 - **Location**: Where you are (required)
-- **Pronouns**: Your [pronouns](https://pronoun.is/) are optional but strongly encouraged. Having these visible helps TTS be gender inclusive. They're not required because we want to ensure people who might change their pronouns don’t feel pressure to have an answer at all times.
 - For people with GSA emails, the `Full name` and `Phone number` are overwritten with [your information from GCIMS]({{site.baseurl}}/changing-your-name/) every time you sign in, so don't bother changing those.
 
 ## Usage

--- a/_pages/tools/slack/getting-started.md
+++ b/_pages/tools/slack/getting-started.md
@@ -10,10 +10,10 @@ _[Back to Slack page](../)_
 
 **[Fill in your profile](https://gsa-tts.slack.com/account/profile).** A complete profile gives everyone a better chance of knowing who you are.
 
-- Display name: You can use your name or a short handle like `@example` or `@first.last`
-- What I do: Include your team here (required)
-- Location: Where you are (required)
-- Pronouns: Your [pronouns](https://pronoun.is/) are optional but strongly encouraged. Having these visible helps TTS be gender inclusive. They're not required because we want to ensure people who might change their pronouns don’t feel pressure to have an answer at all times.
+- **Display name**: You can use your name or a short handle like `@example` or `@first.last`
+- **What I do**: Include your team here (required)
+- **Location**: Where you are (required)
+- **Pronouns**: Your [pronouns](https://pronoun.is/) are optional but strongly encouraged. Having these visible helps TTS be gender inclusive. They're not required because we want to ensure people who might change their pronouns don’t feel pressure to have an answer at all times.
 - For people with GSA emails, the `Full name` and `Phone number` are overwritten with [your information from GCIMS]({{site.baseurl}}/changing-your-name/) every time you sign in, so don't bother changing those.
 
 ## Usage

--- a/_pages/tools/slack/getting-started.md
+++ b/_pages/tools/slack/getting-started.md
@@ -10,8 +10,8 @@ _[Back to Slack page](../)_
 
 **[Fill in your profile](https://gsa-tts.slack.com/account/profile).** A complete profile gives everyone a better chance of knowing who you are.
 
-- **Display name**: You can use your name or a short handle like  `@example (they)` or `@first.last (they/them)`
-    - Your [pronouns](https://pronoun.is/) are optional but strongly encouraged. Having these visible helps TTS be gender inclusive. They're not required because we want to ensure people who might change their pronouns don’t feel pressure to have an answer at all times.
+- **Display name**: You can use your name or a short handle like `@example (they)` or `@first.last (they/them)`
+  - Your [pronouns](https://pronoun.is/) are optional but strongly encouraged. Having these visible helps TTS be gender inclusive. They're not required because we want to ensure people who might change their pronouns don’t feel pressure to have an answer at all times.
 - **What I do**: Include your team here (required)
 - **Location**: Where you are (required)
 - For people with GSA emails, the `Full name` and `Phone number` are overwritten with [your information from GCIMS]({{site.baseurl}}/changing-your-name/) every time you sign in, so don't bother changing those.

--- a/_pages/tools/slack/getting-started.md
+++ b/_pages/tools/slack/getting-started.md
@@ -8,10 +8,12 @@ _[Back to Slack page](../)_
 
 ## Profile
 
-**[Fill in your profile](https://gsa-tts.slack.com/account/profile).** A complete profile gives everyone a better chance of knowing who you are. **For the `Display name`, use the format `<name> (<team>, <location>, <pronouns>)`.**
+**[Fill in your profile](https://gsa-tts.slack.com/account/profile).** A complete profile gives everyone a better chance of knowing who you are.
 
-- Example: `Aidan Feldman (Tech Portfolio, NYC, he/him)`
-- Name, team, and location are required. Your [pronouns](https://pronoun.is/) are optional but strongly encouraged. Having these visible helps TTS be gender inclusive. They're not required because we want to ensure people who might change their pronouns don’t feel pressure to have an answer at all times.
+- Display name: You can use your name or a short handle like `@example` or `@first.last`
+- What I do: Include your team here (required)
+- Location: Where you are (required)
+- Pronouns: Your [pronouns](https://pronoun.is/) are optional but strongly encouraged. Having these visible helps TTS be gender inclusive. They're not required because we want to ensure people who might change their pronouns don’t feel pressure to have an answer at all times.
 - For people with GSA emails, the `Full name` and `Phone number` are overwritten with [your information from GCIMS]({{site.baseurl}}/changing-your-name/) every time you sign in, so don't bother changing those.
 
 ## Usage


### PR DESCRIPTION
I'm unsure who needs to be looped in to approve changes like this, please let me know if there are better channels than a Pull Request to discuss!

I opened a [thread in `#general-talk`](https://gsa-tts.slack.com/archives/C04KL9ZN2/p1649785177313879) and got some positive reactions, so tentatively that seemed like enough to open a PR

Briefly:
- Slack profiles support separate fields for the information that TTS had been putting in the Display Name field (pronoun, location, job)
- Updating the policy to enable shorter display names makes it easier to reduce visual clutter in messages, especially ones that tag multiple people
