### PR TITLE
Remove instances of "the the" from handbook text

### DIFF
--- a/pages/18f/how-18f-works/one-on-ones.md
+++ b/pages/18f/how-18f-works/one-on-ones.md
@@ -200,7 +200,7 @@ After all, if your partner is constantly coming to 1:1s with meaty topics that
 take all the time, that stuff’s probably well worth the time. And, you can
 always ask your partner for more time, and they’ll rarely say “no”.
 
-As for the the specifics of your agenda: much of the time you’ll have an idea of
+As for the specifics of your agenda: much of the time you’ll have an idea of
 what you need to discuss based on whatever’s going on for you and your partner.
 That said, here are a few ideas of things you might want to think about
 discussing:

--- a/pages/18f/how-18f-works/research-guidelines.md
+++ b/pages/18f/how-18f-works/research-guidelines.md
@@ -273,7 +273,7 @@ documents with PII, they always go into a locked file cabinet.
 
 A good rule is to check with your project lead before sharing information
 outside the immediate team. What has been approved by GSA may not be approved by
-partners. Check the the [Design chapter
+partners. Check the [Design chapter
 page]({% page "/design/#designing-in-the-open" %}) for detailed information
 about who can see what, when. The social media, collaboration, and security
 classes in GSA's Online University can also be helpful in managing access.

--- a/pages/18f/projects-partners/acquisition-engagement-types.md
+++ b/pages/18f/projects-partners/acquisition-engagement-types.md
@@ -61,7 +61,7 @@ Acquisition is staffed to the engagement along with the required 18F cross
 functional team. The acquisition lead on the 18F team will take the lead on
 engaging with the Contracting Officer on setting up the procurement, developing
 soliciting materials, helping to identify potential vendors, and will work
-closely with others in the cross functional team at various phases of the the
+closely with others in the cross functional team at various phases of the
 procurement. The designated 18F Team lead will still engage with the partner
 POC, if different than the CO, and will work in tandem.
 

--- a/pages/launching-software/security.md
+++ b/pages/launching-software/security.md
@@ -233,7 +233,7 @@ We gave an introduction to ZAP talk as part of our engineering tech talks series
 Slides and additional information available
 [here](https://github.com/18F/tech-talks/tree/main/talk-materials/vuln-scanning).
 
-Using the the
+Using the
 [Quick Start](https://www.zaproxy.org/docs/desktop/addons/quick-start/) is a
 good way to get a basic idea of what ZAP does.
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Strike one "the" from the typo "the the" throughout the handbook
