### PR TITLE
updates consulting guild page with co-lead and links

### DIFF
--- a/cSpell.json
+++ b/cSpell.json
@@ -87,6 +87,7 @@
     "ISSM",
     "ISSO",
     "ITSS",
+    "Janel",
     "Jamboard",
     "Kanban",
     "Keychain",
@@ -215,7 +216,8 @@
     "wireframes",
     "womxn",
     "workshopping",
-    "XKCD"
+    "XKCD",
+    "Yamashiro"
   ],
   "ignoreWords": [],
   "patterns": [

--- a/pages/training-and-development/working-groups-and-guilds-101.md
+++ b/pages/training-and-development/working-groups-and-guilds-101.md
@@ -148,11 +148,13 @@ Guild meeting times can also be found on the
       <tr>
         <th class="col-grouplet" id="consulting">Consulting</th>
         <td class="col-description">
-          We develop and support the practice of consulting at TTS.<br /> {% slack_channel "g-consulting" %}
+          We develop and support the practice of consulting at TTS.<br />
+          <a href="https://forms.gle/WfDXRH6VobxSscbw9">2024 survey</a> &bull; {% slack_channel "g-consulting" %}
         </td>
         <td>
-          Matt Cloyd - 18F<br />
-	  Jessica Dussault - 18F
+    Janel Yamashiro - 18F<br />
+	  Jessica Dussault - 18F<br />
+    <em>Seeking a co-lead! <a href="https://gsa-tts.slack.com/archives/D02SFCEPEPP">DM Janel if interested!</a></em>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
## Changes proposed in this pull request:

- updates the current consulting guild co-leads
- adds the consulting guild interest survey link
- announces search for co-lead and contact info

The Affinity groups, working groups, guilds, and other communities page will look something like this when merged:

![image](https://github.com/18F/handbook/assets/2480492/ac16edc4-58a2-46fb-ae26-ad67fd1b89bf)
(alt text: three rows of guilds, accessibility, consulting, and content. The consulting guild has a 2024 survey link, and the message Seeking a co-lead, DM Janel if interested with a link to Slack)

## security considerations

None that I am aware of, the links are behind GSA google and slack account protection.
