### PR TITLE
Update TTS COR resources links to working URLs

### DIFF
--- a/_pages/18f/how-18f-works/procurements-over-10000.md
+++ b/_pages/18f/how-18f-works/procurements-over-10000.md
@@ -65,7 +65,7 @@ Buying something over $10,000 means that the Office of Acquisition (OA) needs to
 
 - We assign a COR, most likely from the customer’s team, to aid in the post-award contract management through a COR delegation letter.
 
-- We have [guides and resources](https://drive.google.com/drive/folders/0BxTwA-UymFarOTZBRVFLYkdvcFU) to help the COR with fulfilling their responsibilities.
+- We have [guides and resources](https://drive.google.com/drive/folders/1tSIiw6Jgfpx1OATIBKSXhQf90st1raeQ) to help the COR with fulfilling their responsibilities.
 
 ### Contract modifications
 

--- a/_pages/office-of-acquisition/roles-and-responsibilities.md
+++ b/_pages/office-of-acquisition/roles-and-responsibilities.md
@@ -34,7 +34,7 @@ The acquisition contracting lead primarily serves on the consulting team as the 
 
 ## Contracting Officer Representative (COR)
 
-The COR serves as the contracting officer’s “eyes and ears.” They monitor contractor performance to ensure the contract’s articulated outcomes are being achieved. A COR is responsible for attaining and maintaining required [FAC-COR](https://www.fai.gov/drupal/certification/fac-cor) certifications. Resources and guides to help the COR fulfill their duties can be found [here](https://drive.google.com/drive/folders/0BxTwA-UymFarOTZBRVFLYkdvcFU). The employee can serve as either a term appointee or career employee of GSA. Post award responsibilities may include but are not limited to:
+The COR serves as the contracting officer’s “eyes and ears.” They monitor contractor performance to ensure the contract’s articulated outcomes are being achieved. A COR is responsible for attaining and maintaining required [FAC-COR](https://www.fai.gov/drupal/certification/fac-cor) certifications. Resources and guides to help the COR fulfill their duties can be found [here](https://drive.google.com/drive/folders/1tSIiw6Jgfpx1OATIBKSXhQf90st1raeQ). The employee can serve as either a term appointee or career employee of GSA. Post award responsibilities may include but are not limited to:
 
 - Understanding the terms of a contract and ensuring that the contractor and federal government meet their contractual obligations.
 - Maintaining an open line of communication between the federal government and the contractor.


### PR DESCRIPTION
Updates broken links to TTS COR resources. Links now point to "TTS COR Resources" folder on Google Drive: https://drive.google.com/drive/folders/1tSIiw6Jgfpx1OATIBKSXhQf90st1raeQ. I'm assuming this is where the links should point, but this should be confirmed by someone else.

Closes #3245.