### PR TITLE
Add more Operations content to TTSC Handbook.

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -429,6 +429,10 @@ primary:
                 url: about-us/tts-consulting/operations/regulations/
               - text: Terminology and glossaries
                 url: about-us/tts-consulting/operations/glossary/
+              - text: Tracking your time and Tock
+                url: about-us/tts-consulting/operations/tock/
+              - text: Records management
+                url: about-us/tts-consulting/operations/records/
               - text: Conduct and norms
                 url: about-us/tts-consulting/operations/conduct-and-norms/
               - text: Performance management
@@ -437,6 +441,12 @@ primary:
                 url: about-us/tts-consulting/operations/finance/
               - text: Brand management
                 url: about-us/tts-consulting/operations/brand/
+              - text: Training and professional development
+                url: about-us/tts-consulting/operations/training/
+              - text: Operational initiatives and maintenance support
+                url: about-us/tts-consulting/operations/delivery-assurance/
+              - text: Management oversight of projects
+                url: about-us/tts-consulting/operations/oversight/
       - text: 18F
         children:
           - text: About 18F

--- a/pages/about-us/tts-consulting/about/planning.md
+++ b/pages/about-us/tts-consulting/about/planning.md
@@ -61,4 +61,5 @@ Are we covering the direct costs of our office?
 
 How we measure financial stability:
 
