### PR TITLE
Align proper Slack channels per recent Docker Hub request

### DIFF
--- a/pages/tools/docker-hub.md
+++ b/pages/tools/docker-hub.md
@@ -12,7 +12,7 @@ use with [Docker](https://www.docker.com/) and other container technologies.
 ## How do I get access to Docker Hub?
 
 You may use your personal Docker Hub account for work. Ask
-{% slack_channel "infrastructure" %} for access to the
+{% slack_channel "admins-docker" %} for access to the
 [TTS-wide account](https://hub.docker.com/orgs/gsatts).
 
 ## For admins


### PR DESCRIPTION
## Changes proposed in this pull request:

More context can be found in the related Slack thread below. Apologies again for @JJediny.

https://gsa-tts.slack.com/archives/C039MHHF8/p1725908739784519?thread_ts=1725630358.508639&cid=C039MHHF8

## security considerations

This does properly direct people to the proper admin channel, so it _may_ help ensure good off-boarding, on-boarding, and least privilege management in some negligible way. However, this rationale is a very charitable interpretatino of this section of the PR template. 😄 
