### PR TITLE
Add link to policy for Gmail iOS app

### DIFF
--- a/pages/getting-started/equipment.md
+++ b/pages/getting-started/equipment.md
@@ -174,10 +174,14 @@ activating your iPhone.
     these applications, you can use SMS, or
     [Google Authenticator](https://support.google.com/accounts/answer/1066447?hl=en).
 
-- **Only use Apple's default Mail app to access your GSA email.** You must
+- **Only use Apple's default Mail app to access your GSA email.[^ios-gmail]** You must
   [generate an App Password](https://support.google.com/accounts/answer/185833?hl=en)
   in your Google account to use with your Mail app, instead of your normal email
   password.
+
+[^ios-gmail] The GMail app for iOS is on the [GSA Mobile App ban list](https://sites.google.com/a/gsa.gov/mobileinfo/banned-mobile-apps)
+due to the inability to centrally manage the app at this time.
+
 
 ### Tips
 

--- a/pages/getting-started/equipment.md
+++ b/pages/getting-started/equipment.md
@@ -179,13 +179,13 @@ activating your iPhone.
   in your Google account to use with your Mail app, instead of your normal email
   password.
 
-{%- capture ios_gmail_app -%}
-**Note:** The GMail app for iOS is not currently allowed and is listed on the
-[GSA Mobile App ban list](https://sites.google.com/a/gsa.gov/mobileinfo/banned-mobile-apps)
-due to the inability to centrally manage the app at this time.
-{%- endcapture %}
-
-{% include alert.html content=ios_gmail_app alert_class="usa-alert--info" %}
+{% include "alert.html"
+   content: "
+     **Note:** The GMail app for iOS is not currently allowed and is listed on the
+     [GSA Mobile App ban list](https://sites.google.com/a/gsa.gov/mobileinfo/banned-mobile-apps)
+     due to the inability to centrally manage the app at this time.
+   "
+%}
 
 ### Tips
 

--- a/pages/getting-started/equipment.md
+++ b/pages/getting-started/equipment.md
@@ -180,11 +180,9 @@ activating your iPhone.
   password.
 
 {% include "alert.html"
-   content: "
-     **Note:** The GMail app for iOS is not currently allowed and is listed on the
-     [GSA Mobile App ban list](https://sites.google.com/a/gsa.gov/mobileinfo/banned-mobile-apps)
-     due to the inability to centrally manage the app at this time.
-   "
+   content: "The GMail app for iOS is not not permitted due
+             to lack of MDM management support. See
+             [GSA Mobile App ban list](https://sites.google.com/a/gsa.gov/mobileinfo/banned-mobile-apps)"
 %}
 
 ### Tips

--- a/pages/getting-started/equipment.md
+++ b/pages/getting-started/equipment.md
@@ -174,14 +174,18 @@ activating your iPhone.
     these applications, you can use SMS, or
     [Google Authenticator](https://support.google.com/accounts/answer/1066447?hl=en).
 
-- **Only use Apple's default Mail app to access your GSA email.[^ios-gmail]** You must
+- **Only use Apple's default Mail app to access your GSA email.** You must
   [generate an App Password](https://support.google.com/accounts/answer/185833?hl=en)
   in your Google account to use with your Mail app, instead of your normal email
   password.
 
-[^ios-gmail] The GMail app for iOS is on the [GSA Mobile App ban list](https://sites.google.com/a/gsa.gov/mobileinfo/banned-mobile-apps)
+{%- capture ios_gmail_app -%}
+**Note:** The GMail app for iOS is not currently allowed and is listed on the
+[GSA Mobile App ban list](https://sites.google.com/a/gsa.gov/mobileinfo/banned-mobile-apps)
 due to the inability to centrally manage the app at this time.
+{%- endcapture %}
 
+{% include alert.html content=ios_gmail_app alert_class="usa-alert--info" %}
 
 ### Tips
 

--- a/pages/getting-started/equipment.md
+++ b/pages/getting-started/equipment.md
@@ -180,7 +180,7 @@ activating your iPhone.
   password.
 
 {% include "alert.html"
-   content: "The GMail app for iOS is not not permitted due
+   content: "The Gmail app for iPhone/iOS is not not permitted due
              to lack of MDM management support. See
              [GSA Mobile App ban list](https://sites.google.com/a/gsa.gov/mobileinfo/banned-mobile-apps)"
 %}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add a note with citation for the ban on the Gmail app for iOS.

## security considerations

- The link points to a private informational GSA site.