### PR TITLE
Update alert rendering to fix visual bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To run the site locally:
 3. From the repo directory, run:
    ```sh
    npm install
-   npm run dev
+   npm start
    ```
 4. Open http://localhost:8080
 

--- a/_includes/alert.html
+++ b/_includes/alert.html
@@ -7,6 +7,6 @@ content: markdown body of the alert
 <div class="usa-alert usa-alert--{{ level | default: 'info' }}">
   <div class="usa-alert__body">
     {% if heading %}<h3 class="usa-alert__heading">{{ heading | escape }}</h3>{% endif %}
-    {% if content %}<div class="usa-alert__text">{{ content | default: '' }}</div>{% endif %}
+    {% if content %}<div class="usa-alert__text">{{ content | default: '' | render }}</div>{% endif %}
   </div>
 </div>

--- a/_includes/alert.html
+++ b/_includes/alert.html
@@ -7,6 +7,6 @@ content: markdown body of the alert
 <div class="usa-alert usa-alert--{{ level | default: 'info' }}">
   <div class="usa-alert__body">
     {% if heading %}<h3 class="usa-alert__heading">{{ heading | escape }}</h3>{% endif %}
-    {% if content %}<div class="usa-alert__text">{{ content | default: '' | render }}</div>{% endif %}
+    {% if content %}<div class="usa-alert__text">{{ content | default: '' }}</div>{% endif %}
   </div>
 </div>

--- a/config/filters/render.js
+++ b/config/filters/render.js
@@ -1,6 +1,6 @@
 const MarkdownIt = require("markdown-it");
 
 module.exports = async (content) => {
-  const md = new MarkdownIt();
+  const md = new MarkdownIt({ html: true });
   return md.render(content);
 };

--- a/pages/travel-and-leave/travel-guide-table-of-contents.md
+++ b/pages/travel-and-leave/travel-guide-table-of-contents.md
@@ -13,9 +13,7 @@ sidebar:
 
 <!-- prettier-ignore-start -->
 {% capture travel_content %}
-  {% renderTemplate 'liquid' %}
-    On July 13, 2021, GSA published <a href="{% page "/july-13-travel-guidance/" %}">updated travel guidance</a> for all employees.
-  {% endrenderTemplate %}
+  On July 13, 2021, GSA published [updated travel guidance]({% page "/july-13-travel-guidance/" %}) for all employees.
 {% endcapture %}
 
 {% include "alert.html" level:"info" heading:"Updated Travel Guidance for GSA Employees (07/13/2021)" content:travel_content %}


### PR DESCRIPTION
## Changes proposed in this pull request:

There was a bug in the rendering of https://handbook.tts.gsa.gov/travel-and-leave/travel-guide-table-of-contents/

I spot-checked one more alertbox and it seems to be ok with link content still

| before | after|
| --- | --- |
|  <img width="461" alt="Screenshot 2023-08-07 at 1 53 52 PM" src="https://github.com/18F/handbook/assets/458784/3bbc09d2-68fa-401f-aee3-998a8e81b37a"> | <img width="469" alt="Screenshot 2023-08-07 at 1 53 56 PM" src="https://github.com/18F/handbook/assets/458784/ef4a1bf8-8502-481c-a08c-752707cb76c7"> |
| <img width="461" alt="Screenshot 2023-08-07 at 1 54 07 PM" src="https://github.com/18F/handbook/assets/458784/a27e3aa1-99b2-4e82-841d-7d609f034bad"> | <img width="461" alt="Screenshot 2023-08-07 at 1 54 07 PM" src="https://github.com/18F/handbook/assets/458784/a27e3aa1-99b2-4e82-841d-7d609f034bad"> |

### Bonus Changes

Also updates README instructions for local development



## security considerations

- Removing an extra layer of HTML processing should be safe?