### PR TITLE
Direct link to Login help center in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -10,6 +10,7 @@ Please search on the [issue tracker](../) before creating one.
 
 > [!WARNING]
 > This repo is not monitored for support for Login.gov or any other service. Please open a support ticket in the corresponding help desk.
+> For 24/7 Login.gov support, please see https://www.login.gov/contact/
 
 > [!CAUTION]
 > Please do not post any [Personal Identifiable Information (PII)](https://csrc.nist.gov/glossary/term/PII) in this repo.


### PR DESCRIPTION
## Changes proposed in this pull request:
Users are periodically opening up handbook issues seeking Login.gov support. This puts a direct link in the template to try to help get them back on track.

I did not make this a Markdown link because I expect it will be seen when they are trying to open a GitHub issue in the edit view.

## security considerations
N/A
