### PR TITLE
Update references to microrequests channel

### DIFF
--- a/pages/18f/chapters/design.md
+++ b/pages/18f/chapters/design.md
@@ -53,7 +53,6 @@ Find us on Slack:
 - {% slack_channel "product-design" %}
 - {% slack_channel "g-content" %}
 - {% slack_channel "g-research" %}
-- {% slack_channel "microrequests" %}
 - {% slack_channel "18f-helpwanted" %}
 - {% slack_channel "dev-frontend" %}
 - {% slack_channel "18f-methods" %}

--- a/pages/18f/chapters/design.md
+++ b/pages/18f/chapters/design.md
@@ -45,7 +45,8 @@ organization, including:
 
 Find us on Slack:
 
-- {% slack_channel "18f-design" %} — Our home base for chapter conversation and news
+- {% slack_channel "18f-design" %} — Our home base for chapter conversation and
+  news
 - {% slack_channel "design" %} (TTS-wide)
 - {% slack_channel "content-design" %}
 - {% slack_channel "service-design" %}
@@ -53,7 +54,7 @@ Find us on Slack:
 - {% slack_channel "product-design" %}
 - {% slack_channel "g-content" %}
 - {% slack_channel "g-research" %}
-- {% slack_channel "18f-helpwanted" %}
+- {% slack_channel "18f-help-wanted" %}
 - {% slack_channel "dev-frontend" %}
 - {% slack_channel "18f-methods" %}
 
@@ -71,8 +72,8 @@ You might not have much assigned work during your first two weeks here. That’s
 okay and expected. If you’ve gotten all the government onboarding items done and
 a project _still_ hasn’t landed, the design team has a list of internal projects
 that aren’t funded but that will help us all work better together. Talk to your
-supervisor to get more information about these internal
-projects and how you can get involved.
+supervisor to get more information about these internal projects and how you can
+get involved.
 
 ## Who we are
 
