### PR TITLE
Add Samira as new engineering guild co-lead

### DIFF
--- a/cSpell.json
+++ b/cSpell.json
@@ -157,6 +157,7 @@
     "rotaters",
     "roundtable",
     "routable",
+    "Samira",
     "screenshare",
     "SDLC",
     "Servicedesk",

--- a/pages/training-and-development/working-groups-and-guilds-101.md
+++ b/pages/training-and-development/working-groups-and-guilds-101.md
@@ -187,7 +187,7 @@ Guild meeting times can also be found on the
           <a href="https://github.com/18F/development-guide">Eng Guide repo</a> &bull; {% slack_channel "dev" %}
         </td>
         <td>
-          Kimball Bighorse - 18F<br />
+          Samira Sadat - USDC, Vote.gov<br />
           Drew Bollinger - cloud.gov Pages
         </td>
       </tr>


### PR DESCRIPTION
## Changes proposed in this pull request:

- Engineering Practices Guild Co-Lead: Add Samira Sadata, Remove Kimball Bighorse 

## security considerations
None
