### PR TITLE
Added U.S. Digital Corps presentation template to external speaking r…

### DIFF
--- a/pages/training-and-development/external-speaking-request-playbook.md
+++ b/pages/training-and-development/external-speaking-request-playbook.md
@@ -245,6 +245,12 @@ As your speaking engagement is moving through the approval process, take some ti
    <td></td>
    <td></td>
   </tr>  
+  <tr>
+   <td><a href="https://docs.google.com/presentation/d/1hcMLKckygjW13pYMLvz9CEa0STTGpI4oDneJLs0IH68/edit#slide=id.g137f58abcf2_1_0">U.S. Digital Corps template</a></td>
+   <td></td>
+   <td></td>
+   <td></td>
+  </tr>  
 </table>
 
 - Is your presentation accessible? Do you verbally describe the images on your


### PR DESCRIPTION
## Changes proposed in this pull request:

- Completes [Issue#3864: Add USDC template to list](https://github.com/18F/handbook/issues/3684). Adds link to USDC presentation template to external speaking requests page.

## security considerations

[Note the any security considerations here, or make note of why there are none]
