### PR TITLE
Adjust organization of TTSC Tock page

### DIFF
--- a/pages/about-us/tts-consulting/operations/tock.md
+++ b/pages/about-us/tts-consulting/operations/tock.md
@@ -3,9 +3,28 @@ title: Tracking your time and using Tock
 cspell: ignore Nonbillable, Tocks
 ---
 
-## How should TTSC staff allocate our time?
+Tock is a different tool than [HRLinks](https://hrlinks.gsa.gov/). Here is a quick comparison:
+
+|  | Tock timesheet | HRLinks timesheet |
+|--|----------------|-------------------|
+| **Level** | TTS | GSA |
+| **Cadence** | Weekly | Bi-weekly |
+| **Goal** | Tracks how time is spent, so we bill partners appropriately | Tracks how much an employee is working, so we track leave appropriately |
+| **Timesheet shows** | How time is spent within a given week (billable and nonbillable) | How much time was spent working within a pay period, and what kind of leave was taken (sick, annual, award, admin, etc.) |
+
+## Billable expectations
+
+{% alert %}
+  Failing to Tock on time prevents Operations from running financial reports and creates a lot of work for other people. Please make sure you Tock before you end your workday on Friday. If Friday is a holiday, then you’ll be expected to complete your timecard by the first workday following.
+
+  Timecards for the current week should be available no later than Monday at 9AM PST.
+{% endalert %}
 
 TTSC employees are expected to bill a certain amount of hours towards assigned billable projects each week. TTSC does not penalize employees for lower utilization if they haven’t been assigned billable work.
+
+- **All TTSC employees** are expected to Tock weekly by COB (close of business) each Friday, and submit HRLinks timesheets every two weeks.
+- **Supervisors** are responsible for [checking hours logged by their direct reports in Tock](#supervisor-review), including billable and nonbillable time. They also approve HRLinks timesheets every two weeks.
+- **AM/EL/EMTs** review and approve time billed to engagements on a monthly basis via the engagement Tock report.
 
 Supervisors’ utilization expectations are based on the number of direct reports, detailed in the table below:
 
@@ -18,14 +37,14 @@ Supervisors’ utilization expectations are based on the number of direct report
 | 1-3 | 65% | 20-26 hours |
 | 0 (individual contributors) | 80%+ | 32+ hours |
 
-## What is billable? What is not billable?
+### What is billable? What is not billable? What codes do I use?
 
 Generally:
 
 - **Billable time** = Work that enables engagement delivery
 - **Nonbillable time** = Indirect work that does not provide direct value to engagement delivery
 
-### Billable time
+#### Billable time
 
 You must bill all time that is a direct cost to a project. This includes:
 
@@ -47,7 +66,7 @@ You must bill all time that is a direct cost to a project. This includes:
 
 Sometimes internal TTSC meetings provide direct value to your engagement and can be billed — for example, a discussion with your supervisor about a deliverable, attending a guild session where you learn tips for your current ATO process, or getting feedback in a critique group. Talk to your supervisor if you’re unsure if an activity is billable or not billable.
 
-#### Billable TTSC Tock codes
+##### Billable TTSC Tock codes
 
 We are in the process of consolidating nonbillable codes across TTSC, but for now please continue to use the appropriate codes for your team:
 
@@ -58,7 +77,7 @@ We are in the process of consolidating nonbillable codes across TTSC, but for no
 | **Fully reimbursable details.** If a detail is not fully reimbursable, talk to leadership first. | ? | 1995 |
 | **Helping TTS/GSA.** If you are asked to assist with any hiring or support activities outside of 18F/CoE, please talk to your supervisor. They can advise you on the proper code and billability. | Ask supervisor | Ask supervisor |
 
-### Nonbillable time
+#### Nonbillable time
 
 {% alert %}
   Supervisors will review other non-billable circumstances and provide further guidance. Ask your supervisor if you are unclear what to bill.
@@ -75,7 +94,7 @@ You must not bill for the following activities because these are indirect costs 
 - Performance reviews
 - New hire onboarding
 
-#### Common nonbillable TTSC Tock codes
+##### Common nonbillable TTSC Tock codes
 
 We are in the process of consolidating nonbillable codes across TTSC, but for now please continue to use the appropriate codes for your team:
 
@@ -100,58 +119,31 @@ We are in the process of consolidating nonbillable codes across TTSC, but for no
 | **Non-reimbursable details.** Talk to leadership before taking non-reimbursable details and for guidance on how to report the time. | Ask leadership | Ask leadership |
 | **Helping TTS/GSA.** If you are asked to assist with any hiring or support activities outside of 18F/CoE, please talk to your supervisor. They can advise you on the proper code and billability. | Ask supervisor | Ask supervisor |
 
-## Frequently asked questions
+### Where do I go for guidance on specific Tocking activity?
 
-### About Tock and time tracking
-
-#### What is Tock and why do we use it?
-
-Tock is a different tool than [HRLinks](https://hrlinks.gsa.gov/). Here is a quick comparison:
-
-|  | Tock timesheet | HRLinks timesheet |
-|--|----------------|-------------------|
-| **Level** | TTS | GSA |
-| **Cadence** | Weekly | Bi-weekly |
-| **Goal** | Tracks how time is spent, so we bill partners appropriately | Tracks how much an employee is working, so we track leave appropriately |
-| **Timesheet shows** | How time is spent within a given week (billable and nonbillable) | How much time was spent working within a pay period, and what kind of leave was taken (sick, annual, award, admin, etc.) |
-
-#### Who is responsible for time tracking?
-
-- **All TTSC employees** are expected to Tock weekly by COB (close of business) each Friday, and submit HRLinks timesheets every two weeks.
-- **Supervisors** are responsible for checking hours logged by their direct reports in Tock, including billable and nonbillable time. They also approve HRLinks timesheets every two weeks.
-- **AM/EL/EMTs** review and approve time billed to engagements on a monthly basis via the engagement Tock report.
-
-#### How and when do I log my time in Tock?
-
-The weekly time reporting period lasts one week, beginning on Sunday and ending on Saturday. You must review and submit your timecard each week by the end of the day (close of business) on Friday. When submitting your timecard, choose the correct week for your entries from the list on the homepage, adjust your Tock entry to reflect how you spent your time, and then submit your timesheet.
-
-Failing to Tock on time prevents Operations from running financial reports and creates a lot of work for other people. Please make sure you Tock before you end your workday on Friday. If Friday is a holiday, then you’ll be expected to complete your timecard by the first workday following.
-
-Timecards for the current week should be available no later than Monday at 9AM PST.
-
-#### Where do I go for guidance on specific Tocking activity?
-
-##### For billable engagement work
+#### For billable engagement work
 
 The AM/EL is your first point of contact regarding Tock guidance. If the activity is still in question or is not related to a specific engagement, escalate up to the supervisor, and then your director for further guidance.
 
 If you ARE the AM/EL, go to your Supervisor.
 
-##### For non-billable Work
+#### For non-billable Work
 
 Your supervisor is the first point of contact regarding Tock guidance on non-engagement work.
 
-### Working more than 40 hours
+## Working more than 40 hours
 
-#### Can I Tock more than 40 hours in a week?
+### With an Alternate Work Schedule (AWS)
 
-We can’t work more than 40 total hours without being compensated for that time. Working overtime without prior approval violates the [Antideficiency Act](https://www.gao.gov/legal/appropriations-law/resources).
+Tock will limit you to 40 hours per week by default. Please request an alternative work schedule in {% slack_channel "tock" %} if you are on an AWS. You do not need to do this if you are on a flexible week schedule.
+
+### With a standard working schedule
+
+{% alert "", "warning" %}
+  We can’t work more than 40 total hours without being compensated for that time. Working overtime without prior approval violates the [Antideficiency Act](https://www.gao.gov/legal/appropriations-law/resources).
+{% endalert %}
 
 If you find yourself needing to work more than 40 hours, here are the steps to take *before* you work any extra hours.
-
-{% alert %}
-  If you have an established Alternate Work Schedule (AWS), your situation may be [slightly different](#how-does-aws-impact-how-i-tock?).
-{% endalert %}
 
 First, ensure you can work the extra hours:
 
@@ -170,11 +162,7 @@ Then, make sure to accurately track your overtime hours in Tock and HRLinks:
 
 No matter how many hours you work, it is crucial that you accurately report those hours in Tock. Knowing the actual amount of time you work helps us better scope and estimate costs and rates.
 
-#### How does AWS impact how I Tock? {#how-does-aws-impact-how-i-tock?}
-
-Tock will limit you to 40 hours per week by default. Please request an alternative work schedule in {% slack_channel "tock" %} if you are on an AWS. You do not need to do this if you are on a flexible week schedule.
-
-#### Can I ‘save’ billable hours to apply to a subsequent week?
+### Can I ‘save’ billable hours to apply to a subsequent week?
 
 No. Please don’t “save” hours or avoid billing for time you’ve worked in a given week. In addition to hurting our capacity to improve our engagement scoping assumptions, it is illegal not to bill for time spent working for partners.
 
@@ -185,19 +173,19 @@ There are several mechanisms and processes in place to make sure engagements don
 
 In short, we need to know if our scoping is accurate and understand the cadence of work throughout an engagement. We’d rather be over budget and have our teams deliver value than be under budget and hide how many hours it truly takes to deliver on our engagements.
 
-## How do I correct a prior Tock submission?
+## Correcting prior Tock submissions
 
 Submit a Tock change request using [the Tock Change Request form](https://docs.google.com/forms/d/e/1FAIpQLSe5RDFOlyWm0IXv7_eXjZ3CEjaGj2CmM-_TNgqwMjdspfQz7Q/viewform). You can also ping the Tock team in the {% slack_channel "tock" %} Slack channel. Make sure to inform your AM/EL with any submitted change requests.
 
-## How do I log my time for upcoming leave?
+## Logging time for upcoming leave
 
-If you are going to be out of the office for an extended period of time, head to the {% slack_channel "tock" %} channel in Slack before you leave and ask that the team submit your Tock hours for you during your out of office period.
+If you are going to be out of the office for an extended period of time and that time period is not available to report yet, head to the {% slack_channel "tock" %} channel in Slack before you leave and ask that the team submit your Tock hours for you during your out of office period.
 
 Example:
 
 > “I will be out of the office from Monday September 16th through Monday September 23rd: could you enter 40 hours for me to \#670 for the 16th-20th time period?”
 
-## How do supervisors review hours logged in Tock?
+## How do supervisors review hours logged in Tock? {#supervisor-review}
 
 Supervisors should regularly review the hours their direct reports are logging.
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adjusts headings and organization of content in the TTSC Tock guidance page to address https://github.com/18F/handbook/pull/4048#pullrequestreview-2518394311.

Direct link to [this page preview link](https://federalist-cf8341ad-ca07-488c-bd96-0738014c79ca.sites.pages.cloud.gov/preview/18f/handbook/ttsc-handbook-tock-updates/about-us/tts-consulting/operations/tock/). 

I'll want @SelenaJV’s eyes on this before merging. 

## Security considerations

None, content changes only.
