### PR TITLE
Fix the link to the training database

### DIFF
--- a/pages/tools/tock.md
+++ b/pages/tools/tock.md
@@ -393,5 +393,5 @@ Tock likely doesn't have your start date listed correctly. To fix this:
 
 ### How do I change a reporting period I already filled out?
 
-Submit a Tock change request using [this form](https://docs.google.com/forms/d/1EpVTxXgRNgYfoSA2J8Oi-csjhFKqFm5DT542vIlahpU/viewform?edit_requested=true).
+Submit a Tock change request using [this form](https://docs.google.com/forms/d/e/1FAIpQLSe5RDFOlyWm0IXv7_eXjZ3CEjaGj2CmM-_TNgqwMjdspfQz7Q/viewform).
 You can also ping us in {% slack_channel "tock" %} and we'll help you out.

--- a/pages/tools/tock.md
+++ b/pages/tools/tock.md
@@ -392,6 +392,5 @@ Tock likely doesn't have your start date listed correctly. To fix this:
 
 ### How do I change a reporting period I already filled out?
 
-Submit a Tock change request using
-[this form](https://docs.google.com/forms/d/1EpVTxXgRNgYfoSA2J8Oi-csjhFKqFm5DT542vIlahpU/viewform?edit_requested=true).
+Submit a Tock change request using [this form](https://docs.google.com/forms/d/1EpVTxXgRNgYfoSA2J8Oi-csjhFKqFm5DT542vIlahpU/viewform?edit_requested=true).
 You can also ping us in {% slack_channel "tock" %} and we'll help you out.

--- a/pages/training-and-development/conferences-events-training.md
+++ b/pages/training-and-development/conferences-events-training.md
@@ -22,7 +22,7 @@ redirect_from:
 
 TTS encourages all staff to attend conferences, speak at events, and focus on
 professional development and training opportunities. Check out the
-[TTS Training Database](https://docs.google.com/spreadsheets/d/1vB1xbe02jCpKYn6BGSyCH2FziIRNkXXi29yAFT5N9Dg/edit#gid=1891423646)
+[TTS Training Database](https://docs.google.com/spreadsheets/d/1vB1xbe02jCpKYn6BGSyCH2FziIRNkXXi29yAFT5N9Dg/edit#gid=2127569068)
 to see what conferences and trainings your colleagues have attended. If you're
 looking for guidelines around speaking at events (in either a personal or
 professional capacity), see


### PR DESCRIPTION
Update link to training database to the correct tab

## Changes proposed in this pull request:

- Update handbook link to the correct tab within the spreadsheet to reduce clicks and confusion

## security considerations

n/a