### PR TITLE
Remove outdated Slack channels from Washington D.C. page

### DIFF
--- a/pages/general-information-and-resources/washington-dc.md
+++ b/pages/general-information-and-resources/washington-dc.md
@@ -27,7 +27,7 @@ cSpell: ignore capitalweather,Thurgood,Wich,Greenberry,Totten,Smar,WMATA
           <strong>Slack channels</strong>
         </td>
         <td class="col-value">
-          {% slack_channel "dc" %}, {% slack_channel "dc-lunchbell" %}, {% slack_channel "dc-snack-inventory" %}
+          {% slack_channel "dc" %}
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
## Changes proposed in this pull request:

- `#dc` is the only active Slack channel for the DC office
- See https://gsa-tts.slack.com/archives/C02AJ3H3K/p1734011156403549?thread_ts=1733947160.483789&cid=C02AJ3H3K

## security considerations

None