### PR TITLE
New section for compensating research participants

### DIFF
--- a/_pages/18f/how-18f-works/research-guidelines.md
+++ b/_pages/18f/how-18f-works/research-guidelines.md
@@ -36,59 +36,61 @@ When sending participant agreements electronically, please use our [participant 
 
 ### Background
 
-As long ago as 2012 for PIFs and 2014 for 18F, the idea of paying for users to provide feedback has been discussed in depth. Our teams attempted to incentivize users to participate in our tests with gift cards or pizza or even payment to attend. This model implicated a number of appropriations law issues, among other regulations-based issues, that resulted in the concept of paying for user testing being rejected. So while we *could* conduct user research, we weren’t able to *compensate* users until relatively recently.
+As long ago as 2012 for PIFs and 2014 for 18F, the idea of paying for users to provide feedback has been discussed in depth. Our teams attempted to incentivize users to participate in our tests with gift cards or pizza or even payment to attend. This model implicated a number of appropriations law issues, among other regulations-based issues, that resulted in the concept of paying for user testing being rejected. So while we _could_ conduct user research, we weren’t able to _compensate_ users until relatively recently.
 
 Fortunately, we have made a lot of progress in developing approved processes for compensating research participants. We will continue to update this page as we streamline and refine our practices.
 
-### Should I compensate research participants? 
+### Should I compensate research participants?
 
 In general, if you are conducting research with members of the public, you should compensate them for their time and expertise. Offering compensation is critical to reaching the people most in need of government services. It helps ensure that we are gathering feedback and input from diverse audiences to develop and improve our products and services. It makes it easier to recruit participants, especially from underserved communities, and helps build trust. Without providing incentives and compensation, we are likely to hear only from the people who can afford to volunteer their time.
 
-### Who is not eligible for compensation? 
+### Who is not eligible for compensation?
 
-There are exceptions when it comes to financial compensation. Federal government employees, paid NGO staff, and private company employees being interviewed or participating in research activities as part of their paid duties are typically not eligible for compensation. Additionally, state, local, tribal and territory government employees are likely not eligible. You should work directly with your participants to understand any restrictions on financial compensation or other relevant rules and regulations. 
+There are exceptions when it comes to financial compensation. Federal government employees, paid NGO staff, and private company employees being interviewed or participating in research activities as part of their paid duties are typically not eligible for compensation. Additionally, state, local, tribal and territory government employees are likely not eligible. You should work directly with your participants to understand any restrictions on financial compensation or other relevant rules and regulations.
 
 In addition to paying participants, there are other ways to recognize the value of participants’ knowledge and experience. These can include:
+
 - Opportunity to provide feedback on design over time
 - Resources for additional information on the topic
 - Offer to find out answers to questions they may have
 - Whenever possible, share the outcomes of the research
 
-### What authorization and approvals do I need? 
+### What authorization and approvals do I need?
 
-**TTS User Research Participant Compensation Justification Checklist:** Each project team must document their need to compensate user research participants by creating a justification for user research [template](https://docs.google.com/document/d/15SxB0JCi-OvTD2lLokkuixb9sWuu1i2v-K8wGhPqcno/edit). Teams can use this [sample justification](https://docs.google.com/document/d/1dNxmqlvtTwFbVBnypsVqA4rU2aNS1oXA1k4tmWLSwUw/edit#heading=h.qgqf6gne4pg0) for reference. Teams do not need to submit this justification, but they must keep a copy in the [user research compensation justifications folder](https://drive.google.com/drive/folders/0AGmTTInlTCCQUk9PVA). 
+**TTS User Research Participant Compensation Justification Checklist:** Each project team must document their need to compensate user research participants by creating a justification for user research [template](https://docs.google.com/document/d/15SxB0JCi-OvTD2lLokkuixb9sWuu1i2v-K8wGhPqcno/edit). Teams can use this [sample justification](https://docs.google.com/document/d/1dNxmqlvtTwFbVBnypsVqA4rU2aNS1oXA1k4tmWLSwUw/edit#heading=h.qgqf6gne4pg0) for reference. Teams do not need to submit this justification, but they must keep a copy in the [user research compensation justifications folder](https://drive.google.com/drive/folders/0AGmTTInlTCCQUk9PVA).
 
-The justification answers the following questions: 
+The justification answers the following questions:
+
 - Does this work directly advance GSA’s or the client’s statutory mission and objectives?
 - Does the benefit to the government outweigh the benefit to the individual?
 - Has the agency attempted to accomplish its goals through means other than paid user research?
 
-**Interagency Agreement (IAA) Attachment B - User Research Compensation Authorization:** Additionally, this approved attachment [template](https://docs.google.com/document/d/1ehb3W14_eEo8DdHjU0bCeyzG_t8I__7VyLV_cU4ZmQY)) must be part of your project’s IAA (if you have one). If it is not, work with your account manager to get it signed by an authorized official at the partner agency. 
+**Interagency Agreement (IAA) Attachment B - User Research Compensation Authorization:** Additionally, this approved attachment [template](https://docs.google.com/document/d/1ehb3W14_eEo8DdHjU0bCeyzG_t8I__7VyLV_cU4ZmQY)) must be part of your project’s IAA (if you have one). If it is not, work with your account manager to get it signed by an authorized official at the partner agency.
 
 The partner’s OGC will need to provide TTS a concurrence that “the benefit accruing to [the requesting agency] in obtaining this feedback outweighs the personal nature of this expense. [The requesting agency] has also determined that the feedback from this user research will directly advance the statutory mission and objectives of [the requesting agency]."
 
 ### How much compensation should I offer?
 
-While TTS is working to standardized base rates, the IAA [Attachment B - User Research Compensation Authorization](https://docs.google.com/document/d/1ehb3W14_eEo8DdHjU0bCeyzG_t8I__7VyLV_cU4ZmQY) sets a rate of $70 an hour for moderated research sessions. From 2020 research on third-party recruiters, the median range was between $50 to $70 per person per hour (this does not account for recruiting expenses an organization might incur). Recruitment and support averaged about $125 per participant, which means that the total cost for a moderated session would be about $195 per person. 
+While TTS is working to standardized base rates, the IAA [Attachment B - User Research Compensation Authorization](https://docs.google.com/document/d/1ehb3W14_eEo8DdHjU0bCeyzG_t8I__7VyLV_cU4ZmQY) sets a rate of $70 an hour for moderated research sessions. From 2020 research on third-party recruiters, the median range was between $50 to $70 per person per hour (this does not account for recruiting expenses an organization might incur). Recruitment and support averaged about $125 per participant, which means that the total cost for a moderated session would be about $195 per person.
 
 In 2022, TTS considers $70/hour as a starting point for compensation. Teams should consider factors of equity and complexity of the research when determining compensation for user research on their project.
 
-### How do I actually distribute the compensation to research participants? ###
+### How do I actually distribute the compensation to research participants?
 
 There are a few different ways to distribute compensation to research participants.
 
-**Pay participants via gift card:** Compensation can be distributed to participants via digital/e-gift or physical gift cards through [GiftBit](https://www.giftbit.com/). Gift cards can be purchased by submitting a [purchase card request](https://docs.google.com/forms/d/e/1FAIpQLSd-GoOE9xWWfJvdZNRP3SE7mj5ysI_RfM8brxdG8YpyJV9yKA/viewform). The total amount of the purchase must be under $10,000 per project. 
+**Pay participants via gift card:** Compensation can be distributed to participants via digital/e-gift or physical gift cards through [GiftBit](https://www.giftbit.com/). Gift cards can be purchased by submitting a [purchase card request](https://docs.google.com/forms/d/e/1FAIpQLSd-GoOE9xWWfJvdZNRP3SE7mj5ysI_RfM8brxdG8YpyJV9yKA/viewform). The total amount of the purchase must be under $10,000 per project.
 
-For more information, see [how do I complete a micropurchase request?](https://handbook.tts.gsa.gov/office-of-acquisition/#how-do-i-complete-a-micropurchase) in the handbook.
+For more information, see [how do I complete a micropurchase request?]({{site.baseurl}}/office-of-acquisition/#how-do-i-complete-a-micropurchase) in the handbook.
 
 **Use user-testing.com:** Teams can also use usertesting.com, if that’s applicable. TTS currently has a no cost agreement for that service (with help from a third party vendor) [per instructions](https://docs.google.com/document/d/1zJuzKW1txg73ukZlFF37vp5RRhf-iR0r2QZzs0-MXY8/edit).
 
-### Step-by-step checklist for compensating participants ###
+### Step-by-step checklist for compensating participants
 
 Follow these steps when you are ready to begin the compensation process.
 
-1. Complete the [TTS User Research Participant Compensation Justification Checklist](https://docs.google.com/document/d/15SxB0JCi-OvTD2lLokkuixb9sWuu1i2v-K8wGhPqcno/edit). Save it in your project folder, and save a copy in the u[ser research compensation justifications folder](https://drive.google.com/drive/folders/0AGmTTInlTCCQUk9PVA). 
-2. If working with a partner agency, confirm the IAA includes [Attachment B - User Research Compensation Authorization](https://docs.google.com/document/d/1ehb3W14_eEo8DdHjU0bCeyzG_t8I__7VyLV_cU4ZmQY). 
+1. Complete the [TTS User Research Participant Compensation Justification Checklist](https://docs.google.com/document/d/15SxB0JCi-OvTD2lLokkuixb9sWuu1i2v-K8wGhPqcno/edit). Save it in your project folder, and save a copy in the u[ser research compensation justifications folder](https://drive.google.com/drive/folders/0AGmTTInlTCCQUk9PVA).
+2. If working with a partner agency, confirm the IAA includes [Attachment B - User Research Compensation Authorization](https://docs.google.com/document/d/1ehb3W14_eEo8DdHjU0bCeyzG_t8I__7VyLV_cU4ZmQY).
 
 For gift card purchases, see [instructions](https://docs.google.com/document/d/1QBBwldQDgqxCgDeHMivHhDjOyo2oBfGn8_DaXe9HnXk/edit?usp=sharing) ($10,000 or less)
 

--- a/_pages/18f/how-18f-works/research-guidelines.md
+++ b/_pages/18f/how-18f-works/research-guidelines.md
@@ -54,13 +54,14 @@ In addition to paying participants, there are other ways to recognize the value 
 
 ### What authorization and approvals do I need? 
 
-**TTS User Research Participant Compensation Justification Checklist:** Each project team must document their need to compensate user research participants by creating a justification for user research [(template)](https://docs.google.com/document/d/15SxB0JCi-OvTD2lLokkuixb9sWuu1i2v-K8wGhPqcno/edit). Teams can use this [sample justification](https://docs.google.com/document/d/1dNxmqlvtTwFbVBnypsVqA4rU2aNS1oXA1k4tmWLSwUw/edit#heading=h.qgqf6gne4pg0) for reference. Teams do not need to submit this justification, but they must keep a copy in the [user research compensation justifications folder](https://drive.google.com/drive/folders/0AGmTTInlTCCQUk9PVA). 
+**TTS User Research Participant Compensation Justification Checklist:** Each project team must document their need to compensate user research participants by creating a justification for user research [template](https://docs.google.com/document/d/15SxB0JCi-OvTD2lLokkuixb9sWuu1i2v-K8wGhPqcno/edit). Teams can use this [sample justification](https://docs.google.com/document/d/1dNxmqlvtTwFbVBnypsVqA4rU2aNS1oXA1k4tmWLSwUw/edit#heading=h.qgqf6gne4pg0) for reference. Teams do not need to submit this justification, but they must keep a copy in the [user research compensation justifications folder](https://drive.google.com/drive/folders/0AGmTTInlTCCQUk9PVA). 
 
 The justification answers the following questions: 
-Does this work directly advance GSA’s or the client’s statutory mission and objectives?
-Does the benefit to the government outweigh the benefit to the individual?
-Has the agency attempted to accomplish its goals through means other than paid user research?
-Interagency Agreement (IAA) Attachment B - User Research Compensation Authorization: Additionally, this approved attachment [(template)](https://docs.google.com/document/d/1ehb3W14_eEo8DdHjU0bCeyzG_t8I__7VyLV_cU4ZmQY)) must be part of your project’s IAA (if you have one). If it is not, work with your account manager to get it signed by an authorized official at the partner agency. 
+- Does this work directly advance GSA’s or the client’s statutory mission and objectives?
+- Does the benefit to the government outweigh the benefit to the individual?
+- Has the agency attempted to accomplish its goals through means other than paid user research?
+
+**Interagency Agreement (IAA) Attachment B - User Research Compensation Authorization:** Additionally, this approved attachment [template](https://docs.google.com/document/d/1ehb3W14_eEo8DdHjU0bCeyzG_t8I__7VyLV_cU4ZmQY)) must be part of your project’s IAA (if you have one). If it is not, work with your account manager to get it signed by an authorized official at the partner agency. 
 
 The partner’s OGC will need to provide TTS a concurrence that “the benefit accruing to [the requesting agency] in obtaining this feedback outweighs the personal nature of this expense. [The requesting agency] has also determined that the feedback from this user research will directly advance the statutory mission and objectives of [the requesting agency]."
 
@@ -68,7 +69,26 @@ The partner’s OGC will need to provide TTS a concurrence that “the benefit a
 
 While TTS is working to standardized base rates, the IAA [Attachment B - User Research Compensation Authorization](https://docs.google.com/document/d/1ehb3W14_eEo8DdHjU0bCeyzG_t8I__7VyLV_cU4ZmQY) sets a rate of $70 an hour for moderated research sessions. From 2020 research on third-party recruiters, the median range was between $50 to $70 per person per hour (this does not account for recruiting expenses an organization might incur). Recruitment and support averaged about $125 per participant, which means that the total cost for a moderated session would be about $195 per person. 
 
-In 2022, TTS considers $70/hour as a starting point for compensation. Teams should consider the factors of equity and complexity of the research when determining compensation for user research on their project. Review additional considerations (internal use). 
+In 2022, TTS considers $70/hour as a starting point for compensation. Teams should consider factors of equity and complexity of the research when determining compensation for user research on their project.
+
+### How do I actually distribute the compensation to research participants? ###
+
+There are a few different ways to distribute compensation to research participants.
+
+**Pay participants via gift card:** Compensation can be distributed to participants via digital/e-gift or physical gift cards through [GiftBit](https://www.giftbit.com/). Gift cards can be purchased by submitting a [purchase card request](https://docs.google.com/forms/d/e/1FAIpQLSd-GoOE9xWWfJvdZNRP3SE7mj5ysI_RfM8brxdG8YpyJV9yKA/viewform). The total amount of the purchase must be under $10,000 per project. 
+
+For more information, see [how do I complete a micropurchase request?](https://handbook.tts.gsa.gov/office-of-acquisition/#how-do-i-complete-a-micropurchase) in the handbook.
+
+**Use user-testing.com:** Teams can also use usertesting.com, if that’s applicable. TTS currently has a no cost agreement for that service (with help from a third party vendor) [per instructions](https://docs.google.com/document/d/1zJuzKW1txg73ukZlFF37vp5RRhf-iR0r2QZzs0-MXY8/edit).
+
+### Step-by-step checklist for compensating participants ###
+
+Follow these steps when you are ready to begin the compensation process.
+
+1. Complete the [TTS User Research Participant Compensation Justification Checklist](https://docs.google.com/document/d/15SxB0JCi-OvTD2lLokkuixb9sWuu1i2v-K8wGhPqcno/edit). Save it in your project folder, and save a copy in the u[ser research compensation justifications folder](https://drive.google.com/drive/folders/0AGmTTInlTCCQUk9PVA). 
+2. If working with a partner agency, confirm the IAA includes [Attachment B - User Research Compensation Authorization](https://docs.google.com/document/d/1ehb3W14_eEo8DdHjU0bCeyzG_t8I__7VyLV_cU4ZmQY). 
+
+For gift card purchases, see [instructions](https://docs.google.com/document/d/1QBBwldQDgqxCgDeHMivHhDjOyo2oBfGn8_DaXe9HnXk/edit?usp=sharing) ($10,000 or less)
 
 ## Managing Personally Identifiable Information (PII)
 

--- a/_pages/18f/how-18f-works/research-guidelines.md
+++ b/_pages/18f/how-18f-works/research-guidelines.md
@@ -44,7 +44,9 @@ Fortunately, we have made a lot of progress in developing approved processes for
 
 In general, if you are conducting research with members of the public, you should compensate them for their time and expertise. Offering compensation is critical to reaching the people most in need of government services. It helps ensure that we are gathering feedback and input from diverse audiences to develop and improve our products and services. It makes it easier to recruit participants, especially from underserved communities, and helps build trust. Without providing incentives and compensation, we are likely to hear only from the people who can afford to volunteer their time.
 
-However, there are exceptions when it comes to financial compensation. Federal government employees, paid NGO staff, and private company employees being interviewed or participating in research activities as part of their paid duties are typically not eligible for compensation. Additionally, state, local, tribal and territory government employees are likely not eligible. You should work directly with your participants to understand any restrictions on financial compensation or other relevant rules and regulations. 
+### Who is not eligible for compensation? 
+
+There are exceptions when it comes to financial compensation. Federal government employees, paid NGO staff, and private company employees being interviewed or participating in research activities as part of their paid duties are typically not eligible for compensation. Additionally, state, local, tribal and territory government employees are likely not eligible. You should work directly with your participants to understand any restrictions on financial compensation or other relevant rules and regulations. 
 
 In addition to paying participants, there are other ways to recognize the value of participants’ knowledge and experience. These can include:
 - Opportunity to provide feedback on design over time

--- a/_pages/18f/how-18f-works/research-guidelines.md
+++ b/_pages/18f/how-18f-works/research-guidelines.md
@@ -32,6 +32,44 @@ TTS gets explicit consent from anyone who participates in our moderated research
 
 When sending participant agreements electronically, please use our [participant agreement email template](https://docs.google.com/document/d/1t01t_eLYWJXuKdJkhiyBqkWf4Yr5XsFAbNv-BDAZqzE/edit). This template clearly specifies how people can opt out of a study and/or request that we do not contact them in the future.
 
+## Compensating user research participants
+
+### Background
+
+As long ago as 2012 for PIFs and 2014 for 18F, the idea of paying for users to provide feedback has been discussed in depth. Our teams attempted to incentivize users to participate in our tests with gift cards or pizza or even payment to attend. This model implicated a number of appropriations law issues, among other regulations-based issues, that resulted in the concept of paying for user testing being rejected. So while we *could* conduct user research, we weren’t able to *compensate* users until relatively recently.
+
+Fortunately, we have made a lot of progress in developing approved processes for compensating research participants. We will continue to update this page as we streamline and refine our practices.
+
+### Should I compensate research participants? 
+
+In general, if you are conducting research with members of the public, you should compensate them for their time and expertise. Offering compensation is critical to reaching the people most in need of government services. It helps ensure that we are gathering feedback and input from diverse audiences to develop and improve our products and services. It makes it easier to recruit participants, especially from underserved communities, and helps build trust. Without providing incentives and compensation, we are likely to hear only from the people who can afford to volunteer their time.
+
+However, there are exceptions when it comes to financial compensation. Federal government employees, paid NGO staff, and private company employees being interviewed or participating in research activities as part of their paid duties are typically not eligible for compensation. Additionally, state, local, tribal and territory government employees are likely not eligible. You should work directly with your participants to understand any restrictions on financial compensation or other relevant rules and regulations. 
+
+In addition to paying participants, there are other ways to recognize the value of participants’ knowledge and experience. These can include:
+- Opportunity to provide feedback on design over time
+- Resources for additional information on the topic
+- Offer to find out answers to questions they may have
+- Whenever possible, share the outcomes of the research
+
+### What authorization and approvals do I need? 
+
+**TTS User Research Participant Compensation Justification Checklist:** Each project team must document their need to compensate user research participants by creating a justification for user research [(template)](https://docs.google.com/document/d/15SxB0JCi-OvTD2lLokkuixb9sWuu1i2v-K8wGhPqcno/edit). Teams can use this [sample justification](https://docs.google.com/document/d/1dNxmqlvtTwFbVBnypsVqA4rU2aNS1oXA1k4tmWLSwUw/edit#heading=h.qgqf6gne4pg0) for reference. Teams do not need to submit this justification, but they must keep a copy in the [user research compensation justifications folder](https://drive.google.com/drive/folders/0AGmTTInlTCCQUk9PVA). 
+
+The justification answers the following questions: 
+Does this work directly advance GSA’s or the client’s statutory mission and objectives?
+Does the benefit to the government outweigh the benefit to the individual?
+Has the agency attempted to accomplish its goals through means other than paid user research?
+Interagency Agreement (IAA) Attachment B - User Research Compensation Authorization: Additionally, this approved attachment [(template)](https://docs.google.com/document/d/1ehb3W14_eEo8DdHjU0bCeyzG_t8I__7VyLV_cU4ZmQY)) must be part of your project’s IAA (if you have one). If it is not, work with your account manager to get it signed by an authorized official at the partner agency. 
+
+The partner’s OGC will need to provide TTS a concurrence that “the benefit accruing to [the requesting agency] in obtaining this feedback outweighs the personal nature of this expense. [The requesting agency] has also determined that the feedback from this user research will directly advance the statutory mission and objectives of [the requesting agency]."
+
+### How much compensation should I offer?
+
+While TTS is working to standardized base rates, the IAA [Attachment B - User Research Compensation Authorization](https://docs.google.com/document/d/1ehb3W14_eEo8DdHjU0bCeyzG_t8I__7VyLV_cU4ZmQY) sets a rate of $70 an hour for moderated research sessions. From 2020 research on third-party recruiters, the median range was between $50 to $70 per person per hour (this does not account for recruiting expenses an organization might incur). Recruitment and support averaged about $125 per participant, which means that the total cost for a moderated session would be about $195 per person. 
+
+In 2022, TTS considers $70/hour as a starting point for compensation. Teams should consider the factors of equity and complexity of the research when determining compensation for user research on their project. Review additional considerations (internal use). 
+
 ## Managing Personally Identifiable Information (PII)
 
 We work in the open, but we need to be mindful of discussing agency partners, collecting any PII, or accidentally disclosing PII.


### PR DESCRIPTION
Added a section to Doing Research at TTS that describes how to compensate research participants. This is the outgrowth of the #wg-user-research-compensation meetings that included team members from 18F, 10X, and PeopleOps. This process has been piloted with 18F's vote.gov project and COE CX's project with DOL. This content was drafted collaboratively in a Google doc: https://docs.google.com/document/d/1kFCjoyWSHEHdkl4y7DcGQFs0TxawpCbsVHLTnEsluqE/edit#