### PR TITLE
Clarify language around SF-182 requirement for buying books

### DIFF
--- a/pages/training-and-development/conferences-events-training.md
+++ b/pages/training-and-development/conferences-events-training.md
@@ -195,7 +195,7 @@ question, enter the website where the book can be purchased.
 When you have submitted that form, you and your supervisor will receive an email
 with further instructions. In the case where the book is not being used for
 training, the only thing that needs to be done is an email from your supervisor
-approving the purchase. If the book is being used in a training, then there are
+approving the purchase. If the book is being used for training purposes, then there are
 further tasks to be completed with form SF-182 as detailed in that initial
 response email.
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Based on conversations with a member of the Operations team, this changes the language for the SF-182 to be "for training purposes" rather than "in a training". Specifically, the language used for determining whether an SF-182 is required when purchasing is a book is:

> Is this book(s) being used for training?

Ultimately, whether or not a book is "training" is determined by the approving supervisor, so I am reluctant to make further suggestions to the paragraph on whether filling out an SF-182 is required (but it seems like it would be as a layperson). I think it may be helpful to set the expectation that it's likely required if that is the case though.

## security considerations

No security considerations, this should strictly be a change in content.