### PR TITLE
Update the link to the Transit Subsidy Handbook page

### DIFF
--- a/pages/general-information-and-resources/washington-dc.md
+++ b/pages/general-information-and-resources/washington-dc.md
@@ -323,7 +323,7 @@ laptop screen.
 
 ### Transit subsidy
 
-See the [Transit Subsidy Handbook page]({% page "/general-information-and-resources/washington-dc/#transit-subsidy" %}).
+See the [Transit Subsidy Handbook page]({% page "/general-information-and-resources/employee-resources-policies/transit-benefit/" %}).
 
 ### Helpful contacts
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update the link to the D.C. transit subsidy to point to the correct place (it currently anchors to itself).


## security considerations

None, this only updates one internal link to another internal link.