@@ -85,10 +86,15 @@ non-profits, consultancies, corporations, and academia.
 
 As per the
 [org chart](https://docs.google.com/presentation/d/189TanLPSFF9MWvNr6VdfUvhBAWBSXeoCSGD2ZXRDm3s/edit?usp=sharing),
-18F Design is itself composed of product design, content strategy, service design, and user experience teams. Members of the Design team are active participants in the content and research
+18F Design is itself composed of product design, content strategy, service
+design, and user experience teams. Members of the Design team are active
+participants in the content and research
 [guilds]({% page "/working-groups-and-guilds-101" %}).
 
-Before starting at 18F, you will have been assigned a supervisor. Supervisors meet with you regularly and carry out most managerial responsibilities for their disciplines. They lead staffing, hiring, training, and project troubleshooting for their discipline. More detail on
+Before starting at 18F, you will have been assigned a supervisor. Supervisors
+meet with you regularly and carry out most managerial responsibilities for their
+disciplines. They lead staffing, hiring, training, and project troubleshooting
+for their discipline. More detail on
 [Design team roles and responsibilities](https://docs.google.com/document/d/1XqgwiUItzRZu4I8KcpQlkCCd5iXM_EbTwsUzXwy-L-w/edit#heading=h.bc6vwqoy0xk4)
 is provided internally.
 
@@ -128,30 +134,31 @@ initiatives. As you’d guess, everyone’s weeks look a little different. That
 said, there are recurring weekly meetings and commitments we all have on our
 calendars.
 
-- **Wednesdays:** Every other week for 30-45 minutes at 2pm ET (11am PT)
-  design team huddle. The whole team meets to discuss project status, policy
-  updates, and general design-specific news. Our huddles typically follow the
-  same format: We start with an intro question for everyone to answer, welcome new teammates, and get chapter and organizational updates. The rest of
-  the huddle features a presentation or conversation about a topic of current
-  interest to the team. Past topics have included: project share-outs, an overview of the Paperwork Reduction Act, and discussion around common challenges.
+- **Wednesdays:** Every other week for 30-45 minutes at 2pm ET (11am PT) design
+  team huddle. The whole team meets to discuss project status, policy updates,
+  and general design-specific news. Our huddles typically follow the same
+  format: We start with an intro question for everyone to answer, welcome new
+  teammates, and get chapter and organizational updates. The rest of the huddle
+  features a presentation or conversation about a topic of current interest to
+  the team. Past topics have included: project share-outs, an overview of the
+  Paperwork Reduction Act, and discussion around common challenges.
 - **Once a week/Every two weeks:** Meet with your discipline team.
-- **Once a week/Every two weeks:** Meet with your supervisor. You’ll have a short
-  check-in with your supervisor at a time that’s convenient for both of you.
-  The purpose of this meeting is both administrative and personal. It’s how the
-  team leadership keeps on top of project timelines and activities to coordinate
-  resourcing. It’s also a time to talk through any project concerns, figure out
-  how to wrangle the federal bureaucracy, and talk about how to make 18F work
-  better for you.
-- **Once a week/Every two weeks:** Meet with your critique group. Crit groups discuss creative
-  questions and share work. We re-form the groups periodically so we have
-  opportunities to learn from the whole group.
+- **Once a week/Every two weeks:** Meet with your supervisor. You’ll have a
+  short check-in with your supervisor at a time that’s convenient for both of
+  you. The purpose of this meeting is both administrative and personal. It’s how
+  the team leadership keeps on top of project timelines and activities to
+  coordinate resourcing. It’s also a time to talk through any project concerns,
+  figure out how to wrangle the federal bureaucracy, and talk about how to make
+  18F work better for you.
+- **Once a week/Every two weeks:** Meet with your critique group. Crit groups
+  discuss creative questions and share work. We re-form the groups periodically
+  so we have opportunities to learn from the whole group.
 
 ### Tools
 
 Here are some common tools we use, how we use them, and how you can get access
 to them. If you can’t find the information you need in the chart below, get in
-touch with your supervisor; they’ll be able to point you in the right
-direction.
+touch with your supervisor; they’ll be able to point you in the right direction.
 
 And one more thing: before you start using any new tool that asks for access to
 files/browser data, see the [Software]({{base.baseurl}}/software/) page and
@@ -163,8 +170,10 @@ Unless otherwise specified, **see
 [Software]({% page "/general-information-and-resources/software/#software-already-approved-in-gear" %})
 to get a license** for any of these.
 
-- **Figma** You'll need to email the 18F design tool owner and request to join our account. Ask your supervisor who's currently in this role.
-- **Sketch** You'll need to email the 18F design tool owner and request to join our account. Ask your supervisor who's currently in this role.
+- **Figma** You'll need to email the 18F design tool owner and request to join
+  our account. Ask your supervisor who's currently in this role.
+- **Sketch** You'll need to email the 18F design tool owner and request to join
+  our account. Ask your supervisor who's currently in this role.
 - **OmniGraffle:**
   [Request a license](https://gsa.servicenowservices.com/sp/?id=sc_cat_item&sys_id=1bfdfdca78d3a400ce3ddff91a64940b)
 - [**Adobe Creative Cloud**]({% page "/adobe/" %})
@@ -182,8 +191,9 @@ Trello]({% page "/trello" %}) page.
 #### Research
 
 - Please read [Doing Research at TTS]({% page "/research-guidelines" %}) for
-  more information on the tools and techniques. 
-- The [18F UX Guide](https://ux-guide.18f.gov/) provides additional guidance on how we conduct research.
+  more information on the tools and techniques.
+- The [18F UX Guide](https://ux-guide.18f.gov/) provides additional guidance on
+  how we conduct research.
 - **Analytics:** We recommend leveraging the
   [Digital Analytics Program](https://digital.gov/services/dap/) whenever
   possible. We augment DAP with site-specific Google analytics tracking. Ask

--- a/pages/18f/chapters/design.md
+++ b/pages/18f/chapters/design.md
@@ -45,8 +45,7 @@ organization, including:
 
 Find us on Slack:
 
-- {% slack_channel "18f-design" %} — Our home base for chapter conversation and
-  news
+- {% slack_channel "18f-design" %} — Our home base for chapter conversation and news
 - {% slack_channel "design" %} (TTS-wide)
 - {% slack_channel "content-design" %}
 - {% slack_channel "service-design" %}
@@ -72,8 +71,8 @@ You might not have much assigned work during your first two weeks here. That’s
 okay and expected. If you’ve gotten all the government onboarding items done and
 a project _still_ hasn’t landed, the design team has a list of internal projects
 that aren’t funded but that will help us all work better together. Talk to your
-supervisor to get more information about these internal projects and how you can
-get involved.
+supervisor to get more information about these internal
+projects and how you can get involved.
 
 ## Who we are
 
@@ -86,15 +85,10 @@ non-profits, consultancies, corporations, and academia.
 
 As per the
 [org chart](https://docs.google.com/presentation/d/189TanLPSFF9MWvNr6VdfUvhBAWBSXeoCSGD2ZXRDm3s/edit?usp=sharing),
-18F Design is itself composed of product design, content strategy, service
-design, and user experience teams. Members of the Design team are active
-participants in the content and research
+18F Design is itself composed of product design, content strategy, service design, and user experience teams. Members of the Design team are active participants in the content and research
 [guilds]({% page "/working-groups-and-guilds-101" %}).
 
-Before starting at 18F, you will have been assigned a supervisor. Supervisors
-meet with you regularly and carry out most managerial responsibilities for their
-disciplines. They lead staffing, hiring, training, and project troubleshooting
-for their discipline. More detail on
+Before starting at 18F, you will have been assigned a supervisor. Supervisors meet with you regularly and carry out most managerial responsibilities for their disciplines. They lead staffing, hiring, training, and project troubleshooting for their discipline. More detail on
 [Design team roles and responsibilities](https://docs.google.com/document/d/1XqgwiUItzRZu4I8KcpQlkCCd5iXM_EbTwsUzXwy-L-w/edit#heading=h.bc6vwqoy0xk4)
 is provided internally.
 
@@ -134,31 +128,30 @@ initiatives. As you’d guess, everyone’s weeks look a little different. That
 said, there are recurring weekly meetings and commitments we all have on our
 calendars.
 
-- **Wednesdays:** Every other week for 30-45 minutes at 2pm ET (11am PT) design
-  team huddle. The whole team meets to discuss project status, policy updates,
-  and general design-specific news. Our huddles typically follow the same
-  format: We start with an intro question for everyone to answer, welcome new
-  teammates, and get chapter and organizational updates. The rest of the huddle
-  features a presentation or conversation about a topic of current interest to
-  the team. Past topics have included: project share-outs, an overview of the
-  Paperwork Reduction Act, and discussion around common challenges.
+- **Wednesdays:** Every other week for 30-45 minutes at 2pm ET (11am PT)
+  design team huddle. The whole team meets to discuss project status, policy
+  updates, and general design-specific news. Our huddles typically follow the
+  same format: We start with an intro question for everyone to answer, welcome new teammates, and get chapter and organizational updates. The rest of
+  the huddle features a presentation or conversation about a topic of current
+  interest to the team. Past topics have included: project share-outs, an overview of the Paperwork Reduction Act, and discussion around common challenges.
 - **Once a week/Every two weeks:** Meet with your discipline team.
-- **Once a week/Every two weeks:** Meet with your supervisor. You’ll have a
-  short check-in with your supervisor at a time that’s convenient for both of
-  you. The purpose of this meeting is both administrative and personal. It’s how
-  the team leadership keeps on top of project timelines and activities to
-  coordinate resourcing. It’s also a time to talk through any project concerns,
-  figure out how to wrangle the federal bureaucracy, and talk about how to make
-  18F work better for you.
-- **Once a week/Every two weeks:** Meet with your critique group. Crit groups
-  discuss creative questions and share work. We re-form the groups periodically
-  so we have opportunities to learn from the whole group.
+- **Once a week/Every two weeks:** Meet with your supervisor. You’ll have a short
+  check-in with your supervisor at a time that’s convenient for both of you.
+  The purpose of this meeting is both administrative and personal. It’s how the
+  team leadership keeps on top of project timelines and activities to coordinate
+  resourcing. It’s also a time to talk through any project concerns, figure out
+  how to wrangle the federal bureaucracy, and talk about how to make 18F work
+  better for you.
+- **Once a week/Every two weeks:** Meet with your critique group. Crit groups discuss creative
+  questions and share work. We re-form the groups periodically so we have
+  opportunities to learn from the whole group.
 
 ### Tools
 
 Here are some common tools we use, how we use them, and how you can get access
 to them. If you can’t find the information you need in the chart below, get in
-touch with your supervisor; they’ll be able to point you in the right direction.
+touch with your supervisor; they’ll be able to point you in the right
+direction.
 
 And one more thing: before you start using any new tool that asks for access to
 files/browser data, see the [Software]({{base.baseurl}}/software/) page and
@@ -170,10 +163,8 @@ Unless otherwise specified, **see
 [Software]({% page "/general-information-and-resources/software/#software-already-approved-in-gear" %})
 to get a license** for any of these.
 
-- **Figma** You'll need to email the 18F design tool owner and request to join
-  our account. Ask your supervisor who's currently in this role.
-- **Sketch** You'll need to email the 18F design tool owner and request to join
-  our account. Ask your supervisor who's currently in this role.
+- **Figma** You'll need to email the 18F design tool owner and request to join our account. Ask your supervisor who's currently in this role.
+- **Sketch** You'll need to email the 18F design tool owner and request to join our account. Ask your supervisor who's currently in this role.
 - **OmniGraffle:**
   [Request a license](https://gsa.servicenowservices.com/sp/?id=sc_cat_item&sys_id=1bfdfdca78d3a400ce3ddff91a64940b)
 - [**Adobe Creative Cloud**]({% page "/adobe/" %})
@@ -191,9 +182,8 @@ Trello]({% page "/trello" %}) page.
 #### Research
 
 - Please read [Doing Research at TTS]({% page "/research-guidelines" %}) for
-  more information on the tools and techniques.
-- The [18F UX Guide](https://ux-guide.18f.gov/) provides additional guidance on
-  how we conduct research.
+  more information on the tools and techniques. 
+- The [18F UX Guide](https://ux-guide.18f.gov/) provides additional guidance on how we conduct research.
 - **Analytics:** We recommend leveraging the
   [Digital Analytics Program](https://digital.gov/services/dap/) whenever
   possible. We augment DAP with site-specific Google analytics tracking. Ask

--- a/pages/18f/projects-partners/consulting-engineering-guide.md
+++ b/pages/18f/projects-partners/consulting-engineering-guide.md
@@ -186,7 +186,7 @@ skills. If so, some options you might want to look at include:
 
 - Billable projects — Cloud.gov and Login.gov often can use some extra help
   across a broad range of skill sets. Check their staffing issues.
-- {% slack_channel "microrequests" %} may have a small (less than 12 hours,
+- {% slack_channel "18f-helpwanted" %} may have a small (less than 12 hours,
   usually) project that needs some engineering help
 - Non-billable projects — talk with your supervisor about pitching in on an
   internal project like Tock

--- a/pages/18f/projects-partners/consulting-engineering-guide.md
+++ b/pages/18f/projects-partners/consulting-engineering-guide.md
@@ -186,7 +186,7 @@ skills. If so, some options you might want to look at include:
 
 - Billable projects — Cloud.gov and Login.gov often can use some extra help
   across a broad range of skill sets. Check their staffing issues.
-- {% slack_channel "18f-helpwanted" %} may have a small (less than 12 hours,
+- {% slack_channel "18f-help-wanted" %} may have a small (less than 12 hours,
   usually) project that needs some engineering help
 - Non-billable projects — talk with your supervisor about pitching in on an
   internal project like Tock

--- a/pages/18f/projects-partners/leading-projects.md
+++ b/pages/18f/projects-partners/leading-projects.md
@@ -63,7 +63,7 @@ Missteps on projects will happen. Teams do not have a crystal ball into partner
 expectations or communication preferences. This is a good time to bring in a
 facilitator from outside the project to help the team reflect on what is and
 isn’t going well, and then help the team come up with alternative methods in the
-future. Try {% slack_channel "18f-helpwanted" %} to ask for a facilitator.
+future. Try {% slack_channel "18f-help-wanted" %} to ask for a facilitator.
 
 ### Manage work so it is equitably distributed
 
@@ -105,8 +105,8 @@ happening.
   tools and deliverables)
   - If artifacts (e.g. RFQs, final reports, decks) should be durable over time,
     consider budgeting time to make them accessible (talk to your account
-    manager or use {% slack_channel "18f-helpwanted" %} if the team doesn't have
-    this ability)
+    manager or use {% slack_channel "18f-help-wanted" %} if the team doesn't
+    have this ability)
 - Ensure sprint planning, review, and other recurring meetings are scheduled
 - Facilitate identification of project management tracking tools
 - Facilitate identification of how administrative tasks will be rotated
@@ -194,8 +194,8 @@ most common types of 18F project endings are some combination of the following:
 - Conduct, document, and post a Project Reflection at the end of the project (or
   every 3-4 months for longer projects). Request a facilitator from outside the
   project in {% slack_channel "workshop-facilitation" %} or
-  {% slack_channel "18f-helpwanted" %} so everyone on the project team can fully
-  participate.
+  {% slack_channel "18f-help-wanted" %} so everyone on the project team can
+  fully participate.
 - Use the
   [project reflection for performance evals template](https://docs.google.com/document/d/1ko28PDLcEa_VB3ulMKbEjLzi88u8K8WJqXsBryrBV-U/edit?usp=sharing)
   to collaborate on drafting examples of evaluation criteria. In some cases, an
@@ -301,7 +301,7 @@ conversations, client management skills, and strategic direction.
   [guides](https://18f.gsa.gov/guides/).
 - If you need support in a specific skill set, help with deliverables, or would
   like to have someone facilitate a session, get help by using
-  {% slack_channel "18f-helpwanted" %}.
+  {% slack_channel "18f-help-wanted" %}.
 - If your project is part of a portfolio, the portfolio director and your
   colleagues in the portfolio can be a great resource.
 - If you need advice or coaching, look to the chapters

--- a/pages/18f/projects-partners/leading-projects.md
+++ b/pages/18f/projects-partners/leading-projects.md
@@ -104,8 +104,9 @@ happening.
 - Identify stakeholder accessibility needs for project work (in collaboration
   tools and deliverables)
   - If artifacts (e.g. RFQs, final reports, decks) should be durable over time,
-    consider budgeting time to make them accessible (use
-    {% slack_channel "microrequests" %} if the team doesn't have this ability)
+    consider budgeting time to make them accessible (talk to your account
+    manager or use {% slack_channel "18f-helpwanted" %} if the team doesn't have
+    this ability)
 - Ensure sprint planning, review, and other recurring meetings are scheduled
 - Facilitate identification of project management tracking tools
 - Facilitate identification of how administrative tasks will be rotated
@@ -193,7 +194,7 @@ most common types of 18F project endings are some combination of the following:
 - Conduct, document, and post a Project Reflection at the end of the project (or
   every 3-4 months for longer projects). Request a facilitator from outside the
   project in {% slack_channel "workshop-facilitation" %} or
-  {% slack_channel "microrequests" %} so everyone on the project team can fully
+  {% slack_channel "18f-helpwanted" %} so everyone on the project team can fully
   participate.
 - Use the
   [project reflection for performance evals template](https://docs.google.com/document/d/1ko28PDLcEa_VB3ulMKbEjLzi88u8K8WJqXsBryrBV-U/edit?usp=sharing)
@@ -300,7 +301,7 @@ conversations, client management skills, and strategic direction.
   [guides](https://18f.gsa.gov/guides/).
 - If you need support in a specific skill set, help with deliverables, or would
   like to have someone facilitate a session, get help by using
-  {% slack_channel "microrequests" %}.
+  {% slack_channel "18f-helpwanted" %}.
 - If your project is part of a portfolio, the portfolio director and your
   colleagues in the portfolio can be a great resource.
 - If you need advice or coaching, look to the chapters


### PR DESCRIPTION
The `#microrequests` Slack channel has been archived. This PR updates references to it to direct people to different resources (their account managers or `#18f-helpwanted`) instead.