### PR TITLE
Make private links more consistent across experiences

### DIFF
--- a/pages/travel-and-leave/travel-and-leave-policies/travel-guide-faq.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/travel-guide-faq.md
@@ -11,7 +11,7 @@ redirect_from:
 sidebar:
   navigation: travel
   current: FAQ
-cSpell: ignore Trav,DeLeve,Brydges,Nico,Papafil,Mahan,Rostami
+cSpell: ignore Trav,DeLeve,Brydges,Nico,Papafil,Mahan,Rostami,Krzystan
 ---
 
 ## Questions about booking travel

--- a/styles/custom/screen.scss
+++ b/styles/custom/screen.scss
@@ -34,12 +34,6 @@ a.button span.slack {
   }
 }
 
-a.private-link::after {
-  content: "🔒";
-  font-size: 0.75em;
-  text-decoration: none;
-}
-
 /* Travel Guide Image Toggles */
 a.travel-image-link {
   display: block;


### PR DESCRIPTION
## Changes proposed in this pull request:

Currently the Handbook marks private links (Google Docs, Slack, etc.) by adding the `private-link` CSS class, which uses the `::after` selector to add a padlock emoji, and setting the `title` attribute to "This link is private to TTS." However, as noted in #3543, this isn't a very friendly experience for people using screen readers. They are read something like this:
> Link, Hiring Manager Guide, closed lock. <long pause> This link is private to TTS.

This PR implements the [guidance](https://docs.google.com/document/d/18a2YMYhthITego22yNfEhK9FpY9A4kmys1BbiuLfXk8/edit) developed by the 18F Guides and Methods team in 18F/ux-guide#340:

- ditches the `private-link` class entirely
- a span node that is only visible to screen readers is inserted before the link with the text "TTS only"
- an SVG node that is hidden from screen readers is inserted after the link with a reference to the USWDS `lock_outline` icon

When a screen reader lands on a private link, it now reads something more like:
 > Link, TTS-only, Hiring Manager Guide.

In addition to private links, this PR also adds identification to external links. Any links out of gsa.gov will be marked external. Screen readers will announce that they are external and an icon is shown to sighted users. The screen reader announces something like this:
> Link, external, Airtable

This also works with private links:
> Link, external, TTS-only, Hiring Manager Guide

Visually, they end up looking like this:
![Screen Shot 2023-06-23 at 4 43 29 PM](https://github.com/18F/handbook/assets/1775733/cd5f2c16-d89b-4c99-b8a5-f7ffafb7051b)

Closes #3543

## security considerations

None
