### PR TITLE
Fix the sitemap

### DIFF
--- a/_includes/layouts/base.html
+++ b/_includes/layouts/base.html
@@ -1,3 +1,6 @@
+---
+date: git Last Modified
+---
 <!DOCTYPE html>
 
 <html lang="en">

--- a/pages/sitemap.xml.njk
+++ b/pages/sitemap.xml.njk
@@ -1,14 +1,14 @@
 ---
 permalink: /sitemap.xml
 eleventyExcludeFromCollections: true
+layout: layouts/pure
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 {%- for page in collections.all %}
-  {% set absoluteUrl %}{{ page.url | url | absoluteUrl }}{% endset %}
   <url>
-    <loc>{{ absoluteUrl }}</loc>
-    <lastmod>{{ page.date | htmlDateString }}</lastmod>
+    <loc>{{ site.host }}{{ page.url }}</loc>
+    <lastmod>{{ page.date.toISOString() }}</lastmod>
   </url>
 {%- endfor %}
 </urlset>


### PR DESCRIPTION
## Changes proposed in this pull request:

- adds some default frontmatter to all pages with the date, derived from the last modified date in git
- updates the sitemap template file to use the `pure` layout, which does not wrap the content in HTML
- fixes the way sitemap `<loc>` URLs are generated so that they are, like, correct

Hopefully addresses #3329 but I don't think we'll know for sure until the sitemap is published and the site is indexed again.