### PR TITLE
Update email for travel vendor ID requests from new employees

### DIFF
--- a/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
@@ -27,8 +27,7 @@ you to make your flight and hotel reservations via AdTrav by calling (877)
    
    The EFT form is needed so that the reimbursement for your hotels, meals, and other expenses can be reimbursed (GSA only pays for your flight or Amtrak tickets upfront).
 
-   _Note if you haven't yet started working at GSA and don't have your GSA email address_:
-
+   **_Note, if you haven't yet started working at GSA and don't have your GSA email address_:**
 Your access to the EFT form linked above may be restricted, so you should have
 received it as an attachment in your welcome email-- feel free to reach out to
 [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov) if you never got it. Email the filled out EFT to [ext-vendor.help@gsa.gov](mailto:ext-vendor.help@gsa.gov).

--- a/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
@@ -23,7 +23,7 @@ you to make your flight and hotel reservations via AdTrav by calling (877)
    filling out
    [the EFT form](https://drive.google.com/a/gsa.gov/file/d/0B0Kck5dqF_Ebb0FFZ29RR0JmVVk/view?usp=sharing)
    and sending it to:
-   [kc-vendor.number.requests@gsa.gov](mailto:kc-vendor.number.requests@gsa.gov).
+   [ext-vendor.help@gsa.gov](mailto:ext-vendor.help@gsa.gov).
 
    _Note if you haven't started and don't have your GSA email address yet_:
 

--- a/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
@@ -28,6 +28,7 @@ you to make your flight and hotel reservations via AdTrav by calling (877)
    The EFT form is needed so that the reimbursement for your hotels, meals, and other expenses can be reimbursed (GSA only pays for your flight or Amtrak tickets upfront).
 
    **_Note, if you haven't yet started working at GSA and don't have your GSA email address_:**
+
 Your access to the EFT form linked above may be restricted, so you should have
 received it as an attachment in your welcome email-- feel free to reach out to
 [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov) if you never got it. Email the filled out EFT to [ext-vendor.help@gsa.gov](mailto:ext-vendor.help@gsa.gov).

--- a/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
@@ -23,16 +23,15 @@ you to make your flight and hotel reservations via AdTrav by calling (877)
    filling out
    [the EFT form](https://drive.google.com/a/gsa.gov/file/d/0B0Kck5dqF_Ebb0FFZ29RR0JmVVk/view?usp=sharing)
    and sending it to:
-   [ext-vendor.help@gsa.gov](mailto:ext-vendor.help@gsa.gov).
+   [kc-vendor.number.requests@gsa.gov](mailto:kc-vendor.number.requests@gsa.gov).
+   
+   The EFT form is needed so that the reimbursement for your hotels, meals, and other expenses can be reimbursed (GSA only pays for your flight or Amtrak tickets upfront).
 
-   _Note if you haven't started and don't have your GSA email address yet_:
+   _Note if you haven't yet started working at GSA and don't have your GSA email address_:
 
 Your access to the EFT form linked above may be restricted, so you should have
 received it as an attachment in your welcome email-- feel free to reach out to
-[tts-travel@gsa.gov](mailto:tts-travel@gsa.gov) if you never got it. The EFT
-form is needed so that the reimbursement for your hotels, meals, and other
-expenses can be reimbursed (GSA only pays for your flight or Amtrak tickets
-upfront).
+[tts-travel@gsa.gov](mailto:tts-travel@gsa.gov) if you never got it. Email the filled out EFT to [ext-vendor.help@gsa.gov](mailto:ext-vendor.help@gsa.gov).
 
 2. Once you receive your travel vendor ID (should be in the format _E000xxxxx_),
    forward it to [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov), along with


### PR DESCRIPTION

## Changes proposed in this pull request:

- Updating email for travel vendor ID requests from pre-start employees per conversation w/ Djemila on May 24, 2023. External parties to GSA (including onboarding employees who haven't started yet) should email ext-vendor.help@gsa.gov instead of the existing inbox.

## security considerations
None.