### PR TITLE
Update how-to-log-in.md

### DIFF
--- a/pages/getting-started/how-to-log-in.md
+++ b/pages/getting-started/how-to-log-in.md
@@ -51,7 +51,7 @@ following prompt if their password is due to expire within 14 days. I
 
 You can change the password that you use to log into your Mac or reset the
 password by following
-[ServiceNow KB0024344](https://gsa.servicenowservices.com/sp/?id=kb_article&sys_id=bd3133f7db78d300a54d72131f961906).
+[ServiceNow KB0024344](https://gsa.servicenowservices.com/sp/?sys_kb_id=361130c11b2829109fffa93be54bcba8&id=kb_article_view&sysparm_rank=1&sysparm_tsqueryId=220b62411b04fd90164442ecac4bcb7d).
 
 Users must follow security requirements:
 


### PR DESCRIPTION
ServiceNow KB0024344 link to invite led to page that stated item had expired. Updated link to https://gsa.servicenowservices.com/sp/?sys_kb_id=361130c11b2829109fffa93be54bcba8&id=kb_article_view&sysparm_rank=1&sysparm_tsqueryId=220b62411b04fd90164442ecac4bcb7d

## Changes proposed in this pull request:

-
-
-

## security considerations

[Note the any security considerations here, or make note of why there are none]
