### PR TITLE
Clean up meta keywords

### DIFF
--- a/pages/office-of-operations/blogging.md
+++ b/pages/office-of-operations/blogging.md
@@ -1,8 +1,6 @@
 ---
 title: Blogging Guide
-tag:
-  - blogging
-  - guide
+keywords: blogging, guide
 questions:
   - blog
   - outreach

--- a/pages/office-of-operations/fas-speaker-guide.md
+++ b/pages/office-of-operations/fas-speaker-guide.md
@@ -1,15 +1,6 @@
 ---
 title: Guidelines for speaking at events
-tag:
-  - attend
-  - attending
-  - speaking
-  - speaker
-  - events
-  - event
-  - conference
-  - conferences
-  - guide
+keywords: attend, attending, speaking, speaker, events, event, conference, conferences, guide
 redirect_from:
   - /fas-speaker-guide/
 cSpell: ignore Simms

--- a/pages/supervisor-resources/new-supervisor-playbook/play-10.md
+++ b/pages/supervisor-resources/new-supervisor-playbook/play-10.md
@@ -2,9 +2,7 @@
 title:
   Play 10 - Promote a healthy culture of improvement through constructive
   feedback
-tags:
-  - supervisor playbook
-  - leadership
+keywords: supervisor playbook, leadership
 ---
 
 Feedback, similar to delegation, is a fundamental tool in a supervisor’s (or

--- a/pages/tools/github.md
+++ b/pages/tools/github.md
@@ -1,7 +1,6 @@
 ---
 title: GitHub
-tag:
-  - Git
+keywords: Git
 questions:
   - admins-github
   - dev

--- a/pages/training-and-development/external-speaking-request-playbook.md
+++ b/pages/training-and-development/external-speaking-request-playbook.md
@@ -1,16 +1,6 @@
 ---
 title: External speaking request playbook
-tag:
-  - attend
-  - attending
-  - speaking
-  - speaker
-  - external event
-  - events
-  - event
-  - conference
-  - conferences
-  - guide
+keywords: attend, attending, speaking, speaker, external event, events, event, conference, conferences, guide
 ---
 
 **If this is a press request (newspaper, TV station, radio station, podcast, or

--- a/pages/travel-and-leave/fmla.md
+++ b/pages/travel-and-leave/fmla.md
@@ -1,13 +1,6 @@
 ---
 title: Family Medical Leave Act (FMLA)
-tags:
-  - leave
-  - request
-  - parental
-  - parent
-  - parental leave
-  - maternity
-  - paternity
+keywords: leave, request, parental, parent, parental leave, maternity, paternity
 ---
 If you have a serious personal or family medical event, the Family and Medical Leave Act (FMLA) can help give you peace of mind. 
 

--- a/pages/travel-and-leave/going-out-of-office.md
+++ b/pages/travel-and-leave/going-out-of-office.md
@@ -1,7 +1,6 @@
 ---
 title: Going out of office
-tags: 
-  - out of office
+keywords: out of office
 ---
 ## Your overall responsibilities
 

--- a/pages/travel-and-leave/paid-parental-leave.md
+++ b/pages/travel-and-leave/paid-parental-leave.md
@@ -1,12 +1,6 @@
 ---
 title: Paid parental leave (PPL)
-tags:
-  - parental
-  - parent
-  - parental leave
-  - timesheets
-  - maternity
-  - paternity
+keywords: parental, parent, parental leave, timesheets, maternity, paternity
 ---
 TTS has paid parental leave (PPL) for the birth or placement (adoption or foster care) of a child.
 


### PR DESCRIPTION
## Changes proposed in this pull request:
Replaced any other instances of `tags:` or `tag:` with `keywords:` so it will get picked up by the template to add meta keywords for search.

## security considerations
None, just content changes.