### PR TITLE
Remove references to a no-longer-supported Google Meet plugin

### DIFF
--- a/pages/tools/google-meet.md
+++ b/pages/tools/google-meet.md
@@ -44,11 +44,6 @@ editing is restricted. Here's how:
 - You can start a Google Hangout from Slack by typing `/hangout`.
 - You can make and receive free domestic phone calls from within Gmail or Google
   Hangouts. Just create a new number with your GSA account at google.com/voice
-- Use the
-  [Google Meet Grid View](https://chrome.google.com/webstore/detail/google-meet-grid-view/ecmogldeoigldjmgieekjifmhaboipmc/related)
-  extension to be able to see a large number of participants at once
-  - Note this is a GSA-packaged version of
-    [the open source extension](https://github.com/stgeorgesepiscopal/google-meet-grid-view-extension)
 
 ### Fix audio issues
 


### PR DESCRIPTION
## Changes proposed in this pull request:

GSA IT used to support a repackaged version of a Chrome plugin for Google Meet that enabled various features that have since been incorporated natively into Google Meet. This was from the early days of the COVID pandemic and greatly improved our video meeting experience and GSA IT was an absolute gem in supporting the organization! ❤️ GSA IT

- closes #3495