### PR TITLE
Add line break to research guild paragraphs

### DIFF
--- a/pages/18f/how-18f-works/research-guidelines.md
+++ b/pages/18f/how-18f-works/research-guidelines.md
@@ -304,4 +304,5 @@ Portfolio]({% page "/office-of-solutions/tech-portfolio/#questions" %}).
 ## Join the research guild!
 
 Learn more about the research guild in our [README.](https://docs.google.com/document/d/1kc73HuxXWxr4RIKG0aeHSW3VFK5SRD597vZNfX4_huM/edit#heading=h.wdpwcv6e5j47)
+
 [Learn more about guilds at TTS here.]({% page "/training-and-development/working-groups-and-guilds-101/#current-guilds" %})


### PR DESCRIPTION
## Add line break to Join the Research Guild section's paragraphs in Research Guidelines page (needs handbook admin review)

- Formatting bug fix to [PR for Add Research Guild README](https://github.com/18F/handbook/pull/3698). Adds line break to separate the two new paragraphs from PR.

## security considerations

Line break was manually added to markdown file. No security considerations at the moment.