### PR TITLE
Allow Markdown to add CSS classes and other attributes

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -6,6 +6,7 @@ const pluginRss = require("@11ty/eleventy-plugin-rss");
 const pluginNavigation = require("@11ty/eleventy-navigation");
 const markdownIt = require("markdown-it");
 const markdownItAnchor = require("markdown-it-anchor");
+const markdownItAttrs = require("markdown-it-attrs");
 const yaml = require("js-yaml");
 const svgSprite = require("eleventy-plugin-svg-sprite");
 const {
@@ -111,10 +112,12 @@ module.exports = function (config) {
   // Customize Markdown library and settings:
   let markdownLibrary = markdownIt({
     html: true,
-  }).use(markdownItAnchor, {
-    permalink: headingLinks, // use our custom heading links
-    slugify: config.getFilter("slugify"),
-  });
+  })
+    .use(markdownItAnchor, {
+      permalink: headingLinks, // use our custom heading links
+      slugify: config.getFilter("slugify"),
+    })
+    .use(markdownItAttrs);
   config.setLibrary("md", markdownLibrary);
 
   // Override Browsersync defaults (used only with --serve)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@uswds/uswds": "^3.2.0",
         "jsdom": "^20.0.3",
+        "markdown-it-attrs": "^4.1.6",
         "netlify-cms": "^2.10.192"
       },
       "devDependencies": {
@@ -1983,8 +1984,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-differ": {
       "version": "3.0.0",
@@ -6691,7 +6691,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
       "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
-      "dev": true,
       "dependencies": {
         "uc.micro": "^1.0.1"
       }
@@ -6992,7 +6991,6 @@
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
       "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "~3.0.1",
@@ -7014,11 +7012,21 @@
         "markdown-it": "*"
       }
     },
+    "node_modules/markdown-it-attrs": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-4.1.6.tgz",
+      "integrity": "sha512-O7PDKZlN8RFMyDX13JnctQompwrrILuz2y43pW2GagcwpIIElkAdfeek+erHfxUOlXWPsjFeWmZ8ch1xtRLWpA==",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "markdown-it": ">= 9.0.0"
+      }
+    },
     "node_modules/markdown-it/node_modules/entities": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
       "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -13024,8 +13032,7 @@
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "dev": true
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "node_modules/uglify-js": {
       "version": "3.17.4",
@@ -15383,8 +15390,7 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "array-differ": {
       "version": "3.0.0",
@@ -18828,7 +18834,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
       "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
-      "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
       }
@@ -19070,7 +19075,6 @@
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
       "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
-      "dev": true,
       "requires": {
         "argparse": "^2.0.1",
         "entities": "~3.0.1",
@@ -19082,8 +19086,7 @@
         "entities": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-          "dev": true
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
         }
       }
     },
@@ -19092,6 +19095,12 @@
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.5.tgz",
       "integrity": "sha512-PI1qEHHkTNWT+X6Ip9w+paonfIQ+QZP9sCeMYi47oqhH+EsW8CrJ8J7CzV19QVOj6il8ATGbK2nTECj22ZHGvQ==",
       "dev": true,
+      "requires": {}
+    },
+    "markdown-it-attrs": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-4.1.6.tgz",
+      "integrity": "sha512-O7PDKZlN8RFMyDX13JnctQompwrrILuz2y43pW2GagcwpIIElkAdfeek+erHfxUOlXWPsjFeWmZ8ch1xtRLWpA==",
       "requires": {}
     },
     "markdown-table": {
@@ -23687,8 +23696,7 @@
     "uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "dev": true
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "uglify-js": {
       "version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "@uswds/uswds": "^3.2.0",
     "jsdom": "^20.0.3",
+    "markdown-it-attrs": "^4.1.6",
     "netlify-cms": "^2.10.192"
   },
   "prettier": {

--- a/pages/launching-software/lifecycle.md
+++ b/pages/launching-software/lifecycle.md
@@ -4,7 +4,7 @@ title: Lifecycle of a Launch
 
 ## ATOs
 
-[Learn about ATOs](https://atos.open-control.org/){: .usa-button}
+[Learn about ATOs](https://atos.open-control.org/){.usa-button}
 
 ### Timeline
 
@@ -141,8 +141,7 @@ follow the usual steps for getting an ATO, starting with
 
 ## ATO Checklist
 
-[Create your ATO checklist](https://github.com/18F/tts-tech-portfolio/issues/new?template=ato.md&title=ATO+for+%5Bsystem%5D+-+due+%5Bdate%5D){:
-.usa-button}
+[Create your ATO checklist](https://github.com/18F/tts-tech-portfolio/issues/new?template=ato.md&title=ATO+for+%5Bsystem%5D+-+due+%5Bdate%5D){.usa-button}
 
 ([preview](https://github.com/18F/tts-tech-portfolio/blob/main/.github/ISSUE_TEMPLATE/ato.md#readme))
 
@@ -250,13 +249,11 @@ As described in
 
 At TTS, the system security plan (SSP) is a long Google Doc.
 
-[Tips](https://atos.open-control.org/tips/#system-security-plans-ssps){:
-.usa-button}
+[Tips](https://atos.open-control.org/tips/#system-security-plans-ssps){.usa-button}
 
 ## Diagrams
 
-[General info](https://atos.open-control.org/tips/#systemnetwork-diagrams){:
-.usa-button}
+[General info](https://atos.open-control.org/tips/#systemnetwork-diagrams){.usa-button}
 
 ### Examples within TTS
 
@@ -325,4 +322,4 @@ Contact ispcompliance@gsa.gov for any issues.
   _Ask the {% slack_channel "api" %} if you have questions._
 - Make sure you have all the social media metadata and preview images.
 
-[More](https://atos.open-control.org/tips/){: .usa-button}
+[More](https://atos.open-control.org/tips/){.usa-button}

--- a/pages/tools/sketch.md
+++ b/pages/tools/sketch.md
@@ -10,8 +10,7 @@ You can get started with a trial version [immediately](https://www.sketch.com/).
 Upgrade to the full version whenever you get the license. Visit
 {% slack_channel "sketch" %} on Slack for help and sharing tips.
 
-[Request a license](https://gsa.servicenowservices.com/sp/?id=sc_cat_item&sys_id=1bfdfdca78d3a400ce3ddff91a64940b){:
-.usa-button}
+[Request a license](https://gsa.servicenowservices.com/sp/?id=sc_cat_item&sys_id=1bfdfdca78d3a400ce3ddff91a64940b){.usa-button}
 
 ## Plugins
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adding `{.my-class}` after a Markdown element will now add `class="my-class"` to the rendered output
- Other arbitrary attributes are also allowed; e.g., `{alt="this is some alt text"}`
- Uses [this library](https://www.npmjs.com/package/markdown-it-attrs) for adding attributes