### PR TITLE
Update Research & Consulting guild co-leads

### DIFF
--- a/pages/training-and-development/working-groups-and-guilds-101.md
+++ b/pages/training-and-development/working-groups-and-guilds-101.md
@@ -153,7 +153,7 @@ Guild meeting times can also be found on the
         </td>
         <td>
     Janel Yamashiro - 18F<br />
-	  Jessica Dussault - 18F<br />
+	  Ethan Marcotte - 18F<br />
     <em>Seeking a co-lead! <a href="https://gsa-tts.slack.com/archives/D02SFCEPEPP">DM Janel if interested!</a></em>
         </td>
       </tr>
@@ -198,7 +198,6 @@ Guild meeting times can also be found on the
           {% slack_channel "g-research" %}
         </td>
         <td>
-          Amanda Kennedy - 18F  <br />
 	  Sarah Moss-Horwitz - 18F <br />
 	  Espy Thomson - USDC
         </td>


### PR DESCRIPTION
Removed Amanda Kennedy from the Research guild co-lead and replaced Jessica Dussault from the Consulting guild co-lead with Ethan Marcotte.

## security considerations

None
