### PR TITLE
Remove 2021 travel update alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To run the site locally:
 3. From the repo directory, run:
    ```sh
    npm install
-   npm run dev
+   npm start
    ```
 4. Open http://localhost:8080
 

--- a/pages/travel-and-leave/travel-guide-table-of-contents.md
+++ b/pages/travel-and-leave/travel-guide-table-of-contents.md
@@ -11,16 +11,6 @@ sidebar:
   navigation: travel
 ---
 
-<!-- prettier-ignore-start -->
-{% capture travel_content %}
-  {% renderTemplate 'liquid' %}
-    On July 13, 2021, GSA published <a href="{% page "/july-13-travel-guidance/" %}">updated travel guidance</a> for all employees.
-  {% endrenderTemplate %}
-{% endcapture %}
-
-{% include "alert.html" level:"info" heading:"Updated Travel Guidance for GSA Employees (07/13/2021)" content:travel_content %}
-<!-- prettier-ignore-end -->
-
 - [Travel 101]({% page "/travel-101/" %})
 - 1. First Time Travel Guide
   - [1 - Get access to


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removed the July 2021 travel alert from the [Travel Guide (table of contents)](https://federalist-cf8341ad-ca07-488c-bd96-0738014c79ca.sites.pages.cloud.gov/preview/18f/handbook/travel-update-update/travel-and-leave/travel-guide-table-of-contents/) since the link HTML was overflowing the grid. Also, it's outdated.
- Updated the "Not Docker" run script to `npm start` to reflect what worked for me. (`npm run dev` did not work.)