### PR TITLE
Correct link to Service Now Portal

### DIFF
--- a/pages/tools/github.md
+++ b/pages/tools/github.md
@@ -59,7 +59,7 @@ Include the following:
   [GitHub settings](https://github.com/settings/emails), they will both be tied
   to your GitHub account anyway.
 - If you will be using `git ssh`, create a ticket in ServiceNow to be added to the TTS - SSH User Group. Follow these steps:
-  1. Go to [GSA IT Self Service Portal](gsa.servicenowservices.com)
+  1. Go to [GSA IT Self Service Portal](https://gsa.servicenowservices.com)
   2. Click on Service Catalog
   3. Search for "generic"
   4. Select "GSA Generic Request"


### PR DESCRIPTION
## Changes proposed in this pull request:
- link to service now was missing _https_ which was invalid and sending user to the wrong path on handbook page
-
-

## security considerations

[Note the any security considerations here, or make note of why there are none]
