### PR TITLE
Remove Atom from suggested text editors

### DIFF
--- a/pages/tools/text-editors.md
+++ b/pages/tools/text-editors.md
@@ -17,7 +17,6 @@ to develop code.
   default. Also available on OS X via [Homebrew](https://brew.sh/).
 - [Emacs](https://www.gnu.org/software/emacs/): Installed on OS X and Linux by
   default. Also available on OS X via [Homebrew](https://brew.sh/)
-- [Atom](https://atom.io/)
 - [Visual Studio Code](https://code.visualstudio.com/): VS Code is very
   extensible with lots plugins. One great plugin for pairing is
   [Live Share](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare),


### PR DESCRIPTION
## Changes proposed in this pull request:

Update the list of suggested text editors to remove Atom, which has been sunset.

- closes #3496