### PR TITLE
Try to redirect Login.gov help requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Login.gov Issues
+    url: https://www.login.gov/contact/
+    about: For help with Login.gov
+  - name: Report a vulnerability
+    url: https://github.com/18F/handbook/security/advisories/new
+    about:  Privately report a security vulnerability.


### PR DESCRIPTION
## Changes proposed in this pull request:

As discussed in https://github.com/18F/handbook/pull/3930 I am trying to help redirect people coming here looking for help with Login.gov to the Help Center.

The goal is to get it to show up as an option on https://github.com/18F/handbook/issues/new/choose

I am using https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository as a guideline. In the spirit of full disclosure, I don't entirely know what I'm doing here.

## security considerations

🤷‍♂️ Hopefully none?
