### PR TITLE
remove broken Insite link

### DIFF
--- a/_pages/travel-and-leave/leave.md
+++ b/_pages/travel-and-leave/leave.md
@@ -295,6 +295,7 @@ In cases of serious disability or ailment, and when the exigencies of the situat
 ### Additional advanced leave resources
 
 - [Fact Sheet: Advanced Sick Leave](https://www.opm.gov/policy-data-oversight/pay-leave/leave-administration/fact-sheets/advanced-sick-leave/)
+- [Insite: Advanced Leave](https://insite.gsa.gov/employee-resources/hr-eeo-pay-and-leave/pay-and-leave/leave/types-of-paid-leave?term=#Advanced)
 
 ## Court leave (including jury duty)
 

--- a/_pages/travel-and-leave/leave.md
+++ b/_pages/travel-and-leave/leave.md
@@ -295,7 +295,6 @@ In cases of serious disability or ailment, and when the exigencies of the situat
 ### Additional advanced leave resources
 
 - [Fact Sheet: Advanced Sick Leave](https://www.opm.gov/policy-data-oversight/pay-leave/leave-administration/fact-sheets/advanced-sick-leave/)
-- [Insite: Advanced Sick Leave](https://insite.gsa.gov/portal/category/510090)
 
 ## Court leave (including jury duty)
 


### PR DESCRIPTION
The[ handbook page on leave](https://handbook.tts.gsa.gov/travel-and-leave/leave/#advanced-sick-leave) mentions a Insite page on advanced sick leave, but[ this link returns a 404](https://insite.gsa.gov/portal/category/510090). 

I suggest removing it, as I couldn't find a replacement link on Insite. 