### PR TITLE
Add first section of the TTS Consulting Handbook.

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -370,7 +370,7 @@ primary:
                 internal: true
           - text: Market Development and Partnerships
             children:
-              - text: Overview of Market Development and Partnerships  
+              - text: Overview of Market Development and Partnerships
                 url: office-of-operations/market-dev-and-partnerships/
                 internal: true
           - text: Talent team
@@ -405,6 +405,19 @@ primary:
           - text: Contractors
             url: contractors/
             internal: true
+      - text: TTS Consulting
+        main-file-path: /about-us/tts-consulting/
+        use_section_menu: true
+        children:
+          - text: About TTS Consulting
+            main-file-path: /about-us/tts-consulting/about/
+            children:
+              - text: Mission, approach, and history
+                url: about-us/tts-consulting/about/mission/
+              - text: Success measures
+                url: about-us/tts-consulting/about/planning/
+              - text: About the TTS Consulting Handbook
+                url: about-us/tts-consulting/about/handbook/
       - text: 18F
         children:
           - text: About 18F

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -21,3 +21,73 @@
     </div>
   </nav>
 </header>
+{%- assign section_navigation = navigation.primary | find_section: page.inputPath -%}
+{%- if section_navigation -%}
+  <header class="usa-header usa-header--extended usa-section--light">
+    <div class="usa-navbar">
+      <div class="usa-logo">
+        <em class="usa-logo__text">
+          {% if section_navigation.url %}
+            <a href="{% page section_navigation.url %}">
+              {{ section_navigation.text }}
+            </a>
+          {% else %}
+            {{ section_navigation.text }}
+          {% endif %}
+        </em>
+      </div>
+    </div>
+
+    <nav aria-label="Section navigation">
+      <div class="usa-nav__inner">
+        <ul class="usa-nav__primary usa-accordion">
+          {% for item in section_navigation.children %}
+            {% unless item.topnavcondense %}
+              {% if item.children %}
+                <li class="usa-nav__primary-item">
+                  <button
+                    type="button"
+                    class="usa-accordion__button usa-nav__link {% usa_current item.main-file-path page.inputPath %}"
+                    aria-expanded="false"
+                    aria-controls="extended-nav-section-{{ item.text | slugify }}"
+                  >
+                    <span>{{ item.text }}</span>
+                  </button>
+                  {% assign subitemsSize = item.children.size %}
+                  {% if item.sub %}
+                    <div id="extended-nav-section-{{ item.text | slugify }}" class="usa-nav__submenu usa-megamenu">
+                      <div class="grid-row grid-gap-4">
+                        {% include "usa-nav__usa-col-subnav.html" item:item %}
+
+                        {% for condensedItem in section_navigation.children %}
+                          {% if condensedItem.topnavcondense == item.text %}
+                            {% include "usa-nav__usa-col-subnav.html" item:condensedItem %}
+                          {% endif %}
+                        {% endfor %}
+                      </div>
+                    </div>
+                  {% else %}
+                    <ul id="extended-nav-section-{{ item.text | slugify }}" class="usa-nav__submenu">
+                    {% for index in (1..subitemsSize) %}
+                      {% if item.children[forloop.index0].url %}
+                        <li class="usa-nav__submenu-item">
+                          {% assign suburl = item.children[forloop.index0].url %}
+                          <a href="{% link suburl %}"><span>{{ item.children[forloop.index0].text }}</span></a>
+                        </li>
+                      {% endif %}
+                    {% endfor %}
+                    </ul>
+                  {% endif %}
+                </li>
+              {% else %}
+                <li class="usa-nav__primary-item">
+                  <a href="{% link item.url %}" class="usa-nav-link"><span>{{ item.text }}</span></a>
+                </li>
+              {% endif %}
+            {% endunless %}
+          {% endfor %}
+        </ul>
+      </div>
+    </nav>
+  </header>
+{%- endif -%}

--- a/cSpell.json
+++ b/cSpell.json
@@ -203,6 +203,7 @@
     "Touchpoints",
     "trackpad",
     "transformative",
+    "TTSC",
     "unaccrued",
     "Unarchiving",
     "underserved",
@@ -224,6 +225,7 @@
     "wireframes",
     "womxn",
     "workshopping",
+    "workstreams",
     "XKCD",
     "Yamashiro"
   ],

