### PR TITLE
Update navigation.yml to add U.S. Digital Corps website

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -509,6 +509,11 @@ primary:
           - text: PIF Website
             url: https://presidentialinnovationfellows.gov/
             internal: false
+      - text: U.S. Digital Corps (USDC)
+        children:
+          - text: USDC Website
+            url: https://digitalcorps.gsa.gov/
+            internal: false
   - text: Tools
     href: /#tools
     blurb: |


### PR DESCRIPTION
Adding USDC as an organization in TTS, ahead of Fellows onboarding