### PR TITLE
Add note to equipment page about development environments on Windows GFE

### DIFF
--- a/pages/getting-started/equipment.md
+++ b/pages/getting-started/equipment.md
@@ -35,6 +35,10 @@ number) prior to your first day.
 See [information about using PIV card readers with GSA-issued
 MacBooks]({% page "/piv/" %}).
 
+If you’re a software engineer who’s been given a PC — especially if you're more
+accustomed to MacOS or Linux — refer to this guide for
+[establishing a development environment on Windows GFE](https://docs.google.com/document/d/1uJFCAl4IF-GR4a2laUEeIOfT8iWA8ALQ4-eR_SZBlwA).
+
 ### MacBook Operating System
 
 Your MacBook will come preloaded with the latest, GSA-approved/supported


### PR DESCRIPTION
## Changes proposed in this pull request:

This adds a link to a document describing some processes to set up a development environment on Windows GFE. This is something that tends to come up in Slack somewhat regularly and I thought it would be useful to compile information on the current state of development work on Windows GFE along with some tips to make the environment easier to use.

I am very open to wording suggestions, to moving someplace else that may be better suited for the note, or to changes in the linked document itself!

## Security considerations

This links to a Google Doc that is shared internally with GSA.gov users. The document contains various details about what kind of software is available to TTS engineers and the edges of what is _not_ available. The information is generally available elsewhere, but disperse.
