### PR TITLE
Treasury Executive Institute (TEI) training link broken

### DIFF
--- a/pages/training-and-development/index.md
+++ b/pages/training-and-development/index.md
@@ -96,7 +96,7 @@ If you are interested in becoming a mentor, there is a list of
 GSA has a partnership with the Department of Treasury's Executive Institute
 (TEI) which offers employees at the GS-14, 15, and SES grade levels access to
 the
-[TEI training programs](https://insite.gsa.gov/topics/training-and-development/leadership-resources/treasury-executive-institute-tei)
+[TEI training programs](https://home.tei.treasury.gov/)
 both online and in the classroom to help develop and grow managerial skills.
 Questions? Contact [TEIInquiries@gsa.gov](mailto:TEIInquiries@gsa.gov).
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- The link to "Treasury Executive Institute (TEI) training" is 404'ing; I _believe_ I found the correct URL, but I'm open to suggestions if a better GSA resource/link should be used

## security considerations

None known
