### PR TITLE
Remove confusing sentences about parental leave in leave.md

### DIFF
--- a/pages/travel-and-leave/leave.md
+++ b/pages/travel-and-leave/leave.md
@@ -494,10 +494,7 @@ least 12 weeks after your final day on PPL.
 
 #### Combining paid parental leave, annual leave, and sick leave
 
-You can use annual and sick leave for parental leave reasons. This would be
-_regular_ annual leave and _regular_ sick leave. Please note, though, that if
-these _regular_ leave options are used without completing the PPL paperwork, the
-PPL cannot be retroactively applied.
+You can use annual and sick leave for parental leave reasons. 
 
 We **highly recommend** you talk with our
 [Workforce Relations HR Specialist](https://docs.google.com/document/d/15glvq9UakKUN8XTRTa6gRkhBHm2whhQyAGmf8ibTtBs/edit)


### PR DESCRIPTION
## Changes proposed in this pull request:

- I consulted with Vivi C. on these sentences about parental leave, we determined that they are confusing & not relevant. 
- There are references to _regular_ annual/sick leave, but it's not clear what "regular" is meant to compare or contrast to. 
- Vivi encouraged me to make edit to the Handbook with these changes. 