### PR TITLE
Replace broken link

### DIFF
--- a/pages/general-information-and-resources/software.md
+++ b/pages/general-information-and-resources/software.md
@@ -136,7 +136,7 @@ review will also start during the Micropurchase request process.
 
 ## Links & policies
 
-- [Chrome extensions](https://insite.gsa.gov/topics/information-technology/assistance-and-help-desks/service-catalog/it-service-catalog-google-chrome-extension-request?term=google%20extensions)
+- [Chrome extensions]([https://insite.gsa.gov/topics/information-technology/assistance-and-help-desks/service-catalog/it-service-catalog-google-chrome-extension-request?term=google%20extensions](https://insite.gsa.gov/employee-resources/information-technology/it-help-desk-and-assistance/service-catalog/google-chrome-extension-request))
 - [GitHub integrations]({% page "/tools/github/#rules" %})
 - [Google Cloud / G Suite services, including APIs](https://docs.google.com/spreadsheets/d/1h0338doPlHIfslS7Huypzs7TlJTFVw_-98oPnum0Cvo/edit#gid=467863101)
 - [Slack integrations]({% page "/tools/slack/integrations/" %})


### PR DESCRIPTION
## Changes proposed in this pull request:

- Replace broken "Chrome extensions" link
- Old link: https://insite.gsa.gov/employee-resources/information-technology/it-assistance-and-help-desk/service-catalog/google-chrome-extension-request?term=google%20extensions
- New link: https://insite.gsa.gov/employee-resources/information-technology/it-help-desk-and-assistance/service-catalog/google-chrome-extension-request

## security considerations

[Note the any security considerations here, or make note of why there are none]
