### PR TITLE
Update research-guidelines.md

### DIFF
--- a/pages/18f/how-18f-works/research-guidelines.md
+++ b/pages/18f/how-18f-works/research-guidelines.md
@@ -262,7 +262,7 @@ satisfied the law.
 
 If you are collecting PII in the course of research, the best place to store it
 is in a locked-down folder on Google Drive that is only accessible to the core
-research team, as Google Drive is is a GSA-approved place to store PII. (The
+research team, as Google Drive is a GSA-approved place to store PII. (The
 only other GSA-approved software for storing PII is Salesforce, which we don't
 use for research). Raw interview notes, which may contain PII, should be stored
 in this folder. The core research team should also create a document that gives

--- a/pages/18f/how-18f-works/research-guidelines.md
+++ b/pages/18f/how-18f-works/research-guidelines.md
@@ -262,10 +262,10 @@ satisfied the law.
 
 If you are collecting PII in the course of research, the best place to store it
 is in a locked-down folder on Google Drive that is only accessible to the core
-research team, as Google Drive is a GSA-approved place to store PII. (The
-only other GSA-approved software for storing PII is Salesforce, which we don't
-use for research). Raw interview notes, which may contain PII, should be stored
-in this folder. The core research team should also create a document that gives
+research team, as Google Drive is a GSA-approved place to store PII. (The only
+other GSA-approved software for storing PII is Salesforce, which we don't use
+for research). Raw interview notes, which may contain PII, should be stored in
+this folder. The core research team should also create a document that gives
 each participant a pseudonym (eg. a codename or number such as "PO1"). Analysis
 & synthesis documents and research reports, which are typically accessed by
 additional members of the project team, should only contain those pseudonyms or


### PR DESCRIPTION
There was a double "is" "Google Drive is is a GSA-approved place to store PII." Now there is on "is"

## Changes proposed in this pull request:

- Fixed a typo: one less "is"
-
-

## security considerations

[Note the any security considerations here, or make note of why there are none]
