### PR TITLE
Update deaf-hoh.md -- Add definition of CRAF -- Centralized Reasonable Accommodation fund

### DIFF
--- a/pages/general-information-and-resources/employee-resources-policies/deaf-hoh.md
+++ b/pages/general-information-and-resources/employee-resources-policies/deaf-hoh.md
@@ -319,6 +319,8 @@ technology solutions through the
   description of background elements, music, and other sounds. Unlike open
   captions, closed captioning is optional and activated by the viewer. (_See
   difference, subtitles_).
+- **Centralized Reasonable Accommodation Fund (CRAF):** A centralized funding pool
+  shared across departments to pay for services like interpretation. 
 - **Hearing person:** A Deaf culture term identifying a person with a typical
   hearing ability.
 - **Federal Relay (FedRelay):** Provides telecommunications services for federal


### PR DESCRIPTION
Add definition of CRAF -- Centralized Reasonable Accommodation fund

## Changes proposed in this pull request:

- Add definition of CRAF to Resources for Deaf and Hard of Hearing individuals in TTS page. [Preview link.](https://federalist-cf8341ad-ca07-488c-bd96-0738014c79ca.sites.pages.cloud.gov/preview/18f/handbook/ars/add-craf-definition/general-information-and-resources/employee-resources-policies/deaf-hoh/#terms-to-know-2)

## security considerations

- None