### PR TITLE
Update writing lab page

### DIFF
--- a/pages/getting-started/classes/writing-lab.md
+++ b/pages/getting-started/classes/writing-lab.md
@@ -74,12 +74,8 @@ ask for guidance on getting somebody assigned to your project.
 
 ### How do I ask for help?
 
-If your request is billable, you can post your request in
-{% slack_channel "microrequests" %}. If you do not have a budget for this work,
-please post in {% slack_channel "tts-helpwanted" %}, or
-{% slack_channel "18f-helpwanted" %} for work on 18F products. If you are not
-sure, you can post in {% slack_channel "microrequests" %} and someone will point
-you in the right direction.
+You can post your request in {% slack_channel "18f-helpwanted" %}, or
+{% slack_channel "tts-helpwanted" %} if you are not in 18F.
 
 ### What should I do if my issue isn't picked up?
 

--- a/pages/getting-started/classes/writing-lab.md
+++ b/pages/getting-started/classes/writing-lab.md
@@ -75,11 +75,11 @@ ask for guidance on getting somebody assigned to your project.
 ### How do I ask for help?
 
 If your request is billable, you can post your request in
-[#microrequests](https://app.slack.com/client/T025AQGAN/CNFHBCXDW). If you do
-not have a budget for this work, please post in
-[`#helpwanted`](https://app.slack.com/client/T025AQGAN/C018QJ2L44X). If you are
-not sure, you can post in #microrequests and someone will point you in the right
-direction.
+{% slack_channel "microrequests" %}. If you do not have a budget for this work,
+please post in {% slack_channel "tts-helpwanted" %}, or
+{% slack_channel "18f-helpwanted" %} for work on 18F products. If you are not
+sure, you can post in {% slack_channel "microrequests" %} and someone will point
+you in the right direction.
 
 ### What should I do if my issue isn't picked up?
 

--- a/pages/getting-started/classes/writing-lab.md
+++ b/pages/getting-started/classes/writing-lab.md
@@ -74,8 +74,8 @@ ask for guidance on getting somebody assigned to your project.
 
 ### How do I ask for help?
 
-You can post your request in {% slack_channel "18f-helpwanted" %}, or
-{% slack_channel "tts-helpwanted" %} if you are not in 18F.
+You can post your request in {% slack_channel "18f-help-wanted" %}, or
+{% slack_channel "tts-help-wanted" %} if you are not in 18F.
 
 ### What should I do if my issue isn't picked up?
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Update the Writing Lab page to use the `slack_channel` helper for Slack links. Also updates to reference the new split from `#helpwanted` to `#tts-helpwanted` and `#18f-helpwanted`.

- closes #3499