### PR TITLE
Update Dave's title in a quote attribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .sass-cache/
 _site/
 node_modules/
+vendor/

--- a/_pages/about-us/deia.md
+++ b/_pages/about-us/deia.md
@@ -12,7 +12,7 @@ questions:
 > Diversity, equity, inclusion, and accessibility are the fabric of a healthy
 > democracy and innovation.
 >
-> \- **Dave Zvenyach, TTS Director**
+> \- **Dave Zvenyach, former TTS Director**
 
 At TTS, [our mission]({{site.baseurl}}/tts-history/) is to design and deliver a digital government with and for the American public. To ensure that the products we build and services we offer truly serve everyone, we center our work on **diversity, equity, inclusion,** and **accessibility** (also known as **DEIA**). In particular, we align our efforts with recent Executive Orders on [DEIA in the federal workforce](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/06/25/executive-order-on-diversity-equity-inclusion-and-accessibility-in-the-federal-workforce/) and [advancing racial equity through government services](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/01/20/executive-order-advancing-racial-equity-and-support-for-underserved-communities-through-the-federal-government/).
 


### PR DESCRIPTION
- also adds `vendor/` to `.gitignore`, so local development can rely on locally-stored dependencies instead of them having to only exist in a container