### PR TITLE
Revise description of Maxiflex schedule

### DIFF
--- a/pages/general-information-and-resources/employee-resources-policies/work-schedules.md
+++ b/pages/general-information-and-resources/employee-resources-policies/work-schedules.md
@@ -101,7 +101,7 @@ For example:
 
 
 ##### Maxiflex
-- Same as Variable Week, but you only work 9 days instead of 10 days per pay period. 
+- Same as Variable Week, but you may work fewer than 10 days per pay period. 
 
 For example:
 |**Day**   |**Hours** | **Day**  |**Hours** | 


### PR DESCRIPTION
The current version of the work schedule page includes "you only work 9 days instead of 10 days per pay period" in the description of the maxiflex schedule. This is a valid example of a possible maxiflex schedule, but so far as I have been able to confirm it is not a stipulation. One could, for example, work four 10-hour days each week on maxiflex. 

I chatted about this with @awichman, checked for any relevant policy on [the OPM alternative work schedule page](https://www.opm.gov/policy-data-oversight/pay-leave/reference-materials/handbooks/alternative-work-schedules/), and tried drafting a base schedule with two 4x10 weeks to be sure HR Links wouldn't prevent me. 

[Preview link for revised text](https://federalist-cf8341ad-ca07-488c-bd96-0738014c79ca.sites.pages.cloud.gov/preview/18f/handbook/revise-maxiflex-description/general-information-and-resources/employee-resources-policies/work-schedules/#maxiflex)

## Changes proposed in this pull request:
- Replaces the "you only work 9 days" language for maxiflex with "you may work fewer than 10 days".

## Security considerations
None
