### PR TITLE
Add default issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -1,0 +1,46 @@
+---
+name: Default
+about: Use this template for reporting bugs or feature work for the TTS Handbook only.
+title: "[DATE]: [FEATURE NAME]"
+---
+
+Your issue may already be reported!
+
+Please search on the [issue tracker](../) before creating one.
+
+> [!WARNING]
+> This repo is not monitored for support for Login.gov or any other service. Please open a support ticket in the corresponding help desk.
+
+> [!CAUTION]
+> Please do not post any [Personal Identifiable Information (PII)](https://csrc.nist.gov/glossary/term/PII) in this repo.
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Browser Name and version:
+* Operating System and version (desktop or mobile):
+* Link to your project:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Added an issue template for issue
- Includes warning that it's not the right place for service support, and cautions against adding PII to the 

## security considerations
None, it's just adding a template