-- **The organization aims to cover its direct costs,** which include staff labor. The metric we use to gauge progress towards cost recovery is utilization rate. {% comment %} - See: [organizational financial management](#TODO){% endcomment %}
+- **The organization aims to cover its direct costs,** which include staff labor. The metric we use to gauge progress towards cost recovery is utilization rate.
+  - See: [Organizational financial management]({% page "about-us/tts-consulting/operations/finance/" %})

--- a/pages/about-us/tts-consulting/operations/delivery-assurance.md
+++ b/pages/about-us/tts-consulting/operations/delivery-assurance.md
@@ -1,0 +1,54 @@
+---
+title: Operational initiatives and maintenance support
+---
+
+As a lean and learning organization, a variety of one-off tasks, special initiatives, and occasional maintenance chores bubble up all the time. Sometimes these tasks fit clearly within the scope of an existing staff role, other times they could be done by anyone with a bit of time.
+
+Here are some of the mechanisms TTSC has to do this kind of work:
+
+| Resource | Helps with |
+|----------|------------|
+| [**\#18f-help-wanted**](##18f-help-wanted-slack-channel)  | **Short, fast, billable or non-billable tasks**  like writing review, graphic design, general volunteers |
+| **[Delivery Assurance (aka TLC)](#18f-delivery-assurance-\(aka-tlc-crew\))** | **Two week or less, non-billable tasks** like Facilitating project reflections, making updates or fixing bugs on 18F products,  |
+| [**18F Working Groups**](#18f-working-groups)  | **A few hours a week for a few months** like Internal surveys and analysis, developing smart default templates, revising performance plans |
+| [**TTS Operations support services**](#tts-operations-support-services)  | **Recurring TTS-level ops tasks or improvements**  like processing agreements, outreach approvals, hiring actions |
+
+## \#18f-help-wanted Slack channel {##18f-help-wanted-slack-channel}
+
+TTSC staff may request help from peers for a few hours of billable or non-billable work by posting to the {% slack_channel "18f-help-wanted Slack" %} channel.
+
+If your task is specifically for writing/editing help, use `@writing-editors` to ping the content designer group.
+
+If the task is for a partner project, Tock to the appropriate engagement code.
+
+## 18F Delivery Assurance (aka TLC Crew) {#18f-delivery-assurance-(aka-tlc-crew)}
+
+Between partner engagements, 18F staff provide operational and maintenance support to 18F products, processes, and teams. Individuals are temporarily staffed to “Delivery Assurance” which was nicknamed by staff “TLC Crew” because they are giving our organization and practices Tender Loving Care.
+
+Assignments occur in two-week increments. Supervisors take turns managing the crew and a member of the 18F LT leads issue prioritization every increment.
+
+TLC works on issues submitted through [the TLC repo](https://github.com/18F/TLC-crew/issues) or through connected repos for 18f.gsa.gov, 18F blog drafts, 18F Guides, and Tock. Common requests include leading project reflections, making updates or fixing bugs on 18F products, or supporting operational functions.
+
+To submit a request for the TLC Crew, please use the issue [templates](https://github.com/18F/TLC-crew/issues/new/choose). If you need access to 18F’s GitHub, post your request in the Slack channel {% slack_channel "admins-github" %}. (Watch a [tutorial on how to use GitHub](https://docs.google.com/presentation/d/1Kha6M0C2OC87x1zeXtFMKNrAbZZGJbkephbbBr7G_mw/edit?usp=sharing)).
+
+Since there can be no guarantee that this team is staffed every two weeks, TLC can’t guarantee delivery on issues in their repository *until they've been prioritized and assigned*. Consult the [TLC Crew README](https://github.com/18F/TLC-crew) for details.
+
+Billable work should always be prioritized over TLC’s non-billable tasks. Billable work should run through the BD pipeline and staffing process. {% comment %}TODO: link BD process to engagements section{% endcomment %}
+
+## 18F working groups {#18f-working-groups}
+
+Working groups typically start through GMT and include some supervisors. ICs may join working groups if it does not interfere with meeting billable expectations.
+
+Working groups are best for tasks that need a few hours a week for several months and benefit from continuity in who is doing the work. Examples include: conducting pulse check surveys and analysis, developing smart default templates, revising performance plans, building out operational AirTable interfaces.
+
+If you have an idea for a working group, talk to your supervisor.
+
+## TTS Operations support services {#tts-operations-support-services}
+
+The TTS Office of Operations is tasked with supporting business functions in the various TTS Delivery units including TTSC. They are organized into divisions including Acquisitions, Business Operations, Outreach & Marketing, Market Development & Partnerships, and Talent.
+
+For help with hiring, HR, benefits, finances, agreements, travel, coaching, etc, follow these steps:
+
+1. Consult the main TTS Handbook. It is the primary source of information about support services and operational functions managed at the TTS level, including Talent, Business Ops, People Ops, benefits, etc.
+2. Ask your supervisor.
+3. Reach out to your [support contact for TTS employees](https://docs.google.com/document/d/15glvq9UakKUN8XTRTa6gRkhBHm2whhQyAGmf8ibTtBs/edit) for the specific service.

--- a/pages/about-us/tts-consulting/operations/onboarding.md
+++ b/pages/about-us/tts-consulting/operations/onboarding.md
@@ -109,7 +109,7 @@ The outline below suggests topics to cover with new employees in their first two
 
 #### Payroll and tracking time in Tock
 
-- Review Tock guidance, especially what is billable vs non-billable work. {% comment %}TODO link Tock guidance to time tracking page when it exists{% endcomment %}
+- Review [Tock guidance]({% page "about-us/tts-consulting/operations/tock/" %}), especially what is billable vs non-billable work.
 - Offer to demonstrate how to use Tock, what Tock entries can look like with time off or multiple projects, and how to submit a change request.
 - Link them to the [GSA payroll calendars](https://www.gsa.gov/buying-selling/purchasing-programs/shared-services/payroll-shared-services/payroll-calendars) so they know when they will get their first paycheck.
 
@@ -206,7 +206,7 @@ Onboarding buddies are one of the first points of contact for a new employee at 
 - [TTS Onboarding Buddies Overview](https://docs.google.com/document/d/1rO4TRcqYM-j70cHC1y8Vabfwp9TWwp5WFF7BraSUxLk/edit#heading=h.87p1j88vrkez) explains what the role is and is not and what an onboarding buddy does.
 - [\[MAKE A COPY\] TTS Onboarding Buddy Checklist](https://docs.google.com/spreadsheets/d/1JPcm7QE6eF5Y82DGRl4DUMMlBza26FPxmkq3fybum5U/edit#gid=238273324) outlines all the tasks an onboarding buddy should do before and after the new employee arrives. Make a copy for yourself.
 - [How to be a great CoE onboarding buddy!](https://docs.google.com/document/d/12ykZHVH5O182dN7Hm6-6C9z-H3seKGZzDzaUqqo0OxI/edit?tab=t.0#heading=h.4oq35vyptb97) provides additional suggestions for onboarding buddies. Some portions of this document may be out of date.
-- Refer to the handbook section on time tracking for instructions on how to bill your time as an onboarding buddy.{% comment %}TODO: Link the handbook section on time tracking to the Tock guidance when it exists.{% endcomment %}
+- Refer to the [handbook section on time tracking]({% page "about-us/tts-consulting/operations/tock/" %}) for instructions on how to bill your time as an onboarding buddy.
 - Relevant Slack channels for onboarding buddies include:
   - {% slack_channel "wg-onboarding" %}
   - {% slack_channel "18f-wg-onboarding" %}

--- a/pages/about-us/tts-consulting/operations/oversight.md
+++ b/pages/about-us/tts-consulting/operations/oversight.md
@@ -1,0 +1,62 @@
+---
+title: Management oversight of projects
+---
+
+Leadership at the TTS, TTSC, CoE, and 18F levels all need to keep tabs on what’s happening with our projects. Here’s what they look at to do that.
+
+- **How is TTSC doing overall?**
+  - [TTSC Monthly Program Review](https://drive.google.com/drive/folders/1GZhnFA2yNrlYhZszAu_fezZ7Qrl3DEKP): Brief for TTS Front Office and TTS Operations on TTSC’s finance, business development, current project highlights, and people management priorities
+- **Who is assigned to what project?**
+  - [18F Airtable staffing interfaces](https://airtable.com/appsLLLryeqBK2V9d/pagH8pnJhLcix3V2v?CJpsb=allRecords)
+  - [CoE AirTable staffing interfaces](https://airtable.com/appde6nxcyY2NVG4E/pagEMG6s8fenIWCkU)
+  - These can be sorted by project or chapter
+- **What projects are starting soon?**
+  - [18F staffing repo](https://github.com/18F/staffing/issues)
+  - [CoE BD leads in signatures](https://airtable.com/appde6nxcyY2NVG4E/paga9X5WQBBNKSIcS)
+- **What’s happening on active projects?**
+  - Across projects
+    - [18F project health reports](https://airtable.com/appsLLLryeqBK2V9d/pagdt0x1ob5jVASh6?Xq8ld=sfsocbdU0K2Vsxnpd) which 18F LT reviews weekly
+    - [Weekly ships](https://gsa.enterprise.slack.com/archives/C4HGPF9QA) are emailed to partners and posted in Slack
+    - [18F Monthly Project Snapshot meetings](https://drive.google.com/drive/folders/1KPLs6gNkRjHS-eFzHUvmP6wu8GyVJgoO) share high-level project status with TTSC leadership and identify where executive intervention may be helpful
+    - [CoE State of the Centers](https://airtable.com/appde6nxcyY2NVG4E/pagjOUUulLtGB85zH?uBQYc=rec4SqXJxMQVnP7zB)
+  - For specific projects (in [Agency folder](https://drive.google.com/drive/folders/1_7ZD6nozGJd4fjOsa473j0KYvN0rIwUg))
+    - Their executive briefing deck
+    - Their risk tracker
+    - Their project readme
+    - Their burn doc
+- **What prospective projects and leads are coming in?**
+  - [18F Business development pipeline interfaces](https://airtable.com/appsLLLryeqBK2V9d/pagZwxjxxbuYBIItC)
+  - [CoE Business development pipeline](https://airtable.com/appde6nxcyY2NVG4E/paga9X5WQBBNKSIcS)
+- **How does our staff capacity and incoming work line up?**
+  - [18F capacity projections](https://docs.google.com/spreadsheets/d/1Ero0A-o_VlB-rlHFnOiiM8KMPDZqAU_n1E2OnsL_Slk/edit?gid=508470679#gid=508470679)
+  - CoE TK
+- **What projects have we done in the past?**
+  - [List of past 18F projects](https://airtable.com/appH9BA2ezbDuXqhH/tblCdG6BatRBR0j48/viwCjBdbLstTDtq1K?blocks=hide) (Airtable, 2014-2023)
+  - [List of past CoE projects](https://airtable.com/appde6nxcyY2NVG4E/tblM1wWqsnI2YPvmc/viwYbLdiSvmUKm7zf?blocks=hide)
+
+## Tracking operational data in AirTable
+
+TTSC uses AirTable to manage a variety of data about our operational “engine” including our staff, our engagements, and our resources.
+
+### Key AirTable interfaces
+
+- **[TTSC combined base](https://airtable.com/appFD087Gd8jhztYz?ao=cmVjZW50)**
+  - Viewing data about 18F and CoE operations together. This is new and still in development.
+- **[TTSC calendar](https://airtable.com/appN6llr7h1vUry6P/pag1kYDFRwB6qUilp?cmpsj=allRecords)**
+   - Staff to see TTSC events, organizational milestones, etc. — you can [subscribe to a feed that brings these into your Google Calendar](https://airtable.com/appN6llr7h1vUry6P/pag0aA4Lrc6QZta3Q).
+- **[18F Resource Library](https://airtable.com/appkBrEBVTMd9M5VC/pagyCKyWNdrBCgvP1)**
+  - Finding templates, trainings, and examples of past 18F engagement work.
+- **[18F Humans](https://airtable.com/appsLLLryeqBK2V9d/pag7RqRJYNNCXuBsl)**
+  - Tracking 18F staff assignments, BD leads, project health, etc.
+- **[CoE Engagement management tracker](https://airtable.com/appde6nxcyY2NVG4E/tblWc6oYuYa3TLngE/viwHYfeZUj2aiYWi9?blocks=hide)**
+  - Tracking CoE humans and engagements. This is new and still in development.
+
+### How is data maintained in AirTable?
+
+Guidance TK.
+
+{% comment %}
+### Further resources
+
+* [Checklist of project reporting tasks](#TODO) (link to Engagements section)
+{% endcomment %}

--- a/pages/about-us/tts-consulting/operations/records.md
+++ b/pages/about-us/tts-consulting/operations/records.md
@@ -1,0 +1,41 @@
+---
+title: Records management
+---
+
+A “record” is any information — stored in any physical or digital format — that documents the agency’s organization, decisions, functions, activities, and commitments.
+
+At TTSC, records may include emails, contracts, presentations, reports, files in Google Drive, Slack posts, etc. Common records include:
+
+- IAA agreements with partners
+- Business development pipeline notes
+- Roadmaps
+- Decision-making frameworks
+- Research plans
+- Survey results
+- Usability test results
+- Meeting notes
+- Retros
+- Project health responses
+- Prototypes
+
+## Why does records management matter?
+
+Records management is the law (specifically the Federal Records Act of 1950). GSA staff are required to make and preserve records.
+
+Good records management helps us keep our commitments to partners and employees, make good decisions, show evidence of our organization’s impact, and comply with transparency mandates, such as FOIA requests.
+
+For more information on records management policy and general guidance, please review the records management training in OLU.
+
+## Who is responsible for records management?
+
+All TTSC staff are responsible for records management.
+
+On projects, AMs, PLs, and ELs are accountable for ensuring records for their projects are properly managed and archived.
+
+For 18F, the 18F Folder is owned by the 18F Director and the Director of Operations.
+
+For CoE, the CoE Drive is owned by CoE Front Office and CoE Management Team google groups are both owners.
+
+## How should I manage my records in Google Drive?
+
+Guidance TK.

--- a/pages/about-us/tts-consulting/operations/tock.md
+++ b/pages/about-us/tts-consulting/operations/tock.md
@@ -1,0 +1,216 @@
+---
+title: Tracking your time and using Tock
+cspell: ignore Nonbillable, Tocks
+---
+
+## How should TTSC staff allocate our time?
+
+TTSC employees are expected to bill a certain amount of hours towards assigned billable projects each week. TTSC does not penalize employees for lower utilization if they haven’t been assigned billable work.
+
+Supervisors’ utilization expectations are based on the number of direct reports, detailed in the table below:
+
+| Number of direct reports | Utilization % target | Target hours |
+|--------------------------|----------------------|--------------|
+| \>/=7 | 30% | 10-16 hours |
+| 6 | 40% | 14-18 hours |
+| 5 | 50% | 16-20 hours |
+| 4 | 60% | 18-24 hours |
+| 1-3 | 65% | 20-26 hours |
+| 0 (individual contributors) | 80%+ | 32+ hours |
+
+## What is billable? What is not billable?
+
+Generally:
+
+- **Billable time** = Work that enables engagement delivery
+- **Nonbillable time** = Indirect work that does not provide direct value to engagement delivery
+
+### Billable time
+
+You must bill all time that is a direct cost to a project. This includes:
+
+- Discipline-specific work for a project, i.e. Engineering, Design, Product, or Strategy work
+- Project team meetings (stand-ups, grooming, planning, retro, and anything else\!)
+- 1:1s with project team members
+- Client meetings
+- Travel to client meetings, as well as time spent arranging travel and getting reimbursement
+- Time reading Slack channels about the project
+- Time reading emails about a project
+- Time thinking/brainstorming about project work, even if not in front of your computer
+- Time talking about your project at team meetings, or publicly
+- Time writing about your project on the blog
+- Time onboarding to a project, which includes reading documentation and learning about the agency
+- Time offboarding from a project. This includes postmortems, writing documentation, and organizing your working files so that other people could pick it up later and continue your work
+- Business development and IAA work (for continuing projects only)
+- Conferences, training and meetings that are in service of project work
+- Coordinating staffing for projects with a signed IAA
+
+Sometimes internal TTSC meetings provide direct value to your engagement and can be billed — for example, a discussion with your supervisor about a deliverable, attending a guild session where you learn tips for your current ATO process, or getting feedback in a critique group. Talk to your supervisor if you’re unsure if an activity is billable or not billable.
+
+#### Billable TTSC Tock codes
+
+We are in the process of consolidating nonbillable codes across TTSC, but for now please continue to use the appropriate codes for your team:
+
+| Work type | CoE feds | 18F |
+|-----------|----------|-----|
+| **Work for a partner** by folks staffed to the engagement. | Ask EL | Ask AM |
+| **Engagement support or deliverable review.** Use this code if you are not staffed to the engagement. | Ask EL | Ask AM |
+| **Fully reimbursable details.** If a detail is not fully reimbursable, talk to leadership first. | ? | 1995 |
+| **Helping TTS/GSA.** If you are asked to assist with any hiring or support activities outside of 18F/CoE, please talk to your supervisor. They can advise you on the proper code and billability. | Ask supervisor | Ask supervisor |
+
+### Nonbillable time
+
+{% alert %}
+  Supervisors will review other non-billable circumstances and provide further guidance. Ask your supervisor if you are unclear what to bill.
+{% endalert %}
+
+You must not bill for the following activities because these are indirect costs and are not inherently valuable to any one single partner:
+
+- Out of office (Award leave, sick leave, PTO)
+- Conferences, trainings and meetings that are not in service of project work
+- OLU trainings that are not in service of project work
+- Internal organization meetings (Team Coffees, TTS Town Hall)
+- Business development for new projects (on non-live projects – developing a continuation of work plan is okay to bill.)
+- Hiring activities, including interviews, resume reviews, stand-ups
+- Performance reviews
+- New hire onboarding
+
+#### Common nonbillable TTSC Tock codes
+
+We are in the process of consolidating nonbillable codes across TTSC, but for now please continue to use the appropriate codes for your team:
+
+| Work type | CoE feds | 18F |
+|-----------|----------|-----|
+| TTSC change management work | 1947 | 1976 |
+| Business development | 1434 | 1811 |
+| Administrative & supervisory | 2080 | 1814 |
+| TLC Crew | *NA* | 1813 |
+| Hiring & onboarding (18F) | *NA* | 1241 |
+| Tock maintenance and development | *NA* | 1109 |
+| Staffing | *NA* | 1812 |
+| Front office (CoE) | 1112 | *NA* |
+| GSA-mandated | 1347 | *NA* |
+| CAP (Corrective Action Plan) | 1946 | *NA* |
+| External outreach and communications | 1437 | *NA* |
+| COR duties (nonbillable) | 1874 | *NA* |
+| Nonbillable hours | 1145 | *NA* |
+| Professional development | ? | *NA* |
+| **Out of office** (under 3 weeks) | ? | 670 |
+| **Extended out of office** (more than 3 weeks) | ? | 1810 |
+| **Non-reimbursable details.** Talk to leadership before taking non-reimbursable details and for guidance on how to report the time. | Ask leadership | Ask leadership |
+| **Helping TTS/GSA.** If you are asked to assist with any hiring or support activities outside of 18F/CoE, please talk to your supervisor. They can advise you on the proper code and billability. | Ask supervisor | Ask supervisor |
+
+## Frequently asked questions
+
+### About Tock and time tracking
+
+#### What is Tock and why do we use it?
+
+Tock is a different tool than [HRLinks](https://hrlinks.gsa.gov/). Here is a quick comparison:
+
+|  | Tock timesheet | HRLinks timesheet |
+|--|----------------|-------------------|
+| **Level** | TTS | GSA |
+| **Cadence** | Weekly | Bi-weekly |
+| **Goal** | Tracks how time is spent, so we bill partners appropriately | Tracks how much an employee is working, so we track leave appropriately |
+| **Timesheet shows** | How time is spent within a given week (billable and nonbillable) | How much time was spent working within a pay period, and what kind of leave was taken (sick, annual, award, admin, etc.) |
+
+#### Who is responsible for time tracking?
+
+- **All TTSC employees** are expected to Tock weekly by COB (close of business) each Friday, and submit HRLinks timesheets every two weeks.
+- **Supervisors** are responsible for checking hours logged by their direct reports in Tock, including billable and nonbillable time. They also approve HRLinks timesheets every two weeks.
+- **AM/EL/EMTs** review and approve time billed to engagements on a monthly basis via the engagement Tock report.
+
+#### How and when do I log my time in Tock?
+
+The weekly time reporting period lasts one week, beginning on Sunday and ending on Saturday. You must review and submit your timecard each week by the end of the day (close of business) on Friday. When submitting your timecard, choose the correct week for your entries from the list on the homepage, adjust your Tock entry to reflect how you spent your time, and then submit your timesheet.
+
+Failing to Tock on time prevents Operations from running financial reports and creates a lot of work for other people. Please make sure you Tock before you end your workday on Friday. If Friday is a holiday, then you’ll be expected to complete your timecard by the first workday following.
+
+Timecards for the current week should be available no later than Monday at 9AM PST.
+
+#### Where do I go for guidance on specific Tocking activity?
+
+##### For billable engagement work
+
+The AM/EL is your first point of contact regarding Tock guidance. If the activity is still in question or is not related to a specific engagement, escalate up to the supervisor, and then your director for further guidance.
+
+If you ARE the AM/EL, go to your Supervisor.
+
+##### For non-billable Work
+
+Your supervisor is the first point of contact regarding Tock guidance on non-engagement work.
+
+### Working more than 40 hours
+
+#### Can I Tock more than 40 hours in a week?
+
+We can’t work more than 40 total hours without being compensated for that time. Working overtime without prior approval violates the [Antideficiency Act](https://www.gao.gov/legal/appropriations-law/resources).
+
+If you find yourself needing to work more than 40 hours, here are the steps to take *before* you work any extra hours.
+
+{% alert %}
+  If you have an established Alternate Work Schedule (AWS), your situation may be [slightly different](#how-does-aws-impact-how-i-tock?).
+{% endalert %}
+
+First, ensure you can work the extra hours:
+
+1. Talk to your Engagement Lead, Account Manager or Project Lead **and** supervisor to figure out if and how much over 40 hours you can work.
+    - The Engagement Lead, Account Manager, or Project Lead should inform leadership that overtime is necessary, so they can provide support and guidance as needed.
+2. The Engagement Lead, Account Manager, or Project Lead must check and then adjust the engagement’s financial accounting.
+3. The supervisor must approve the requested hours in [HRLinks](https://hrlinks.gsa.gov/). Generally, Compensatory Time (comp time) is the option likely to be approved. Overtime is generally not an option as it triggers increased compensation.
+4. Get your supervisor’s approval in writing. Your Supervisor must justify the comp time upon submission of your timesheet in HRLinks.
+
+Then, make sure to accurately track your overtime hours in Tock and HRLinks:
+
+5. Request overtime in {% slack_channel "tock" %}. The Tock administrator will adjust the Tock setting to allow for 40+ hours to be recorded.
+6. Work your week!
+7. Log total hours in Tock.
+8. Check that your approved extra hours have been properly accounted for prior to submitting your timesheet in HRLinks. Log total hours in HRLinks. This is where your comp time is recorded and where you’ll use it for future leave. In HRLinks, navigate to Request Absence/OT and make a comp time earned request for the extra hours you worked.
+
+No matter how many hours you work, it is crucial that you accurately report those hours in Tock. Knowing the actual amount of time you work helps us better scope and estimate costs and rates.
+
+#### How does AWS impact how I Tock? {#how-does-aws-impact-how-i-tock?}
+
+Tock will limit you to 40 hours per week by default. Please request an alternative work schedule in {% slack_channel "tock" %} if you are on an AWS. You do not need to do this if you are on a flexible week schedule.
+
+#### Can I ‘save’ billable hours to apply to a subsequent week?
+
+No. Please don’t “save” hours or avoid billing for time you’ve worked in a given week. In addition to hurting our capacity to improve our engagement scoping assumptions, it is illegal not to bill for time spent working for partners.
+
+There are several mechanisms and processes in place to make sure engagements don’t go over budget:
+
+- We build a risk reserve within each engagement to ensure we have extra hours for needs that arise during the engagement.
+- Engagement Leads closely monitor engagement burns on a weekly basis and communicate that to TTSC Leadership and Front Office.
+
+In short, we need to know if our scoping is accurate and understand the cadence of work throughout an engagement. We’d rather be over budget and have our teams deliver value than be under budget and hide how many hours it truly takes to deliver on our engagements.
+
+## How do I correct a prior Tock submission?
+
+Submit a Tock change request using [the Tock Change Request form](https://docs.google.com/forms/d/e/1FAIpQLSe5RDFOlyWm0IXv7_eXjZ3CEjaGj2CmM-_TNgqwMjdspfQz7Q/viewform). You can also ping the Tock team in the {% slack_channel "tock" %} Slack channel. Make sure to inform your AM/EL with any submitted change requests.
+
+## How do I log my time for upcoming leave?
+
+If you are going to be out of the office for an extended period of time, head to the {% slack_channel "tock" %} channel in Slack before you leave and ask that the team submit your Tock hours for you during your out of office period.
+
+Example:
+
+> “I will be out of the office from Monday September 16th through Monday September 23rd: could you enter 40 hours for me to \#670 for the 16th-20th time period?”
+
+## How do supervisors review hours logged in Tock?
+
+Supervisors should regularly review the hours their direct reports are logging.
+
+From the [View users](https://tock.18f.gov/employees/) tab in Tock, search the list of users lists of users, then click and open the report to review their recent Tocks. Check:
+
+- Overall utilization rate
+- Out of office time accounted for (including holidays and any administrative leave granted)
+- Correct Tock lines (including details and extended out of office)
+- Correct billable expectation
+
+18F supervisors are expected to complete the [Weekly Supervisor Data Check](https://airtable.com/app1anoO5i5d3RJRA/pagYbQmUcGgPS4lEt/form).
+
+## Technical difficulties? Questions?
+
+{% comment %}* Also see [Managing project finances](#TODO).{% endcomment %}
+- Visit the {% slack_channel "tock" %} Slack channel.

--- a/pages/about-us/tts-consulting/operations/training.md
+++ b/pages/about-us/tts-consulting/operations/training.md
@@ -1,0 +1,32 @@
+---
+title: Training and professional development
+cspell: ignore recertification
+---
+
+After onboarding, TTSC staff have various training obligations, some of which are mandatory. TTSC also encourages staff to seek out and take advantage of professional development opportunities each year.
+
+## Mandatory training
+
+TTS and GSA require employees to complete annual recertification on a variety of topics. Required courses are conducted through GSA’s [Online University](https://gsaolu.gsa.gov/). See the [current list of mandatory trainings](https://insite.gsa.gov/employee-resources/training-and-development/mandatory-training).
+
+Supervisors, CORs, and acquisition consultants may have additional mandatory training to complete.
+
+## Other trainings
+
+### TTS Consulting group trainings
+
+Training themes across the organization are established annually. Staff work to bring in trainings to meet these needs. They are shared via email and Slack.
+
+Resource: [18F training themes for fall and winter 2024](https://docs.google.com/presentation/u/0/d/1-Q6203wFy7CrkVq-Iu2JjkHVKULtizhU8Wi6SZ-i8QY/edit)
+
+### Ad hoc group trainings
+
+Groups within TTSC can arrange for training to meet their specific needs. If training involves a cost, funding may be requested. Guidance TK.
+
+### Individual professional development activities
+
+If you want to attend a virtual or in-person training event, discuss it with your supervisor. Also consult the [guidance in the TTS Handbook]({% page "training-and-development/conferences-events-training/" %}).
+
+OLU is also a source for optional training courses and professional development resources, such as books. Check out the [TTS Handbook page on development and training]({% page "training-and-development/" %}).
+
+The [TTSC Resource Library](https://airtable.com/appkBrEBVTMd9M5VC/pagyCKyWNdrBCgvP1) also includes recorded presentations, templates, and decks on a variety of topics.


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds remaining "ready-to-ship" sections of Operations — after this pull request, we have 4 remaining pages in the Ops section before moving on to Engagements.

## Security considerations

None, content changes only.
