### PR TITLE
Update travel office hours scheduling link

### DIFF
--- a/pages/general-information-and-resources/purchase-requests.md
+++ b/pages/general-information-and-resources/purchase-requests.md
@@ -4,7 +4,7 @@ questions:
   - micropurchase
   - tts-purchasers@gsa.gov
   - text: Book office hours
-    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
+    url: https://calendar.google.com/calendar/u/0/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg
 redirect_from:
   - /purchase-requests/
 cSpell: ignore dotgov

--- a/pages/getting-started/classes/travel-101.md
+++ b/pages/getting-started/classes/travel-101.md
@@ -103,7 +103,7 @@ in Concur.
 in Concur, and answering most\* of the questions you might have along the way.
 You can reach them either via email at tts-travel@gsa.gov, in Slack in the
 #travel channel, or by booking
-[travel/purchase office hours](https://sites.google.com/a/gsa.gov/tts-office-hours/).
+[travel/purchase office hours](https://calendar.google.com/calendar/u/0/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg).
 Note that the travel team won't be available to immediately assist with your
 inquiry, though the team endeavors to answer all questions that come through by
 their next office hours which are twice daily. Properly submitted authorizations

--- a/pages/office-of-operations/bizops.md
+++ b/pages/office-of-operations/bizops.md
@@ -49,7 +49,7 @@ policy, regulations and bureaucratic requirements.
   - Contact: tts-events@gsa.gov; {% slack_channel "training-conferences" %}
 - [Travel]({% page "/travel-guide-table-of-contents/" %})
   - Contact: tts-travel@gsa.gov; {% slack_channel "travel" %};
-    [office hours](https://sites.google.com/a/gsa.gov/tts-office-hours/)
+    [office hours](https://calendar.google.com/calendar/u/0/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg)
 - Personnel Actions
   - moving within the org
   - [requesting a higher security clearance]({% page "/top-secret/" %})

--- a/pages/training-and-development/conferences-events-training.md
+++ b/pages/training-and-development/conferences-events-training.md
@@ -163,7 +163,7 @@ You are responsible for cancelling all reservations (e.g. flight, hotel, rental
 car) if your event is not approved. Always **check the cancellation policy
 before booking** because you may be responsible for paying the cancellation
 fee(s). You can ask questions in {% slack_channel "travel" %} or during
-[travel office hours](https://sites.google.com/a/gsa.gov/tts-office-hours/).
+[travel office hours](https://calendar.google.com/calendar/u/0/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg).
 
 ## Remote working guidance
 

--- a/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-complete-concur-profile.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-complete-concur-profile.md
@@ -5,7 +5,7 @@ questions:
   - travel
   - tts-travel@gsa.gov
   - text: Book office hours
-    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
+    url: https://calendar.google.com/calendar/u/0/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg
 redirect_from:
   - /first-time-travel-complete-concur-profile/
 step_indicator:

--- a/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-get-in-concur-pre-olu.md
@@ -5,7 +5,7 @@ questions:
   - travel
   - tts-travel@gsa.gov
   - text: Book office hours
-    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
+    url: https://calendar.google.com/calendar/u/0/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg
 redirect_from:
   - /first-time-travel-get-in-concur-pre-olu/
 sidebar:
@@ -79,7 +79,7 @@ with rates under the government maximum (also known as the per diem rate).
    Once you get access, you can follow [these instructions for how to complete a
    voucher]({% page "/travel-and-leave/travel-and-leave-policies/travel-guide-4-reimbursement/" %}).
    Feel free to
-   [book travel office hours here](https://sites.google.com/a/gsa.gov/tts-office-hours/)
+   [book travel office hours here](https://calendar.google.com/calendar/u/0/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg)
    any time should you need any assistance.
 
 ### What happens if my flight gets cancelled?

--- a/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-get-in-concur.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-get-in-concur.md
@@ -5,7 +5,7 @@ questions:
   - travel
   - tts-travel@gsa.gov
   - text: Book office hours
-    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
+    url: https://calendar.google.com/calendar/u/0/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg
 redirect_from:
   - /first-time-travel-get-in-concur/
 step_indicator:
@@ -86,7 +86,7 @@ by reading the_ _[FAQ below](#frequently-asked-questions)_
 Email completed CGE form to [tts-travel@gsa.gov](mailto:tts-travel@gsa.gov). _Do
 not email it to cge-access-requests@gsa.gov,_ as the form specifies. Only email
 it to tts-travel@gsa.gov. Your account will be set up before
-[the next travel office hours](https://sites.google.com/a/gsa.gov/tts-office-hours/),
+[the next travel office hours](https://calendar.google.com/calendar/u/0/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg),
 which you can also book any time if you have questions.
 
 [Next Step: First-Time Travel - Get a Travel

--- a/pages/travel-and-leave/travel-and-leave-policies/travel-guide-2-book-travel.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/travel-guide-2-book-travel.md
@@ -5,7 +5,7 @@ questions:
   - travel
   - tts-travel@gsa.gov
   - text: Book office hours
-    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
+    url: https://calendar.google.com/calendar/u/0/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg
 redirect_from:
   - /travel-guide-1-book-travel/
   - /travel-and-leave/travel-and-leave-policies/travel-guide-1-book-travel/

--- a/pages/travel-and-leave/travel-and-leave-policies/travel-guide-3-travel.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/travel-guide-3-travel.md
@@ -5,7 +5,7 @@ questions:
   - travel
   - tts-travel@gsa.gov
   - text: Book office hours
-    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
+    url: https://calendar.google.com/calendar/u/0/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg
 redirect_from:
   - /travel-guide-2-travel/
   - /travel-and-leave/travel-and-leave-policies/travel-guide-2-travel/
@@ -99,7 +99,7 @@ administrative work when submitting a voucher after returning from your trip.
 what you should be aware of when completing your voucher-- should you use the
 GSA travel card for meals and incidental expenses, keeping receipts for your
 personal use may be helpful. Feel free to book
-[travel office hours](https://sites.google.com/a/gsa.gov/tts-office-hours/) for
+[travel office hours](https://calendar.google.com/calendar/u/0/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg) for
 a walkthrough on what to keep in mind when paying for meals while traveling.
 
 ### Other necessary expenses

--- a/pages/travel-and-leave/travel-and-leave-policies/travel-guide-4-reimbursement.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/travel-guide-4-reimbursement.md
@@ -5,7 +5,7 @@ questions:
   - travel
   - tts-travel@gsa.gov
   - text: Book office hours
-    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
+    url: https://calendar.google.com/calendar/u/0/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg
 redirect_from:
   - /travel-guide-3-reimbursement/
   - /travel-and-leave/travel-and-leave-policies/travel-guide-3-reimbursement/

--- a/pages/travel-and-leave/travel-and-leave-policies/travel-guide-a-amended-authorizations.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/travel-guide-a-amended-authorizations.md
@@ -5,7 +5,7 @@ questions:
   - travel
   - tts-travel@gsa.gov
   - text: Book office hours
-    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
+    url: https://calendar.google.com/calendar/u/0/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg
 redirect_from:
   - /travel-guide-a-amended-authorizations/
 sidebar:

--- a/pages/travel-and-leave/travel-and-leave-policies/travel-guide-b-after-hours-emergency-travel-authorizations.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/travel-guide-b-after-hours-emergency-travel-authorizations.md
@@ -5,7 +5,7 @@ questions:
   - travel
   - tts-travel@gsa.gov
   - text: Book office hours
-    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
+    url: https://calendar.google.com/calendar/u/0/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg
 redirect_from:
   - /travel-guide-b-after-hours-emergency-travel-authorizations/
 sidebar:

--- a/pages/travel-and-leave/travel-and-leave-policies/travel-guide-email-templates.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/travel-guide-email-templates.md
@@ -5,7 +5,7 @@ questions:
   - travel
   - tts-travel@gsa.gov
   - text: Book office hours
-    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
+    url: https://calendar.google.com/calendar/u/0/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg
 redirect_from:
   - /travel-guide-email-templates/
 step_indicator:

--- a/pages/travel-and-leave/travel-and-leave-policies/travel-guide-faq.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/travel-guide-faq.md
@@ -5,7 +5,7 @@ questions:
   - travel
   - tts-travel@gsa.gov
   - text: Book office hours
-    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
+    url: https://calendar.google.com/calendar/u/0/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg
 redirect_from:
   - /travel-guide-faq/
 sidebar:

--- a/pages/travel-and-leave/travel-guide-table-of-contents.md
+++ b/pages/travel-and-leave/travel-guide-table-of-contents.md
@@ -4,7 +4,7 @@ questions:
   - travel
   - tts-travel@gsa.gov
   - text: Book office hours
-    url: https://sites.google.com/a/gsa.gov/tts-office-hours/
+    url: https://calendar.google.com/calendar/u/0/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg
 redirect_from:
   - /travel-guide-table-of-contents/
 sidebar:


### PR DESCRIPTION
## Changes proposed in this pull request:

This PR attempts to update all TTS office hours links to use a new URL. The replace was done with `sed`:

```
sed -i '' -e 's/https:\/\/sites.google.com\/a\/gsa.gov\/tts-office-hours\//https:\/\/calendar.google.com\/calendar\/u\/0\/selfsched?cid=ZGplbWlsYS5tY2NyYXlAZ3NhLmdvdg/g' $(find pages/**/* -type f -print)
```

I searched the repository for `tts-office-hours` after running the above, and I didn't find any other matches, so _I think_ this is all of them.

## security considerations

No security considerations, this should strictly be a change in content.
