### PR TITLE
Remove noindex from meta tags

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -8,7 +8,6 @@ to modify some of the meta-data for the site, this is the place to do it.
     ================================================== -->
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="robots" content="noindex, nofollow">
   <!-- Mobile Specific Metas
     ================================================== -->
   <meta name="HandheldFriendly" content="True">


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes the `<meta>` tag that disallows robots from indexing and following. We need robots to do that in order for our search.gov integration to work. Oops. Again.