### PR TITLE
Correct docs about requesting npm access

### DIFF
--- a/pages/tools/npm.md
+++ b/pages/tools/npm.md
@@ -1,7 +1,7 @@
 ---
 title: npm
 questions:
-  - javascript
+  - tts-tech-operations
 redirect_from:
   - /npm/
 ---
@@ -15,7 +15,7 @@ distribute JavaScript libraries and programs for software development.
 Any npm packages published for work should be published under the
 [18f](https://www.npmjs.com/org/18f) npm organization. You may use your personal
 npm account for membership to the 18f organization. Ask
-{% slack_channel "javascript" %} for how to get membership or a token for
+{% slack_channel "tts-tech-operations" %} for how to get membership or a token for
 publishing.
 
 ## For admins


### PR DESCRIPTION
Previously, the handbook instructed individuals to request npm org access in the `#javascript` slack channel.  Based on [this slack post](https://gsa-tts.slack.com/archives/C032KSPPQ/p1730322737706809), the handbook will now direct people to request npm org access via the `#tts-tech-operations` slack channel.