### PR TITLE
Avoid "click here" links

### DIFF
--- a/pages/18f/how-18f-works/research-guidelines.md
+++ b/pages/18f/how-18f-works/research-guidelines.md
@@ -300,5 +300,5 @@ Portfolio]({% page "/office-of-solutions/tech-portfolio/#questions" %}).
 
 ## Join the research guild!
 
-Learn more about the research guild in our [README.](https://docs.google.com/document/d/1kc73HuxXWxr4RIKG0aeHSW3VFK5SRD597vZNfX4_huM/edit#heading=h.wdpwcv6e5j47)
-[Learn more about guilds at TTS here.]({% page "/training-and-development/working-groups-and-guilds-101/#current-guilds" %})
+- Learn more about the research guild in our [README.](https://docs.google.com/document/d/1kc73HuxXWxr4RIKG0aeHSW3VFK5SRD597vZNfX4_huM/edit#heading=h.wdpwcv6e5j47)
+- [Learn more about guilds at TTS.]({% page "/training-and-development/working-groups-and-guilds-101/#current-guilds" %})

--- a/pages/general-information-and-resources/glossary.md
+++ b/pages/general-information-and-resources/glossary.md
@@ -67,8 +67,7 @@ cSpell: ignore Technica
   something down temporarily for maintenance — go for it, not an incident.
 
 - **AWS** - Amazon Web Services. Some TTS services use AWS to host websites.
-  Read easy-to-understand descriptions of the different pieces
-  [here](https://www.expeditedssl.com/aws-in-plain-english).
+  Read [easy-to-understand descriptions of the different pieces](https://www.expeditedssl.com/aws-in-plain-english).
 
 - **AWS** - Alternative Work Schedule. Working eight, 10-hour days or working
   nine, nine-hour days in a pay period.

--- a/pages/general-information-and-resources/software.md
+++ b/pages/general-information-and-resources/software.md
@@ -73,7 +73,7 @@ Government issued device.
 
 Step 3 - If it is not located in the TTS Handbook or the GSA Self Service
 application, submit a service desk request to have it installed:
-[Start a Software request here](https://gsa.servicenowservices.com/nav_to.do?uri=%2Fsp%3Fid%3Dkb_article%26sys_id%3D18833608db0e3b040e1d368d7c9619fb).
+[Start a Software request](https://gsa.servicenowservices.com/nav_to.do?uri=%2Fsp%3Fid%3Dkb_article%26sys_id%3D18833608db0e3b040e1d368d7c9619fb).
 
 #### For Software-as-a-Service (SaaS)
 

--- a/pages/getting-started/equipment.md
+++ b/pages/getting-started/equipment.md
@@ -251,8 +251,7 @@ a
 [Non-Standard Equipment Request](https://gsa.servicenowservices.com/sp?id=sc_cat_item&sys_id=ed419ee8dbd2e7000dc9ff621f9619c6)
 via the GSA IT Service Desk.
 
-If you need to setup a printer while in the office, follow the instructions
-[here](https://insite.gsa.gov/employee-resources/information-technology/do-it-yourself-self-help/telework-technology?term=printer%20driver#Print).
+If you need to setup a printer while in the office, follow [the instructions](https://insite.gsa.gov/employee-resources/information-technology/do-it-yourself-self-help/telework-technology?term=printer%20driver#Print).
 
 ## Equipment to accommodate disability
 

--- a/pages/getting-started/index.md
+++ b/pages/getting-started/index.md
@@ -45,7 +45,7 @@ At TTS, collaboration is a part of our culture. Here are the collaboration tools
 
 ### Video conferencing tools
 - **Google Meet** and **Zoom** are the primary video conferencing tools used at TTS. [Google Meet]({% page "/tools/google-meet/" %}) is typically used for internal TTS/GSA meetings, while [Zoom]({% page "/tools/zoom/" %}) is often used for larger meetings (for example, GSA Town Halls or TTS All Hands) and meetings with our partners or other external stakeholders. Some teams also use [Slack](https://slack.com/help/articles/216771908-Make-calls-in-Slack) for quick conversations and/or meetings as well. 
-- In some cases, we may pre-record meeting sessions and/or provide post-event recordings to ensure our employees don’t miss out on important information. Click here to [view a video of a recorded meeting](https://drive.google.com/file/d/1k_ZxSnvCIxw80awsrfvjfFp-VVM7WscM/view?usp=share_link). *Please note: the host of the meeting is required to notify participants they are recording prior to starting the recording.*
+- In some cases, we may pre-record meeting sessions and/or provide post-event recordings to ensure our employees don’t miss out on important information. [View a video of a recorded meeting](https://drive.google.com/file/d/1k_ZxSnvCIxw80awsrfvjfFp-VVM7WscM/view?usp=share_link). *Please note: the host of the meeting is required to notify participants they are recording prior to starting the recording.*
 - Some types of meetings you might attend include: one-on-ones, [trainings]({% page "/training-and-development/" %}), virtual coffees, team meetings/daily stand-ups, TTS-wide meetings (Town Halls and All Hands), plus many more! 
 
 ### Collaboration tools

--- a/pages/performance-management/employee-resources.md
+++ b/pages/performance-management/employee-resources.md
@@ -80,9 +80,8 @@ end-of-year 1:1 performance review conversation.
 ### Acquisition Critical Element
 
 All CORs on active delegation must have the new Acquisition Critical Element on
-their Performance Plan. For guidance on adding this critical element to
-performance plans
-[click here](https://drive.google.com/file/d/1hOu4GtwpjCAUXenXNE7Vit3O3ldDYSRb/view).
+their Performance Plan. Read [guidance](https://drive.google.com/file/d/1hOu4GtwpjCAUXenXNE7Vit3O3ldDYSRb/view) on adding this critical element to
+performance plans.
 
 ## Training
 

--- a/pages/performance-management/supervisor-resources.md
+++ b/pages/performance-management/supervisor-resources.md
@@ -247,15 +247,12 @@ vacation) or refuses to do so (i.e. does not agree with the evaluation).
 ### Leveraging diversity performance measure
 
 All **supervisory performance plans** must include the “Leveraging Diversity”
-measure. For guidance on adding this to supervisory plans
-[click here](https://docs.google.com/document/d/1LPe6rKUze_tA3OfHhRLUfLSQtY4m8d4J3k4OZq2oFcY/edit#heading=h.7ki5n23m5zhy).
+measure. [Guidance on adding this to supervisory plans](https://docs.google.com/document/d/1LPe6rKUze_tA3OfHhRLUfLSQtY4m8d4J3k4OZq2oFcY/edit#heading=h.7ki5n23m5zhy).
 
 ### Acquisition Critical Element
 
 All CORs on active delegation must have the new Acquisition Critical Element on
-their Performance Plan. For guidance on adding this critical element to
-performance plans
-[click here](https://drive.google.com/file/d/1hOu4GtwpjCAUXenXNE7Vit3O3ldDYSRb/view).
+their Performance Plan. [Guidance on adding this critical element to performance plans](https://drive.google.com/file/d/1hOu4GtwpjCAUXenXNE7Vit3O3ldDYSRb/view).
 
 ## Additional training
 

--- a/pages/tools/slack/integrations.md
+++ b/pages/tools/slack/integrations.md
@@ -18,8 +18,7 @@ We have a few different Slack Apps and bots you'll see in Slack:
   `coffee me` to set up a virtual coffee/tea with a random coworker.
 - [Slackbot](https://get.slack.help/hc/en-us/articles/202026038-Slackbot-your-assistant-notepad-programmable-bot):
   We automate responses to frequently asked questions with a Slackbot. You can
-  update or customize responses
-  [here](https://gsa-tts.slack.com/customize/slackbot). **Do not
+  [update or customize responses](https://gsa-tts.slack.com/customize/slackbot). **Do not
   include private or sensitive information in Slackbot automatic responses.**
 - [TTS Inspector](https://github.com/18F/tts-tech-portfolio/tree/main/inspector):
   Our auditing bot

--- a/pages/training-and-development/conferences-events-training.md
+++ b/pages/training-and-development/conferences-events-training.md
@@ -72,7 +72,7 @@ notes on the process for allocating 18F training funds.
 1. You will receive an automated email when your request has been fully approved
    and paid for or if additional information is needed to complete your
    registration. You can
-   [track the status of your request here](https://docs.google.com/spreadsheets/d/1HqsdJ-pHZcg4n8vWwfOo8-sxAFfP1LtWxRVBWEbZnMA/edit#gid=0)
+   [track the status of your request](https://docs.google.com/spreadsheets/d/1HqsdJ-pHZcg4n8vWwfOo8-sxAFfP1LtWxRVBWEbZnMA/edit#gid=0)
    with the request number in the subject line of the automated email.
 
 _Important note about conference travel:_ If you are traveling to a conference
@@ -114,7 +114,7 @@ as early as possible.
   - Group Conference Training/Attendance
 
 You can
-[track the status of your request here](https://docs.google.com/spreadsheets/d/1HqsdJ-pHZcg4n8vWwfOo8-sxAFfP1LtWxRVBWEbZnMA/edit#gid=0)
+[track the status of your request](https://docs.google.com/spreadsheets/d/1HqsdJ-pHZcg4n8vWwfOo8-sxAFfP1LtWxRVBWEbZnMA/edit#gid=0)
 with the request number in the subject line of the automated email.
 
 ## Additional steps that you may need to take

--- a/pages/training-and-development/intro-to-github.md
+++ b/pages/training-and-development/intro-to-github.md
@@ -55,7 +55,7 @@ code.
 
 ### Set up your account
 
-Follow the instructions [here]({% page "/github/" %})
+Follow the [instructions]({% page "/github/" %})
 
 ### Basics
 

--- a/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-complete-concur-profile.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-complete-concur-profile.md
@@ -62,5 +62,4 @@ authorization]({% page "/travel-and-leave/travel-and-leave-policies/travel-guide
 
 #### Having Trouble
 
-Check out the screen shots
-[here](https://docs.google.com/drawings/d/1eP5E7Tq1K4Iva7aNSHjLukJcZzD2Cdkf6LCoEDRzsFM/edit)
+Check out [the screen shots](https://docs.google.com/drawings/d/1eP5E7Tq1K4Iva7aNSHjLukJcZzD2Cdkf6LCoEDRzsFM/edit)

--- a/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-get-in-concur.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-get-in-concur.md
@@ -70,8 +70,8 @@ GSA travel card]({% page "/first-time-travel-travel-card" %}).
 ### 2. Check that you have completed required training
 
 Ensure you have completed the mandatory security and privacy training required
-of all GSA staff, assigned to you in OLU (https://gsaolu.gsa.gov). Follow the
-instructions [here]({% page "/training-and-development/olu/#help-with-olu" %})
+of all GSA staff, assigned to you in OLU (https://gsaolu.gsa.gov). [Follow the
+[instructions]({% page "/training-and-development/olu/#help-with-olu" %})
 if you need help.
 
 ### 3. Complete the CGE Access Request Form

--- a/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-travel-card.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-travel-card.md
@@ -30,9 +30,9 @@ expenses while on your trip.
 While new employees may travel without one, it is required that everyone at TTS
 have one as soon as possible.
 
-[Instructions for applying for a GSA Travel Card](https://insite.gsa.gov/employee-resources/acquisition-purchases-and-payments/gsa-travel-card/application-renewal-procedures)
+- [Instructions for applying for a GSA Travel Card](https://insite.gsa.gov/employee-resources/acquisition-purchases-and-payments/gsa-travel-card/application-renewal-procedures)
 
-[Visit the GSA SmartPay 3 travel card page for more information](https://smartpay.gsa.gov/content/travel).
+- [Visit the GSA SmartPay 3 travel card page for more information](https://smartpay.gsa.gov/content/travel).
 
-[Next Step: Complete Your Concur
+- [Next Step: Complete Your Concur
 Profile]({% page "/first-time-travel-complete-concur-profile" %})

--- a/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-travel-card.md
+++ b/pages/travel-and-leave/travel-and-leave-policies/first-time-travel-travel-card.md
@@ -30,7 +30,7 @@ expenses while on your trip.
 While new employees may travel without one, it is required that everyone at TTS
 have one as soon as possible.
 
-Instructions for applying for a GSA Travel Card can be found [here](https://insite.gsa.gov/employee-resources/acquisition-purchases-and-payments/gsa-travel-card/application-renewal-procedures)
+[Instructions for applying for a GSA Travel Card](https://insite.gsa.gov/employee-resources/acquisition-purchases-and-payments/gsa-travel-card/application-renewal-procedures)
 
 [Visit the GSA SmartPay 3 travel card page for more information](https://smartpay.gsa.gov/content/travel).
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- I removed "click here" and similar language from some hyperlinks [per policy](https://handbook.tts.gsa.gov/updating-the-handbook/#disclaimers-and-cautions)
- Also, added some bullet points

