### PR TITLE
Fix an issue with processing the site's base URL, causing links across the site to be wrong

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,6 +5,7 @@ const markdownItAttrs = require("markdown-it-attrs");
 const yaml = require("js-yaml");
 const svgSprite = require("eleventy-plugin-svg-sprite");
 const { headingLinks } = require("./config/headingLinks");
+const baseurl = require("./config/baseurl");
 
 const HandbookPlugin = require("./config/HandbookPlugin.js");
 
@@ -59,7 +60,7 @@ module.exports = function (config) {
     templateFormats: ["md", "html", "njk"],
     markdownTemplateEngine: "liquid",
     htmlTemplateEngine: "liquid",
-    pathPrefix: process.env.BASEURL ?? "/",
+    pathPrefix: baseurl,
 
     dir: {
       input: "pages",

--- a/check-links.js
+++ b/check-links.js
@@ -1,6 +1,7 @@
-const cheerio = require("cheerio");
 const fs = require("fs/promises");
 const path = require("path");
+const baseurl = require("./config/baseurl");
+const cheerio = require("cheerio");
 
 const SITE_ROOT = path.join(__dirname, "_site");
 
@@ -51,7 +52,7 @@ const getDom = async (file) => {
       SITE_ROOT,
       // Strip off any URL hashes and remove the base URL portion to get down
       // to just the target file.
-      realFile.replace(/\#.*$/, "").replace(process.env.BASEURL, ""),
+      realFile.replace(/\#.*$/, "").replace(baseurl, ""),
       path.basename(file)
     );
 
@@ -103,7 +104,7 @@ const run = async () => {
 
         // if(/^\/(images|))
 
-        pathComponents.push(url.pathname.replace(process.env.BASEURL, ""));
+        pathComponents.push(url.pathname.replace(baseurl, ""));
 
         // If the link does not include a file path, append index.html
         if (!/\.[a-z]+/i.test(url.pathname)) {

--- a/config/baseurl.js
+++ b/config/baseurl.js
@@ -1,0 +1,19 @@
+// This bit of logic was being used in several places, and that's silly.
+// Especially when it turns out it's a little more complex than I thought it
+// was, and resulted in these issues:
+//
+// https://github.com/18F/handbook/issues/3615
+// https://github.com/18F/handbook/issues/3623
+// https://github.com/18F/handbook/issues/3630
+
+if (!process.env.BASEURL) {
+  // If the BASEURL set is falsey, then our actual baseurl is the root.
+  module.exports = "/";
+  // If the BASEURL is set but it's a string of just whitespace, we want to use
+  // the root for that too.
+} else if (process.env.BASEURL.trim().length === 0) {
+  module.exports = "/";
+} else {
+  // But if the BASEURL is set to a real value, then that's our base.
+  module.exports = process.env.BASEURL;
+}

--- a/config/shortcodes/download.js
+++ b/config/shortcodes/download.js
@@ -18,5 +18,5 @@ module.exports = async (downloadPath) => {
 
   // The resulting URL should include the base URL, if any. This is necessary
   // for cloud.gov Pages previews to work correctly.
-  return `${baseurl}/assets/downloads/${filename}`;
+  return path.join(baseurl, `/assets/downloads/${filename}`);
 };

--- a/config/shortcodes/download.js
+++ b/config/shortcodes/download.js
@@ -1,5 +1,6 @@
 const fs = require("fs/promises");
 const path = require("path");
+const baseurl = require("../baseurl");
 
 // Given a path to a file that should be downloadable, copy that path into the
 // output's assets directory so it'll be available. Return the resulting URL
@@ -17,5 +18,5 @@ module.exports = async (downloadPath) => {
 
   // The resulting URL should include the base URL, if any. This is necessary
   // for cloud.gov Pages previews to work correctly.
-  return `${process.env.BASEURL ?? ""}/assets/downloads/${filename}`;
+  return `${baseurl}/assets/downloads/${filename}`;
 };

--- a/config/shortcodes/imageWithClass.js
+++ b/config/shortcodes/imageWithClass.js
@@ -1,5 +1,6 @@
 const Image = require("@11ty/eleventy-img");
 const path = require("path");
+const baseurl = require("../baseurl");
 
 // Given an image path, copies the file to the assets/images directory so it is
 // available on the web. Returns the text for an <img> element that has the
@@ -31,7 +32,7 @@ module.exports = async (imagePath, cssClass, altText) => {
   // unexpected, hard-to-debug ways that do not break the build.
   const attributes = {
     // We need to honor BASEURL to support cloud.gov Pages preview builds.
-    src: `${process.env.BASEURL ?? ""}/${url}`,
+    src: `${baseurl}/${url}`,
     class: cssClass ?? false,
     alt: altText ?? false,
     loading: "lazy",

--- a/config/shortcodes/imageWithClass.js
+++ b/config/shortcodes/imageWithClass.js
@@ -32,7 +32,7 @@ module.exports = async (imagePath, cssClass, altText) => {
   // unexpected, hard-to-debug ways that do not break the build.
   const attributes = {
     // We need to honor BASEURL to support cloud.gov Pages preview builds.
-    src: `${baseurl}/${url}`,
+    src: path.join(baseurl, url),
     class: cssClass ?? false,
     alt: altText ?? false,
     loading: "lazy",

--- a/config/shortcodes/link.js
+++ b/config/shortcodes/link.js
@@ -1,7 +1,8 @@
 const path = require("path");
+const baseurl = require("../baseurl");
 
 // Given text that should be a link, guarantee that it becomes one. If it's
 // already a link that begins with http/https, leave it alone. Otherwise, add
 // the site BASEURL to it.
 module.exports = (link) =>
-  link.startsWith("http") ? link : path.join(process.env.BASEURL ?? "/", link);
+  link.startsWith("http") ? link : path.join(baseurl, link);

--- a/config/shortcodes/page.js
+++ b/config/shortcodes/page.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const baseurl = require("../baseurl");
 
 // Given a page reference, turn it into a link on the published site.
-module.exports = (link) => path.join(process.env.BASEURL ?? "/", link);
+module.exports = (link) => path.join(baseurl, link);


### PR DESCRIPTION
## Changes proposed in this pull request:

The code previously processed the base URL by defaulting to `/` if the base URL was literally `undefined`. E.g.:

```js
process.env.BASEURL ?? "/"
```

This condition is incorrect. It should default to `/` if base URL is falsey. In the previous code, if `process.env.BASEURL` was `null` or `''`, the returned value would ***not*** be `/`, though it should be.

This PR moves the logic for building the base URL into a single file and updates all the others to refer to that instead. The new logic first checks for falsey values, then the length of the trimmed string value (because environment variables in Node.js are always strings). Only if the value is truthy and more than one non-space character will it be returned. Otherwise we do the default `/`.

- fixes #3615
- fixes #3623 
- fixes #3630

## security considerations

None