### PR TITLE
Post-enterprise acquisition update

### DIFF
--- a/pages/tools/airtable.md
+++ b/pages/tools/airtable.md
@@ -6,8 +6,14 @@ redirect_from:
   - /tools/airtable/
 ---
 
-You can sign up for [Airtable](https://airtable.com/)'s free plan with your GSA
-email. For an [upgraded license](https://airtable.com/pricing), put in a
-[micropurchase request]({% page "/purchase-requests/" %}).
+TTS now has an Enterprise contract with [Airtable](https://airtable.com/). 
+
+Licenses that allow edit access are allocated on a per team basis. The license managers for each group are listed [here](https://docs.google.com/spreadsheets/d/1lbf8mkD4eJuKlRg5Uw2r1FHx3YCAiZp7P9qcoEG6rnk/edit#gid=0). If you are part of one of these teams, you can reach out to the listed point of contract in order to request one of the limited licenses.
+
+If you are on another team that does not yet have an allocation of Airtable licenses but is interested in using it, hang in there! Additional licenses are coming soon, as long as your team has completed the survey (link to survey coming soon).
+
+View-only licenses are free! Any existing Airtable user should be able to grant you one by default by sharing view-only access to an existing base, but should you run into any difficulty, you can reach out in [#airtable-smartsheet](https://app.slack.com/client/T025AQGAN/C6YNTUPS9).
+
+A more complete guide to Airtable, complete with training resources, can be found [here](https://airtable.com/appQbn3D4GMM8SD0O/pagjMkXUv7fCeTWIZ), though you will need to have at least a viewer licenses to Airtable in order to access it. More materials, including additional guidance on privacy, common use cases, and FAQs is coming soon.
 
 {% include "low-system.html" %}


### PR DESCRIPTION
Updated details on how to get a license plus a link to the new TTS Airtable user guide.
