### PR TITLE
Add documentation about updating the Handbook to the front page navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -256,15 +256,17 @@ primary:
             internal: true
       - text: TTS platforms
         children:
-          - text: Cloud.gov
+          - text: cloud.gov
             url: https://cloud.gov/
             internal: false
+          - text: cloud.gov Pages
+            url: tools/pages/
+            internal: true
           - text: Login.gov
             url: https://login.gov/
             internal: false
-          - text: Federalist (publishing platform)
-            url: federalist/
-            internal: true
+          - text: Updating the Handbook
+            url: updating-the-handbook/
       - text: Tech
         children:
           - text: FITARA

--- a/pages/tools/pages.md
+++ b/pages/tools/pages.md
@@ -1,11 +1,11 @@
 ---
-title: Federalist
+title: cloud.gov Pages
 redirect_from:
   - /federalist/
   - /pages/tools/federalist/
 ---
 
-We use [cloud.gov's Pages](https://cloud.gov/pages/) to build websites.
+We use [cloud.gov Pages](https://cloud.gov/pages/) to build websites.
 
 ## Documentation
 
@@ -24,9 +24,10 @@ We use [cloud.gov's Pages](https://cloud.gov/pages/) to build websites.
 
 ## Rules
 
-- TTS teams can use Federalist for internal or TTS-specific projects without
-  cost. However, if the site is part of a project you're doing for another
-  agency, it must be included in and paid for by the agreement with that agency.
+- TTS teams can use cloud.gov Pages for internal or TTS-specific projects
+  without cost. However, if the site is part of a project you're doing for
+  another agency, it must be included in and paid for by the agreement with that
+  agency.
 
 - For 18F staff only - The Outreach team is responsible for 18F's web presence.
   If you are looking to create an 18F microsite (`xyz.18f.gov`), such as a guide

--- a/pages/training-and-development/intro-to-github.md
+++ b/pages/training-and-development/intro-to-github.md
@@ -171,11 +171,12 @@ styles, go back to the file and make sure it ends with the .md file extension.
 
 When you’re ready to start practicing with GitHub, the
 [TTS Handbook repository](https://github.com/18F/handbook) is a good place to
-start. If you see something in the handbook that is out of date or there is at
+start. If you see something in the Handbook that is out of date or there is at
 typo that needs to be fixed, you can create a pull request and make the changes.
-At least one review is required for it to be merged into the handbook, so
-someone will check your work. If you need help, you can ask in the #tts-handbook
-Slack channel.
+At least one review is required for it to be merged into the Handbook, so
+someone will check your work. If you need help, you can ask in the
+{% slack_channel "tts-handbook" %} Slack channel and check out our guidance on
+[updating the Handbook]({% page "updating-the-handbook" %}).
 
 ### 6. Working with GitHub
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds a link to documentation about updating the Handbook to the front page, in the TTS platforms section
- change references to Federalist to cloud.gov Pages, and fix capitalization in some place from "Cloud.gov"
- updates a link to the #tts-handbook channel

## security considerations

none