### PR TITLE
Fix internal & external links to templates in leading-projects.md

### DIFF
--- a/pages/18f/projects-partners/leading-projects.md
+++ b/pages/18f/projects-partners/leading-projects.md
@@ -136,7 +136,7 @@ happening.
 - Weekly:
   - Meet with account manager
   - Monitor project burn doc with account manager
-  - Compile and post a Weekly Ship; send to partner and post in
+  - Compile and post a Weekly Ship. Use the [weekly ship template](https://docs.google.com/document/d/19VyjU7JdIRkmQ_XuEYn7RZr1WVzxVyrWolwx0VtlsWE) ([External version]({% download "downloads/TEMPLATE_Weekly_ship_template.docx" %})). Send to partner and post in
     {% slack_channel "the-shipping-news" %}
 - Every two weeks: Conduct an internal team retrospective
 - Ensure midpoint and other higher-profile presentations are rehearsed or

--- a/pages/18f/projects-partners/leading-projects.md
+++ b/pages/18f/projects-partners/leading-projects.md
@@ -98,9 +98,9 @@ happening.
 ### Beginning of Project
 
 - Facilitate creation of a
-  [team charter](https://docs.google.com/document/d/1N_EtkfGGdvyIfsxblSjKo5m4UI82mAkPNmyMcoZhS2g/edit?usp=sharing),
+  [team charter](https://docs.google.com/document/d/1ncvqtxU9dPAVa3hWu1SxN2Mvqt5y8FzFFtZJz6_988E),
   including how decisions will be made and how the team will navigate
-  disagreement. (Non-18F folks may be interested in our [charter template](./downloads/TEMPLATE_Team_charter.docx)).
+  disagreement. Non-18F folks may be interested in our [team charter template]({% download "downloads/TEMPLATE_Team_charter.docx" %}).
 - Identify stakeholder accessibility needs for project work (in collaboration
   tools and deliverables)
   - If artifacts (e.g. RFQs, final reports, decks) should be durable over time,
@@ -111,9 +111,9 @@ happening.
 - Facilitate identification of project management tracking tools
 - Facilitate identification of how administrative tasks will be rotated
 - Create and maintain a
-  [Project Readme](https://docs.google.com/document/d/1_vL462nws0l1WXMTyTdWcmU2GyjHzF88dHvnLIvYeq4/edit?usp=sharing)
+  [Project Readme](https://docs.google.com/document/d/1kZvT7K6YPAjp6ETR_nlgCycmJyb-5r4-hViRvN6sAbY/)
   in the project’s Drive folder (Account Manager will establish project folder).
-  (Non-18F folks may be interested in our [README template](./downloads/TEMPLATE_Project_README.docx)).
+  Non-18F folks may be interested in our [README template]({% download "downloads/TEMPLATE_Project_README.docx" %}).
 
 ### Ongoing
 

--- a/pages/18f/projects-partners/leading-projects.md
+++ b/pages/18f/projects-partners/leading-projects.md
@@ -97,11 +97,9 @@ happening.
 
 ### Beginning of Project
 
-- Hold an [internal kickoff](https://docs.google.com/document/d/1xrbD7lBar4fTaU9T33AD1xv8v5Yb-grmLms3CNWTMvs/). ([Download template here.]({% download "downloads/TEMPLATE_Internal_kickoff_agenda.docx" %}))
+- Hold an [internal kickoff](https://docs.google.com/document/d/1xrbD7lBar4fTaU9T33AD1xv8v5Yb-grmLms3CNWTMvs/) ([download]({% download "downloads/TEMPLATE_Internal_kickoff_agenda.docx" %})).
 - Facilitate creation of a
-  [team charter](https://docs.google.com/document/d/1ncvqtxU9dPAVa3hWu1SxN2Mvqt5y8FzFFtZJz6_988E),
-  including how decisions will be made and how the team will navigate
-  disagreement. Non-18F folks may be interested in our [team charter template]({% download "downloads/TEMPLATE_Team_charter.docx" %}).
+  [team charter](https://docs.google.com/document/d/1ncvqtxU9dPAVa3hWu1SxN2Mvqt5y8FzFFtZJz6_988E) ([download]({% download "downloads/TEMPLATE_Team_charter.docx" %})).
 - Identify stakeholder accessibility needs for project work (in collaboration
   tools and deliverables)
   - If artifacts (e.g. RFQs, final reports, decks) should be durable over time,
@@ -112,9 +110,7 @@ happening.
 - Facilitate identification of project management tracking tools
 - Facilitate identification of how administrative tasks will be rotated
 - Create and maintain a
-  [Project Readme](https://docs.google.com/document/d/1kZvT7K6YPAjp6ETR_nlgCycmJyb-5r4-hViRvN6sAbY/)
-  in the project’s Drive folder (Account Manager will establish project folder).
-  Non-18F folks may be interested in our [README template]({% download "downloads/TEMPLATE_Project_README.docx" %}).
+  [Project README](https://docs.google.com/document/d/1kZvT7K6YPAjp6ETR_nlgCycmJyb-5r4-hViRvN6sAbY/) ([download]({% download "downloads/TEMPLATE_Project_README.docx" %})).
 
 ### Ongoing
 
@@ -134,11 +130,11 @@ happening.
 - Ensure that
   [project impact](https://docs.google.com/document/d/1XHYJ8MTauUnwX7pDwcb8Pw0H2CftRDekJFa0CV6kanY/edit?usp=sharing)
   metrics are gathered throughout the project
-- Track and mitigate risks throughout the project, using the [risk tracker template](https://docs.google.com/spreadsheets/d/1KHX8dSPvYQ9w4Dy4Y2K50TkHRDA9H8Z76p001ulJuJY). ([Download template here.]({% download "downloads/TEMPLATE_Risk_tracker.xlsx" %}))
+- Track and mitigate risks throughout the project, using the [risk tracker template](https://docs.google.com/spreadsheets/d/1KHX8dSPvYQ9w4Dy4Y2K50TkHRDA9H8Z76p001ulJuJY) ([download]({% download "downloads/TEMPLATE_Risk_tracker.xlsx" %})).
 - Weekly:
   - Meet with account manager
   - Monitor project burn doc with account manager
-  - Compile and post a Weekly Ship. Use the [weekly ship template](https://docs.google.com/document/d/19VyjU7JdIRkmQ_XuEYn7RZr1WVzxVyrWolwx0VtlsWE). ([Download template here.]({% download "downloads/TEMPLATE_Weekly_ship_template.docx" %})) Send to partner and post in
+  - Compile and post a Weekly Ship. Use the [weekly ship template](https://docs.google.com/document/d/19VyjU7JdIRkmQ_XuEYn7RZr1WVzxVyrWolwx0VtlsWE) ([download]({% download "downloads/TEMPLATE_Weekly_ship_template.docx" %})). Send to partner and post in
     {% slack_channel "the-shipping-news" %}
 - Every two weeks: Conduct an internal team retrospective
 - Ensure midpoint and other higher-profile presentations are rehearsed or
@@ -146,8 +142,7 @@ happening.
 - Work with account manager and staffing team when project team identifies a
   need for a shift in staffing
 - Onboard new team members to the project, as needed, including revisiting
-  [team charter](https://docs.google.com/document/d/1N_EtkfGGdvyIfsxblSjKo5m4UI82mAkPNmyMcoZhS2g/edit?usp=sharing)
-  with full team
+  team charter with full team.
 - Periodically: Check in on equitable distribution of administrative tasks among
   team members: re-balance as necessary
 - Add to and organize the project’s Drive folder

--- a/pages/18f/projects-partners/leading-projects.md
+++ b/pages/18f/projects-partners/leading-projects.md
@@ -136,7 +136,7 @@ happening.
 - Weekly:
   - Meet with account manager
   - Monitor project burn doc with account manager
-  - Compile and post a Weekly Ship. Use the [weekly ship template](https://docs.google.com/document/d/19VyjU7JdIRkmQ_XuEYn7RZr1WVzxVyrWolwx0VtlsWE) ([External version]({% download "downloads/TEMPLATE_Weekly_ship_template.docx" %})). Send to partner and post in
+  - Compile and post a Weekly Ship. Use the [weekly ship template](https://docs.google.com/document/d/19VyjU7JdIRkmQ_XuEYn7RZr1WVzxVyrWolwx0VtlsWE). ([Download here.]({% download "downloads/TEMPLATE_Weekly_ship_template.docx" %})) Send to partner and post in
     {% slack_channel "the-shipping-news" %}
 - Every two weeks: Conduct an internal team retrospective
 - Ensure midpoint and other higher-profile presentations are rehearsed or

--- a/pages/18f/projects-partners/leading-projects.md
+++ b/pages/18f/projects-partners/leading-projects.md
@@ -97,6 +97,7 @@ happening.
 
 ### Beginning of Project
 
+- Hold an [internal kickoff](https://docs.google.com/document/d/1xrbD7lBar4fTaU9T33AD1xv8v5Yb-grmLms3CNWTMvs/). ([Download template here.]({% download "downloads/TEMPLATE_Internal_kickoff_agenda.docx" %}))
 - Facilitate creation of a
   [team charter](https://docs.google.com/document/d/1ncvqtxU9dPAVa3hWu1SxN2Mvqt5y8FzFFtZJz6_988E),
   including how decisions will be made and how the team will navigate
@@ -133,10 +134,11 @@ happening.
 - Ensure that
   [project impact](https://docs.google.com/document/d/1XHYJ8MTauUnwX7pDwcb8Pw0H2CftRDekJFa0CV6kanY/edit?usp=sharing)
   metrics are gathered throughout the project
+- Track and mitigate risks throughout the project, using the [risk tracker template](https://docs.google.com/spreadsheets/d/1KHX8dSPvYQ9w4Dy4Y2K50TkHRDA9H8Z76p001ulJuJY). ([Download template here.]({% download "downloads/TEMPLATE_Risk_tracker.xlsx" %}))
 - Weekly:
   - Meet with account manager
   - Monitor project burn doc with account manager
-  - Compile and post a Weekly Ship. Use the [weekly ship template](https://docs.google.com/document/d/19VyjU7JdIRkmQ_XuEYn7RZr1WVzxVyrWolwx0VtlsWE). ([Download here.]({% download "downloads/TEMPLATE_Weekly_ship_template.docx" %})) Send to partner and post in
+  - Compile and post a Weekly Ship. Use the [weekly ship template](https://docs.google.com/document/d/19VyjU7JdIRkmQ_XuEYn7RZr1WVzxVyrWolwx0VtlsWE). ([Download template here.]({% download "downloads/TEMPLATE_Weekly_ship_template.docx" %})) Send to partner and post in
     {% slack_channel "the-shipping-news" %}
 - Every two weeks: Conduct an internal team retrospective
 - Ensure midpoint and other higher-profile presentations are rehearsed or

--- a/pages/updating-the-handbook/shortcodes.md
+++ b/pages/updating-the-handbook/shortcodes.md
@@ -119,21 +119,17 @@ elements or as additional emphasis on the text. {% endcapture %}
 
 ## Downloadable files
 
-If you need to include a file for download in your Handbook page, you can use
-the `download` shortcode.
+To include a file for download in your Handbook page, you must use the `download` shortcode.
 
 #### Arguments
 
-- **file path**: The location of your file in the Handbook source code, relative
-  to the source code base directory. For convenience, there is already a
-  `downloads` directory you can use.
+- **file path**: The location of your file in the Handbook source code, relative to the source code base directory. For convenience, there is already a`downloads` directory you can use.
 
-**Returns** the URL to the downloadable file.
+**Returns** the URL to a downloadable file.
 
 #### Example:
 
-If you put a file called `my-form.pdf` in the `downloads` directory, you can
-make that file available for download and get the URL to it this way:
+If you have a file called `my-form.pdf` in the `downloads` directory, you need to use this shortcode to make the file available for download:
 
 ```
 {% raw %}[download link]
@@ -142,7 +138,7 @@ make that file available for download and get the URL to it this way:
 %}){% endraw %}
 ```
 
-Which would produce a link like this:
+Produces a link like this:
 
 [download link]({% download "downloads/my-form.pdf" %})
 

--- a/pages/updating-the-handbook/shortcodes.md
+++ b/pages/updating-the-handbook/shortcodes.md
@@ -123,7 +123,7 @@ To include a file for download in your Handbook page, you must use the `download
 
 #### Arguments
 
-- **file path**: The location of your file in the Handbook source code, relative to the source code base directory. For convenience, there is already a`downloads` directory you can use.
+- **file path**: The location of your file in the Handbook source code, relative to the source code base directory. For convenience, there is already a `downloads` directory you can use.
 
 **Returns** the URL to a downloadable file.
 


### PR DESCRIPTION
## What changes does this make?

+ Fixes bug -- links to templates in leading projects page are currently broken, this PR fixes
+ Adds links to all templates added in #4005 
+ Clarifies documentation on what `download` shortcode does

## 👁️ Preview build pages

+ [leading projects](https://federalist-cf8341ad-ca07-488c-bd96-0738014c79ca.sites.pages.cloud.gov/preview/18f/handbook/ars/update-leading-projects-templates/18f/projects-partners/leading-projects/)
+ [updating the handbook > shortcodes > downloadable files](https://federalist-cf8341ad-ca07-488c-bd96-0738014c79ca.sites.pages.cloud.gov/preview/18f/handbook/ars/update-leading-projects-templates/updating-the-handbook/shortcodes/#downloadable-files)

## Issue

+ Fixes + #4009 