### PR TITLE
Update travel card link

### DIFF
--- a/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-travel-card.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-travel-card.md
@@ -116,7 +116,7 @@ You need a PIN to complete chip enabled transactions.
    temporary PIN. Select the unique link and follow the prompts to reset your
    PIN, including entering the temporary PIN from the second email.
 
-[Visit the GSA SmartPay 3 purchase card page on InSite for more information](https://insite.gsa.gov/topics/acquisition-purchases-and-payments/gsa-purchase-card/preparing-and-implementing-gsa-smartpay-3-sp3).
+[Visit the GSA SmartPay 3 travel card page for more information](https://smartpay.gsa.gov/content/travel).
 
 [Next Step: Complete Your Concur
 Profile]({% page "/first-time-travel-complete-concur-profile" %})


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates the link to SmartPay 3 travel card information
  - it used to point to a page on InSite. Now it points to the public site at https://smartpay.gsa.gov/content/travel
- closes #3191