### PR TITLE
Update 18F design and project leadership pages to direct folks to #18f-helpwanted

### DIFF
--- a/pages/18f/chapters/design.md
+++ b/pages/18f/chapters/design.md
@@ -54,7 +54,7 @@ Find us on Slack:
 - {% slack_channel "g-content" %}
 - {% slack_channel "g-research" %}
 - {% slack_channel "microrequests" %}
-- {% slack_channel "helpwanted" %}
+- {% slack_channel "18f-helpwanted" %}
 - {% slack_channel "dev-frontend" %}
 - {% slack_channel "18f-methods" %}
 

--- a/pages/18f/projects-partners/leading-projects.md
+++ b/pages/18f/projects-partners/leading-projects.md
@@ -63,7 +63,7 @@ Missteps on projects will happen. Teams do not have a crystal ball into partner
 expectations or communication preferences. This is a good time to bring in a
 facilitator from outside the project to help the team reflect on what is and
 isn’t going well, and then help the team come up with alternative methods in the
-future. Try {% slack_channel "helpwanted" %} to ask for a facilitator.
+future. Try {% slack_channel "18f-helpwanted" %} to ask for a facilitator.
 
 ### Manage work so it is equitably distributed
 


### PR DESCRIPTION
## Changes proposed in this pull request:

The `#helpwanted` channel was split into `#tts-helpwanted` and `#18f-helpwanted` (see 18F/delivery-assurance#20). This PR updates the 18F design and project leadership pages to direct folks to the `#18f-helpwanted` channel instead of the renamed `#helpwanted` channel.