### PR TITLE
Link to Section508.gov content on creating accessible meetings 

### DIFF
--- a/pages/general-information-and-resources/employee-resources-policies/deaf-hoh.md
+++ b/pages/general-information-and-resources/employee-resources-policies/deaf-hoh.md
@@ -263,8 +263,7 @@ Each program office is responsible for the cost of these services.
 
 ### Planning for accessible events
 
-GSA maintains a very useful InSite page on
-[hosting accessible meetings](https://insite.gsa.gov/employee-resources/information-technology/it-accessibility-section-508/hosting-accessible-meetings).
+Section508.gov maintains a useful guide to [hosting accessible meetings](https://www.section508.gov/create/accessible-meetings/).
 It includes actions to take before, during, and after your meeting.
 
 ## Who to contact


### PR DESCRIPTION
## Changes proposed in this pull request:

- Link to Section508.gov content on creating accessible meetings 
- The GSA Insite page (behind auth) links/redirects to Section508.gov guidance (publicly available), so this change will save users a click, and also save them an unnecessary login

## security considerations

None