### PR TITLE
Redirect to participant agreement in UX guide

### DIFF
--- a/pages/18f/how-18f-works/research-guidelines.md
+++ b/pages/18f/how-18f-works/research-guidelines.md
@@ -67,7 +67,7 @@ research, generally by asking that our research participants sign a "design
 research participant agreement". TTS maintains a
 [template](https://docs.google.com/document/d/16qg58Hn92UlXLsi-2taizi7qe5mvQ3LMSkcvyHk8Bdo/edit)
 for internal use, and an
-[example participant agreement](https://methods.18f.gov/participant-agreement/)
+[example participant agreement](https://ux-guide.18f.gov/participant-agreement)
 for sharing with interested parties. Please make a copy of the participant
 agreement document template, put it into your project folder, and edit the
 highlighted text for each of your research studies. If your participants are


### PR DESCRIPTION
The Methods site will soon be deprecating the url that currently hosts the participant agreement example and redirecting to where this example also lives in the 18F UX guide. 

## Changes proposed in this pull request:

- This PR replaces the link to the example in the Methods with a link to the where the example lives in the UX guide.


## security considerations

[Note the any security considerations here, or make note of why there are none]