--- a/config/filters/findSection.js
+++ b/config/filters/findSection.js
@@ -1,0 +1,19 @@
+// Given a nested menu collection and a page, returns the collection item
+// representing the section that matches the page's path.
+//
+// Used to render section menus in the header.
+
+const findSection = (collection, pagePath) => {
+  for (let item of collection) {
+    if (item.use_section_menu && pagePath.includes(item["main-file-path"])) {
+      return item;
+    }
+
+    if (item.children) {
+      const result = findSection(item.children, pagePath);
+      if (result) { return result; }
+    }
+  }
+};
+
+module.exports = findSection;

--- a/config/filters/index.js
+++ b/config/filters/index.js
@@ -1,6 +1,8 @@
+const findSectionFilter = require("./findSection");
 const renderFilter = require("./render");
 
 const filterPlugin = (eleventyConfig) => {
+  eleventyConfig.addFilter("find_section", findSectionFilter);
   eleventyConfig.addFilter("render", renderFilter);
 };
 

--- a/pages/about-us/tts-consulting/about/handbook.md
+++ b/pages/about-us/tts-consulting/about/handbook.md
@@ -1,0 +1,21 @@
+---
+title: TTS Consulting Handbook
+---
+
+The TTS Office of Consulting (TTSC) Handbook establishes standard operating procedures (SOPs) for 18F and the Centers of Excellence (CoE). It sets expectations for managing our consulting business, and delivering for our partners.
+
+These SOPs are how we think we can best achieve our mission. If the majority of our work follows these paved roads, it will improve delivery quality, client satisfaction, employee engagement, and the overall organizational durability.
+
+## Do 18F and CoE do everything the same way now?
+
+No. We’re still blending two teams with different traditions and ways of working. On some matters, a standard approach for all TTSC operations and engagement delivery has been established. On others, 18F and Centers of Excellence still have different approaches. The TTSC Handbook acknowledges these differences when appropriate.
+
+During the TTSC realignment, adjustments will be documented in this handbook on a rolling basis. In the meantime, consolidating the pre-existing guidance in one place is a step toward forming new ways of working together.
+
+## Governance process for the TTSC Handbook
+
+The TTSC Handbook should be considered the source of truth for any TTSC policy or procedure.
+
+We need all staff to help keep the handbook up-to-date. If you find content that is incorrect, missing, or confusing, please [submit an issue](https://github.com/18F/handbook/issues/new).
+
+The TTSC Chief of Staff is the handbook owner. They will review any suggested edits or additions on a rolling basis and direct a content review annually. All pages have a “Last modified date.”

--- a/pages/about-us/tts-consulting/about/mission.md
+++ b/pages/about-us/tts-consulting/about/mission.md
@@ -1,0 +1,136 @@
+---
+title: Mission, approach, and history
+---
+
+**The mission of TTS Consulting is to empower our government partners to create better digital experiences to more effectively serve the American public.**
+
+TTS Consulting works with federal, state, local, and tribal agency partners to:
+
+- Find a starting point for digital modernization
+- Build staff capacity
+- Modernize technology systems
+- Improve the public experience of government
+- Build and buy technology in better ways
+
+Our work resides within the overall GSA mission: “To deliver the best customer experience and value in real estate, acquisition, and technology services to the government and American people.”
+
+The TTS Office of Consulting was created in August 2023 when TTS leadership aligned two groups which consult with government agencies on technology modernization: 18F and IT Modernization Centers of Excellence (CoE).  18F and CoE share a common cause and some similar ways of working. Differences in business and engagement practices are due to each group’s composition and history.
+
+These are _not_ hard and fast rules, but generally the different approaches tend to be:
+
+| Area | CoE common approach | 18F common approach |
+|------|---------------------|---------------------|
+| **Partners** | An agency's OCIO | A program office |
+| **Engagement scope** | Larger modernization efforts involving parallel projects in artificial intelligence, data analytics, cloud adoption, infrastructure optimization, contact center, and customer experience | Agile product development for specific agency challenges |
+| **Staffing** | Federal employees with deep experience in key areas to serve as strategic leads and manage the work of vendors as contractor representatives (CORs) | Teams of federal employees in cross-functional teams, often including designers, engineers, product managers, and acquisition consultants |
+| **Acquisitions** | Assisted acquisitions with trusted industry partners in a variety of disciplines and serves as CORs for those vendors | Works with industry through partners, offering acquisition coaching to help partners' run acquisitions through their own procurement shops |
+
+## 18F's mission and approach
+
+**18F’s mission is to transform how the U.S. government builds and buys digital services and systems.**
+
+18F currently has five chapters:
+
+- Account management
+- Acquisition
+- Design
+- Engineering
+- Product management
+
+{% comment %} TODO - link "various roles on engagements" to role page {% endcomment %}
+Individual contributors from chapters occupy various roles on engagements.
+
+18F provides the following service offerings. Here is the kind of work we do:
+
+- **Strategy Development** - Working with our partner to evaluate options to get actionable recommendations to achieve their goals
+- **Vendor Acquisition Support** - Working with agency partners to buy and help issue and manage a procurement
+- **Website Modernization** - Improving website experience by prototyping, implementing improvements, and getting the tools and coaching to manage the new site.
+- **Digital Services Transformation** - Researching, prototyping, launching, and managing digital products from start to finish- while providing support and coaching.
+
+Read more on the [18F website](https://18f.gsa.gov/).
+
+The 18F approach focuses on these tenets:
+
+- **Center on user needs.** Use an empathy-first approach. We listen to the public and staff working hard to serve them.
+- **Understand the problem.** Get a shared understanding of the problem first to build trust and guide us to better recommendations and solutions.
+- **Build often and iteratively.** Use cross-functional teams and agile methodologies to deliver working software early and often. We build, test, validate with real people, then iterate and build again. These feedback loops deliver value quickly and avoid big failures that can come with “all-at-once” launches.
+- **Build partner capacity.** Identify and empower product owners and advocates within partner agencies to promote and sustain best practices after 18F’s work has finished.
+- **Open by default.** We [code and design in the open](https://github.com/18F), use open-source software, use and build open source code, and evangelize our methods and practices across the federal government.
+
+### History of 18F
+
+18F was [officially launched within GSA on March 19, 2014](https://18f.gsa.gov/2014/03/19/hello-world-we-are-18f/). It became part of TTS in 2015.
+
+The creation of 18F came in the wake of the work of several programs, teams, and nonprofits that focused on improving the way the government approached technology. These included the Consumer Financial Protection Bureau, the Office of Personnel Management Lab, the Sunlight Foundation, Code for America, the U.S. CTO’s office, and the [Presidential Innovation Fellows (PIF)](https://presidentialinnovationfellows.gov/) program.
+
+18F is a direct outgrowth of the PIF program, which was established by the White House in 2012. It placed experienced technologists in various federal agencies for six months, where they helped them learn and apply modern and user-centric approaches to building and maintaining systems, websites, and applications. PIF was moved to GSA in 2013.
+
+Interest in establishing a permanent team of technologists along with the [troubled launch of Healthcare.gov](https://oig.hhs.gov/reports/all/2016/healthcaregov-case-study-of-cms-management-of-the-federal-marketplace/) and federal government shutdown of October 2013 motivated some PIFs to seek funding and ways to extend their terms. By mid-December, the unnamed team had secured a budget and began hiring.
+
+When 18F launched officially, it had 15 full-time staff and had settled on a name: 18F refers to the location of GSA headquarters at the intersection of 18th and F Streets in Washington, DC. Committed to the principles of user-centered design, developing in the open, and incorporating agile and lean development practices, the team worked to make government services simpler and easier to use – a goal that continues to guide 18F over a decade later.
+
+From its inception, 18F focused on providing in-house digital services to a wide array of federal partners. Additionally, the early years also focused on offering digital tools and services for reuse and savings, among these were:
+
+- [cloud.gov](http://cloud.gov) (2014)
+- [USWDS: U.S. Web Design System](https://designsystem.digital.gov/) (2015)
+- [login.gov](http://login.gov) (2016)
+- [cloud.gov Pages](https://cloud.gov/pages/) (2016)
+
+## CoE's mission and approach
+
+**The CoE mission is to accelerate IT modernization at federal agencies by leveraging private sector innovation and government services while centralizing best practices and expertise for holistic transformation.**
+
+CoE has six “centers”:
+
+- Artificial intelligence
+- Data analytics
+- Cloud adoption
+- Infrastructure optimization
+- Contact center
+- Customer experience
+
+The centers are also supported by three practice areas:
+
+- Acquisitions
+- Innovation adoption
+- Client services
+
+CoE engagements are with federal agencies and often have multiple workstreams. Individuals from centers are staffed in the roles of engagement lead and/or technical consultant. CoE engagement teams are composed of federal employees and vendors.
+
+Read more on the [CoE website](https://coe.gsa.gov/).
+
+CoE’s approach follows these tenets:
+
+- **Co-lead and deliver enterprise-level IT modernization** including migration of legacy systems to sustainable platforms
+- **Know our customer.** CoE’s unique position in the federal workspace allows us to understand and anticipate the needs of our agency partners as customers.
+- **Use human-centered design** to identify best outcomes for the public and efficiencies for agency staff.
+- **Leverage commercially available solutions** to deliver results quickly
+- **Embed teams** of our subject matter experts and top industry talent within partner agencies
+- **Speed up the procurement process** by leveraging GSA’s assisted acquisitions and blanket purchase agreements
+
+### History of CoE
+
+On October 24, 2017, the Office of American Innovation (OAI) established the IT Modernization Centers of Excellence within TTS to accelerate IT modernization across government to improve the public experience and increase operational efficiency. GSA implemented the CoE program in partnership with OAI.
+
+CoE originally launched with teams that provided technical expertise in five interrelated areas:
+
+- Cloud adoption
+- Contact center
+- Customer experience
+- Data analytics
+- Infrastructure optimization
+
+In 2019, a sixth center–Artificial Intelligence–was formally added. In 2021 ‘Areas of Practice,’ Innovation Adoption and Acquisition, were introduced to support the work of the six technical centers.
+
+CoE teams were intentionally designed to include partner detailees, GSA, and contractors. These blended teams would leverage best practices and multiple perspectives to deliver innovative solutions.
+
+CoE’s first partner was the United States Department of Agriculture (USDA). The engagement sought to modernize IT across the department according to the USDA secretary's vision for making it data driven and a leader in customer service and experience in government and industry. Phase I began in April 2018, phase II in October 2018.
+
+In October 2018, CoE also began working with its second partner, the United States Department of Housing and Urban Development.
+
+In 2020, the CoE was codified into law by the [IT Modernization Centers of Excellence Program Act](https://www.cio.gov/handbook/it-laws/modernization-centers-of-excellence-program-act/?clickEvt).
+
+## Additional reading
+
+- [Collaborative combined cultural history of TTS](https://docs.google.com/document/d/1TZNX3G86G4zY56YVJCXW4L9GKL6_nfsTPSL-SDxmSVs/edit)
+- [Business Unit/Program Anniversaries & Important Dates to TTS](https://docs.google.com/spreadsheets/d/1uSZVYI3mKTrtyT9VbEajo4z9NGVIYChcodTOjRUbiJk/edit?gid=0#gid=0)

--- a/pages/about-us/tts-consulting/about/mission.md
+++ b/pages/about-us/tts-consulting/about/mission.md
@@ -1,5 +1,6 @@
 ---
 title: Mission, approach, and history
+cSpell: ignore CTO’s
 ---
 
 **The mission of TTS Consulting is to empower our government partners to create better digital experiences to more effectively serve the American public.**

--- a/pages/about-us/tts-consulting/about/planning.md
+++ b/pages/about-us/tts-consulting/about/planning.md
@@ -1,0 +1,64 @@
+---
+title: Success measures
+---
+
+When TTSC succeeds, people have better experiences with the government. Four outcomes define TTSC’s success:
+
+- [Partner satisfaction](#partner-satisfaction)
+- [Delivery quality](#delivery-quality)
+- [Employee engagement](#employee-engagement)
+- [Financial stability](#financial-stability)
+
+### Partner satisfaction
+
+Are our partners happy with our work? Would they work with us again? Would they recommend us to others?
+
+How we measure partner satisfaction:
+
+- **TTSC Customer Listening Tour.** Beginning in FY24, the TTSC director, along with some helpers, interviewed the primary points of contact for most of our active engagements. Questions focus on perceived value for the cost of our services and likelihood to use us again or recommend us. Respondents should be asked to quantify their satisfaction with TTSC so we can track year-over-year improvement via Net Promoter Score, Customer Satisfaction Score, or equivalent score as defined by the TTS Director’s annual goals.
+  - See: [Client Listening Tour 2024 in Google Drive](https://drive.google.com/drive/folders/1aWyWTFWi2lOUWZgU7tKHjQTNVWx96Zel)
+
+- **18F Partner Satisfaction Surveys.** For several years, 18F account managers have conducted partner satisfaction surveys after an engagement ends. These surveys are structured interviews. In FY24, began collecting them throughout the delivery cycle: 90 days after the engagement/project starts, and for longer engagements, every six-months thereafter. The feedback from these interviews is analyzed and shared out in a quarterly cadence.
+  - FY24 benchmarks were:
+    - 50% or more of partner satisfaction survey respondents report being Likely or Very Likely to recommend 18F to others
+    - 50% or more of partner satisfaction survey respondents report the value they received was at least equal to the budget spent
+  - See: [Partner Satisfaction in Airtable](https://airtable.com/appsLLLryeqBK2V9d/pag9PS4fgVFodV4cR) and the [form to add new records](https://airtable.com/appsLLLryeqBK2V9d/shr7nw1cFiwWuGpll)
+
+- **FAS Customer Loyalty Survey.** A standard survey sent annually to customers of each FAS business unit. This is a required survey for all FAS units, but the response rate for TTSC customers has been very low in the past few years so this data has not been a reliable indicator of partner satisfaction.
+  - See: [FY24 results](https://docs.google.com/presentation/d/1MlJH1yQs8cvb90uCDSLPg1wIeA7tM0WyE08TQmOc9W4/edit?usp=sharing)
+
+### Delivery quality
+
+Do our deliverables represent our standard operating procedures? Does our work have a positive impact on the public or government employees?
+
+How we measure delivery quality:
+
+- **Deliverables are consistent with the standard operating procedures in this handbook.** We’ve been helping modernize government for over ten years and know what approaches are likely to be successful. If your engagement needs to deviate from the SOPs in the handbook, you must be prepared to explain why. {% comment %}  - See: [Engagements](#TODO) {% endcomment %}
+
+- **Engagement impact assessment.** At every phase of an engagement, we should be assessing its potential for impact on the public or federal employees. Annually, TTSC also reviews overall impact and highlights.
+  - See: {% comment %}the [process to evaluate engagement success and impact](#TODO) and {% endcomment %}past impact reports:
+    - FY24 TTSC Impact Report TK
+    - [FY23 CoE Impact Report](https://drive.google.com/file/d/1KKzmJ9kULaDW1If6OiEyThhlplTXscPi/view?usp=sharing)
+    - [FY22 CoE Impact Report](https://docs.google.com/presentation/d/1pXcEmQu6w-eGEpogQ9mC5cTkG5XfIrb-nFkoz85ZRmc/edit#slide=id.p1)
+    - [FY22 CoE AI Impact Report](https://docs.google.com/document/d/1_TzPEvCjspG6vPsTur7seqbwdjqqLS5fOckmu1smrN0/edit?tab=t.0)
+
+### Employee engagement
+
+Are our staff stimulated by their work and content with our working conditions?
+
+How we measure employee engagement:
+
+- **TTSC pulse check surveys** have been conducted separately within 18F and CoE. These help us identify areas for improving employee experience. Surveys are conducted three or four times per year. Results are compiled and synthesized by a working group.
+  - See: [Example survey readout](https://docs.google.com/presentation/d/14z7kNBsc9PVaQ8rV8CATSpQw6KPOj3KHV5xEi0ejNKs/edit#slide=id.g22bc6aa6642_0_1288)
+
+- **Federal Employee Viewpoint Survey (FEVS)** is an organizational climate survey administered annually by the Office of Personnel Management. All TTSC employees are encouraged to participate. Results can be broken down to the levels of  TTSC, 18F, and CoE. Data from FEVS is considered in SES performance plans and TTS strategic planning.
+  - See: [OPM on FEVS](https://www.opm.gov/fevs/) and past results:
+    - FY24 FEVS results for TTSC TK
+
+### Financial stability
+
+Are we covering the direct costs of our office?
+
+How we measure financial stability:
+
+- **The organization aims to cover its direct costs,** which include staff labor. The metric we use to gauge progress towards cost recovery is utilization rate. {% comment %} - See: [organizational financial management](#TODO){% endcomment %}


### PR DESCRIPTION
Includes the first section of content for the TTSC handbook

## Changes proposed in this pull request:

- Adds support for section-level navigation in page headers, indicated in the main `navigation.yml` file.
- Adds previously-approved TTS Consulting handbook content (approvals secured by @SelenaJV)

As a note, this is the first of quite a bit of content that will be landing here, hence the new main section navigation approach. 

## Security considerations

None, content changes. 