### PR TITLE
Include page last modified date in footer for all pages.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -21,6 +21,9 @@
       <div class="usa-footer-contact-links usa-width-one-half align-right">
 
         <small>
+          {% if page.date %}
+            Page last modified {{ page.date | date: "%B %e, %Y" }}.
+          {% endif %}
           <a
             href="https://github.com/18F/handbook/edit/main/{{ page.inputPath | url }}"
             class="usa-sidenav-edit"

--- a/federalist.json
+++ b/federalist.json
@@ -1,0 +1,3 @@
+{
+  "fullClone": true
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds the date a page was last modified (based on git commit) to the footer of every page.
- Configures Cloud.gov pages to do a full git clone rather than shallow (to retrieve history).
- The [page date is already configured to use git dates](https://github.com/18F/handbook/blob/e6f614bd60aa0c4a28ea8d3b751fd206ff2163fd/_includes/layouts/base.html#L2).

We're looking to indicate when pages are last modified in updates to the TTS Consulting Handbook.

## Build timing

<details>
<summary>This adds 3-4 seconds to build times, which I think is reasonable for its usefulness.</summary>

```
2024-12-12 16:06:03 INFO [main] Running build for 18f/handbook/add-last-modified-to-footer
2024-12-12 16:06:03 INFO [clone] Cloning into '/tmp/work/site_repo'...
2024-12-12 16:06:04 INFO [clone] Fetching commit details ...
2024-12-12 16:06:04 INFO [clone] commit efaa8b0542cbce8b57a558dbeed66221f95bb545
2024-12-12 16:06:04 INFO [update] Fetching full git history
2024-12-12 16:06:07 INFO [update] From https://github.com/18f/handbook
2024-12-12 16:06:08 INFO [update] * [new tag]           last-jekyll -> last-jekyll
2024-12-12 16:06:08 INFO [update] Already up to date.
2024-12-12 16:06:08 INFO [setup-node] Checking node version specified in .nvmrc
```

```
2024-12-11 20:12:02 INFO [main] Running build for 18f/handbook/ttsc-handbook-section-A
2024-12-11 20:12:02 INFO [clone] Cloning into '/tmp/work/site_repo'...
2024-12-11 20:12:03 INFO [clone] Fetching commit details ...
2024-12-11 20:12:03 INFO [clone] commit 3a7873b1aff8b5d98b4f959afb92d43784eb9949
2024-12-11 20:12:03 INFO [update] Fetching full git history
2024-12-11 20:12:06 INFO [update] From https://github.com/18f/handbook
2024-12-11 20:12:06 INFO [update] * [new tag]           last-jekyll -> last-jekyll
2024-12-11 20:12:06 INFO [update] Already up to date.
2024-12-11 20:12:06 INFO [setup-node] Checking node version specified in .nvmrc
```

</details>

## Security considerations

None, the git history is public information. 

----

<img width="917" alt="screenshot of footer showing date last modified" src="https://github.com/user-attachments/assets/ab8b7d68-db84-427d-ad4a-d825b9b0954e" />
