### PR TITLE
Update working-groups-and-guilds-101.md

### DIFF
--- a/pages/training-and-development/working-groups-and-guilds-101.md
+++ b/pages/training-and-development/working-groups-and-guilds-101.md
@@ -54,8 +54,7 @@ The invite-only affinity groups are:
 
 - **Latinx** — A space for people who identify as Latinx, Hispanic, Chicanx,
   Boricua, Cubano, etc.
-- **Asian and Pacific Islanders** — A place for Asian and Pacific Islander TTS
-  staff members to hang out and talk.
+- **Asian, Native Hawaiian, and Pacific Islanders** — A place for Asian, Native Hawaiian, and Pacific Islander TTS staff members to hang out and talk. Open to any member of the Asian diaspora.
 - **Working While Black** — A space for Black TTS staff members.
 - **Shalom Jews** — A space for TTS employees that consider themselves Jewish,
   Jew-ish, Jew-curious, culturally Jewish, or anything else!


### PR DESCRIPTION
I am the lead for the Asian, Native Hawaiian, and Pacific Islanders affinity group. We recently voted to change our name to be more inclusive, and the description also reflects that change. Compared to the other entries, I don't think I formatted change/entry correctly - would appreciate help with that! Thank you!

## Changes proposed in this pull request:

- Change "Asian and Pacific Islanders" affinity group to "Asian, Native Hawaiian, and Pacific Islanders"
- Change affinity group description from "A place for Asian and Pacific Islander TTS staff members to hang out and talk." to "A place for Asian, Native Hawaiian, and Pacific Islander TTS staff members to hang out and talk. Open to any member of the Asian diaspora."

## security considerations

[Note the any security considerations here, or make note of why there are none]
