### PR TITLE
Remove duplicated "Report a vulnerability" link from Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Login.gov Issues
+  - name: Login.gov issues
     url: https://www.login.gov/contact/
-    about: For help with Login.gov
-  - name: Report a vulnerability
-    url: https://github.com/18F/handbook/security/advisories/new
-    about:  Privately report a security vulnerability.
+    about: For help with Login.gov, use their dedicated Help Center.


### PR DESCRIPTION
## Changes proposed in this pull request:

I had included the "Report a vulnerability" link that was already present because I wasn't sure if creating a config.yml file would overwrite what was already there. It didn't, and instead created a duplicated.

Also tweaks the wording slightly on the Login.gov entry, because I expected "Login.gov Issues" would be the button text, but it was not.


## security considerations

Maybe a slight improvement by not having two duplicated links...
