### PR TITLE
Update Slack links on trello.md

### DIFF
--- a/_layouts/handbook_page.html
+++ b/_layouts/handbook_page.html
@@ -19,7 +19,7 @@ layout: page
     {% elsif contact.text %}
     <a href="{{contact.url}}">{{contact.text}}</a>
     {% else %}
-    <a href="https://gsa-tts.slack.com/messages/{{contact}}/">#{{contact}}</a>
+    <a href="https://gsa-tts.slack.com/channels/{{contact}}/">#{{contact}}</a>
     {% endif %}
   </li>
   {% endfor %}

--- a/_pages/tools/trello.md
+++ b/_pages/tools/trello.md
@@ -1,7 +1,7 @@
 ---
 title: Trello
 questions:
-  - admins-trello
+  - tts-trello
 redirect_from:
   - /trello/
 ---
@@ -25,7 +25,7 @@ People use Trello to track ideas from conception through execution. It's common 
 
 We are limited in the number of Workspace Members we can add. You will be added
 as a Workspace Guest. Most changes to a board will require an Admin. You can
-make requests in [#admins-trello][slack-trello].
+make requests in [#tts-trello](https://gsa-tts.slack.com/archives/C055J0BL0).
 
 To be able to see a board, either the board needs to be
 [public](https://help.trello.com/article/789-changing-the-visibility-of-a-board-to-public-private-or-team)
@@ -58,7 +58,7 @@ Power-Ups that _cannot_ be used:
 
 - [Google Drive](https://trello.com/power-ups/55a5d916446f517774210006)
 
-If you aren't sure or want others reviewed, ask in [#admins-trello][slack-trello].
+If you aren't sure or want others reviewed, ask in [#tts-trello](https://gsa-tts.slack.com/archives/C055J0BL0).
 
 ### Cloudlock warning
 
@@ -69,4 +69,4 @@ If you get a `Manually Banned Apps Policy` email from [Cloudlock](https://insite
 - [Add general users to boards as guests](https://help.trello.com/article/1236-board-guests); don't add them as members of the Workspace(s).
 - All Workspaces used for work at TTS should exist under the `GSA IT - IDT` Enterprise instance.
 
-[slack-trello]: https://gsa-tts.slack.com/messages/admins-trello/
+[#tts-trello](https://gsa-tts.slack.com/archives/C055J0BL0)

--- a/_pages/tools/trello.md
+++ b/_pages/tools/trello.md
@@ -69,4 +69,4 @@ If you get a `Manually Banned Apps Policy` email from [Cloudlock](https://insite
 - [Add general users to boards as guests](https://help.trello.com/article/1236-board-guests); don't add them as members of the Workspace(s).
 - All Workspaces used for work at TTS should exist under the `GSA IT - IDT` Enterprise instance.
 
-[#tts-trello](https://gsa-tts.slack.com/archives/C055J0BL0)
+[#gsa-trello-admins](https://gsa-tts.slack.com/archives/C0318A6RWRJ)


### PR DESCRIPTION
The slack links were to #admins-trello & but link doesn't work/channel doesn't list in browse channels. Switching links to #tts-trello which seems to serve the purpose