### PR TITLE
Fix links to GSA regions in general information pages

### DIFF
--- a/pages/general-information-and-resources/chicago.md
+++ b/pages/general-information-and-resources/chicago.md
@@ -40,7 +40,7 @@ cSpell: ignore Heppner,Buren,chitown
       </tr>
       <tr>
         <td class="col-key"><strong>Region</strong></td>
-        <td class="col-value">Great Lakes Region (<a href="https://www.gsa.gov/portal/category/22227">Region 5</a>)</td>
+        <td class="col-value">Great Lakes Region (<a href="https://www.gsa.gov/about-us/gsa-regions">Region 5</a>)</td>
       </tr>
     </tbody>
   </table>

--- a/pages/general-information-and-resources/distributed.md
+++ b/pages/general-information-and-resources/distributed.md
@@ -32,7 +32,7 @@ cSpell: ignore Elman,Sennheiser,Karman,Sweger
       </tr>
       <tr>
         <td class="col-key"><strong>Region</strong></td>
-        <td class="col-value"><a href="https://www.gsa.gov/portal/category/22227">Find your GSA region</a>.</td>
+        <td class="col-value"><a href="https://www.gsa.gov/about-us/gsa-regions">Find your GSA region</a>.</td>
       </tr>
     </tbody>
   </table>

--- a/pages/general-information-and-resources/new-york-city.md
+++ b/pages/general-information-and-resources/new-york-city.md
@@ -34,7 +34,7 @@ cSpell: ignore Brookfield
       </tr>
       <tr>
         <td class="col-key"><strong>Region</strong></td>
-        <td class="col-value">Northeast and Caribbean (<a href="https://www.gsa.gov/portal/category/22227">region 2</a>)</td>
+        <td class="col-value">Northeast and Caribbean (<a href="https://www.gsa.gov/about-us/gsa-regions">region 2</a>)</td>
       </tr>
       <tr>
         <td class="col-key">


### PR DESCRIPTION
## Changes proposed in this pull request:

In the following general information and resource pages, update a dead link to a gsa.gov page where you can look up your GSA region.

- Chicago
- Distributed
- New York City

## security considerations

Low or none. The new link is another publicly accessible page on the gsa.gov site.
