### PR TITLE
Add stronger warning in about

### DIFF
--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -1,6 +1,6 @@
 ---
 name: Default
-about: Use this template for reporting bugs or feature work for the TTS Handbook only.
+about: For reporting bugs or feature work for the TTS Handbook only. Not for requesting Login.gov or other service support.
 title: "[DATE]: [FEATURE NAME]"
 ---
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adding the lack of Login.gov/other services support in the description in the [New Issue chooser](https://github.com/18F/handbook/issues/new/choose) 

Before:
<img width="1362" alt="Default issue template with a description that reads 'Use this template for reporting bugs or feature work for the TTS Handbook only'" src="https://github.com/18F/handbook/assets/5473830/08051de5-4b2e-438e-9220-f8e8ed469025">


## security considerations
None