### PR TITLE
Update channel name.

### DIFF
--- a/pages/18f/chapters/design.md
+++ b/pages/18f/chapters/design.md
@@ -51,7 +51,7 @@ Find us on Slack:
 - {% slack_channel "product-design" %}
 - {% slack_channel "g-content" %}
 - {% slack_channel "g-research" %}
-- {% slack_channel "18f-help-wanted" %}
+- {% slack_channel "ttsc-help-wanted" %}
 - {% slack_channel "dev-frontend" %}
 - {% slack_channel "18f-methods" %}
 
@@ -181,7 +181,7 @@ Trello]({% page "/trello" %}) page.
 #### Research
 
 - Please read [Doing Research at TTS]({% page "/research-guidelines" %}) for
-  more information on the tools and techniques. 
+  more information on the tools and techniques.
 - The [18F UX Guide](https://ux-guide.18f.gov/) provides additional guidance on how we conduct research.
 - **Analytics:** We recommend leveraging the
   [Digital Analytics Program](https://digital.gov/services/dap/) whenever

--- a/pages/18f/projects-partners/consulting-engineering-guide.md
+++ b/pages/18f/projects-partners/consulting-engineering-guide.md
@@ -186,7 +186,7 @@ skills. If so, some options you might want to look at include:
 
 - Billable projects — Cloud.gov and Login.gov often can use some extra help
   across a broad range of skill sets. Check their staffing issues.
-- {% slack_channel "18f-help-wanted" %} may have a small (less than 12 hours,
+- {% slack_channel "ttsc-help-wanted" %} may have a small (less than 12 hours,
   usually) project that needs some engineering help
 - Non-billable projects — talk with your supervisor about pitching in on an
   internal project like Tock

--- a/pages/18f/projects-partners/leading-projects.md
+++ b/pages/18f/projects-partners/leading-projects.md
@@ -63,7 +63,7 @@ Missteps on projects will happen. Teams do not have a crystal ball into partner
 expectations or communication preferences. This is a good time to bring in a
 facilitator from outside the project to help the team reflect on what is and
 isn’t going well, and then help the team come up with alternative methods in the
-future. Try {% slack_channel "18f-help-wanted" %} to ask for a facilitator.
+future. Try {% slack_channel "ttsc-help-wanted" %} to ask for a facilitator.
 
 ### Manage work so it is equitably distributed
 
@@ -104,7 +104,7 @@ happening.
   tools and deliverables)
   - If artifacts (e.g. RFQs, final reports, decks) should be durable over time,
     consider budgeting time to make them accessible (talk to your account
-    manager or use {% slack_channel "18f-help-wanted" %} if the team doesn't
+    manager or use {% slack_channel "ttsc-help-wanted" %} if the team doesn't
     have this ability)
 - Ensure sprint planning, review, and other recurring meetings are scheduled
 - Facilitate identification of project management tracking tools
@@ -191,14 +191,14 @@ most common types of 18F project endings are some combination of the following:
   engagement]({% page "/18f/projects-partners/projects-in-distress/" %})
 - **Document and share learnings**
   - Conduct, document, and post a Project Reflection at the end of the project (or
-    every 3-4 months for longer projects). Reference the [facilitation guide](https://docs.google.com/document/d/1lB8w_U2SR3X4U78KTOWril_JOINaF98NQwQoR7oYVeo/edit), [conversation guide](https://docs.google.com/document/d/1bsaRrm9Mjnk87UOsHDyTsfK2yVbsnLLywvfFuVXL5HE/edit#), and [summary template](https://docs.google.com/document/d/1R10zQ5hpHYtSA3utxydte-Xk4ktdjUWnlMOrZp3pSwA/edit) to get started. 
+    every 3-4 months for longer projects). Reference the [facilitation guide](https://docs.google.com/document/d/1lB8w_U2SR3X4U78KTOWril_JOINaF98NQwQoR7oYVeo/edit), [conversation guide](https://docs.google.com/document/d/1bsaRrm9Mjnk87UOsHDyTsfK2yVbsnLLywvfFuVXL5HE/edit#), and [summary template](https://docs.google.com/document/d/1R10zQ5hpHYtSA3utxydte-Xk4ktdjUWnlMOrZp3pSwA/edit) to get started.
   - Request a facilitator from outside the
-    project in {% slack_channel "18f-help-wanted" %} so everyone on the project team can fully
+    project in {% slack_channel "ttsc-help-wanted" %} so everyone on the project team can fully
     participate.
   - Post the reflection summary to {% slack_channel "project-reflections" %}
   - Link the completed project reflection to the project record in the 18F dashboard using [this form](https://airtable.com/shrDVLEqUpLYGnvKS).
   - Share re-usable or example tools, presentations, docs, and other resources by [submitting them to the Project Resource Library](https://airtable.com/appkBrEBVTMd9M5VC/paggmwfuX2sEXbiW8)
-    
+
   - As an optional step, use the
     [project reflection for performance evals template](https://docs.google.com/document/d/1ko28PDLcEa_VB3ulMKbEjLzi88u8K8WJqXsBryrBV-U/edit?usp=sharing)
     to collaborate on drafting individual performance language. In some cases, an

--- a/pages/about-us/tts-consulting/operations/brand.md
+++ b/pages/about-us/tts-consulting/operations/brand.md
@@ -43,5 +43,5 @@ Reports, presentations, and other collateral should also follow our delivery sta
 Many of the referenced guides explain how to use them. If you need more help:
 
 - Ask the designers on your team
-- Post a message in {% slack_channel "18f-help-wanted" %}
+- Post a message in {% slack_channel "ttsc-help-wanted" %}
 - Use the [CoE Content Support Intake Form](https://docs.google.com/forms/d/e/1FAIpQLSdFO_8RgAGSoI3nbFNQHQ7johMzK1Z83CHTSzjqtD3IzM-bqg/viewform)

--- a/pages/about-us/tts-consulting/operations/delivery-assurance.md
+++ b/pages/about-us/tts-consulting/operations/delivery-assurance.md
@@ -8,14 +8,14 @@ Here are some of the mechanisms TTSC has to do this kind of work:
 
 | Resource | Helps with |
 |----------|------------|
-| [**\#18f-help-wanted**](##18f-help-wanted-slack-channel)  | **Short, fast, billable or non-billable tasks**  like writing review, graphic design, general volunteers |
+| [**\#ttsc-help-wanted**](##ttsc-help-wanted-slack-channel)  | **Short, fast, billable or non-billable tasks**  like writing review, graphic design, general volunteers |
 | **[Delivery Assurance (aka TLC)](#18f-delivery-assurance-\(aka-tlc-crew\))** | **Two week or less, non-billable tasks** like Facilitating project reflections, making updates or fixing bugs on 18F products,  |
 | [**18F Working Groups**](#18f-working-groups)  | **A few hours a week for a few months** like Internal surveys and analysis, developing smart default templates, revising performance plans |
 | [**TTS Operations support services**](#tts-operations-support-services)  | **Recurring TTS-level ops tasks or improvements**  like processing agreements, outreach approvals, hiring actions |
 
-## \#18f-help-wanted Slack channel {##18f-help-wanted-slack-channel}
+## \#ttsc-help-wanted Slack channel {##ttsc-help-wanted-slack-channel}
 
-TTSC staff may request help from peers for a few hours of billable or non-billable work by posting to the {% slack_channel "18f-help-wanted Slack" %} channel.
+TTSC staff may request help from peers for a few hours of billable or non-billable work by posting to the {% slack_channel "ttsc-help-wanted Slack" %} channel.
 
 If your task is specifically for writing/editing help, use `@writing-editors` to ping the content designer group.
 

--- a/pages/getting-started/classes/writing-lab.md
+++ b/pages/getting-started/classes/writing-lab.md
@@ -74,7 +74,7 @@ ask for guidance on getting somebody assigned to your project.
 
 ### How do I ask for help?
 
-You can post your request in {% slack_channel "18f-help-wanted" %}, or
+You can post your request in {% slack_channel "ttsc-help-wanted" %}, or
 {% slack_channel "tts-help-wanted" %} if you are not in 18F.
 
 ### What should I do if my issue isn't picked up?


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates Slack channel `18f-help-wanted` to `ttsc-help-wanted` following a channel rename ([announcement in Slack](https://gsa-tts.slack.com/archives/C04VCAXU31P/p1736181137527449)).

## Security considerations

None, content change only.
