### PR TITLE
Add content on hosting an accessible Zoom meeting, in particular how to spotlight ASL interpreters

### DIFF
--- a/pages/general-information-and-resources/employee-resources-policies/supporting-deaf-hoh-colleagues.md
+++ b/pages/general-information-and-resources/employee-resources-policies/supporting-deaf-hoh-colleagues.md
@@ -17,3 +17,17 @@ Tips for working effectively & inclusively with your Deaf and Hard of Hearing co
 * Practice ASL. Signing and/or spelling shows you are making an effort.
 * Facial expressions, body language, and the chat are all non-verbal ways to add context and color to the meeting conversation — use them!
 * When working with Deaf and/or Hard of Hearing colleagues, don’t focus on *what* they are (Deaf), focus on *who* they are.
+
+## Hosting accessible meetings
+
+When we host a large meeting, we'll often record it so that people can watch after-the-fact if they can't attend live.
+
+We need both the meeting itself and the recording to be fully accessible. That means making sure that ASL interpreters are highlighted in the recording, so that a Deaf or Hard of Hearing person can watch the ASL interpretation along with the recorded meeting.
+
+Here's a guide to faciliating an accessible meeting:
+
++ Zoom's [Spotlight feature](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0066300) allows the facilitator to spotlight ASL interpreters.
++ On the day of the meeting, join the Zoom room 10 to 15 minutes early. Chat with the interpreters, captioners, and speakers/preserter to make sure all have what they need.
++ Make interpreters co-hosts of the meeting. This allows the interpreters to pin Deaf participants during the meeting. It also allows them to Spotlight themselves. 
++ During the meeting, the facilitator needs to Spotlight each speaker when they begin presenting, and un-Spotlight each speaker after they are done.
++ During the meeting, the facilitator needs to keep their Zoom set to Speaker view. Switching to Gallery view will affect the recording and ASL interpreters will show up as tiny thumbnails, instead of Spotlighted.

--- a/pages/general-information-and-resources/employee-resources-policies/supporting-deaf-hoh-colleagues.md
+++ b/pages/general-information-and-resources/employee-resources-policies/supporting-deaf-hoh-colleagues.md
@@ -40,5 +40,6 @@ Here's a short guide to faciliating an accessible meeting --
 
 ### During the meeting
 + During the meeting, the facilitator needs to Spotlight each speaker when they begin presenting, and un-Spotlight each speaker after they are done.
+  + Actively facilitating a meeting while managing Spotlight controls as host is tricky -- consider splitting these into two separate roles and delegating. 
 + During the meeting, the facilitator needs to keep their Zoom set to Speaker view.
   + Switching to Gallery view will affect the recording and ASL interpreters will show up as tiny thumbnails, instead of Spotlighted.

--- a/pages/general-information-and-resources/employee-resources-policies/supporting-deaf-hoh-colleagues.md
+++ b/pages/general-information-and-resources/employee-resources-policies/supporting-deaf-hoh-colleagues.md
@@ -20,14 +20,18 @@ Tips for working effectively & inclusively with your Deaf and Hard of Hearing co
 
 ## Hosting accessible meetings
 
-When we host a large meeting, we'll often record it so that people can watch after-the-fact if they can't attend live.
+When we host a large meeting, we'll often record it so that people can watch after-the-fact.
 
-We need both the meeting itself and the recording to be fully accessible. That means making sure that ASL interpreters are highlighted in the recording, so that a Deaf or Hard of Hearing person can watch the ASL interpretation along with the recorded meeting.
+We need both the meeting itself and the recording to be fully accessible. 
+
+That means making sure that ASL interpreters are highlighted in the recording, so that a Deaf or Hard of Hearing person can watch the ASL interpretation along with the recorded meeting.
 
 Here's a short guide to faciliating an accessible meeting -- 
 
 ### Before the meeting 
-+ Consider using [Zoom](/tools/zoom), since Zoom's [Spotlight feature](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0066300) allows the facilitator to spotlight ASL interpreters.
++ Request ASL interpreters and CART transcription.
+  + Send the interpreters and transcriber the agenda plus any presentation materials ahead of time. 
++ Consider using [Zoom](/tools/zoom) to host the meeting, since Zoom's [Spotlight feature](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0066300) allows the facilitator to spotlight ASL interpreters.
 
 ### The day of the meeting
 + Join the Zoom room 10 to 15 minutes early. Chat with the interpreters, captioners, and speakers/preserter to make sure all have what they need.

--- a/pages/general-information-and-resources/employee-resources-policies/supporting-deaf-hoh-colleagues.md
+++ b/pages/general-information-and-resources/employee-resources-policies/supporting-deaf-hoh-colleagues.md
@@ -26,7 +26,7 @@ We need both the meeting itself and the recording to be fully accessible.
 
 That means making sure that ASL interpreters are highlighted in the recording, so that a Deaf or Hard of Hearing person can watch the ASL interpretation along with the recorded meeting.
 
-Here's a short guide to faciliating an accessible meeting -- 
+Here's a short guide to facilitating an accessible meeting -- 
 
 ### Before the meeting 
 + Request ASL interpreters and CART transcription.
@@ -34,7 +34,7 @@ Here's a short guide to faciliating an accessible meeting --
 + Consider using [Zoom]({% page "tools/zoom" %})  to host the meeting, since Zoom's [Spotlight feature](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0066300) allows the facilitator to spotlight ASL interpreters.
 
 ### The day of the meeting
-+ Join the Zoom room 10 to 15 minutes early. Chat with the interpreters, captioners, and speakers/preserter to make sure all have what they need.
++ Join the Zoom room 10 to 15 minutes early. Chat with the interpreters, captioner, and presenters to make sure all have what they need.
 + Make interpreters co-hosts of the meeting.
   + This allows the interpreters to pin Deaf participants during the meeting. It also allows them to Spotlight themselves.
 

--- a/pages/general-information-and-resources/employee-resources-policies/supporting-deaf-hoh-colleagues.md
+++ b/pages/general-information-and-resources/employee-resources-policies/supporting-deaf-hoh-colleagues.md
@@ -31,12 +31,14 @@ Here's a short guide to faciliating an accessible meeting --
 ### Before the meeting 
 + Request ASL interpreters and CART transcription.
   + Send the interpreters and transcriber the agenda plus any presentation materials ahead of time. 
-+ Consider using [Zoom](/tools/zoom) to host the meeting, since Zoom's [Spotlight feature](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0066300) allows the facilitator to spotlight ASL interpreters.
++ Consider using [Zoom]({% page "tools/zoom" %})  to host the meeting, since Zoom's [Spotlight feature](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0066300) allows the facilitator to spotlight ASL interpreters.
 
 ### The day of the meeting
 + Join the Zoom room 10 to 15 minutes early. Chat with the interpreters, captioners, and speakers/preserter to make sure all have what they need.
-+ Make interpreters co-hosts of the meeting. This allows the interpreters to pin Deaf participants during the meeting. It also allows them to Spotlight themselves.
++ Make interpreters co-hosts of the meeting.
+  + This allows the interpreters to pin Deaf participants during the meeting. It also allows them to Spotlight themselves.
 
 ### During the meeting
 + During the meeting, the facilitator needs to Spotlight each speaker when they begin presenting, and un-Spotlight each speaker after they are done.
-+ During the meeting, the facilitator needs to keep their Zoom set to Speaker view. Switching to Gallery view will affect the recording and ASL interpreters will show up as tiny thumbnails, instead of Spotlighted.
++ During the meeting, the facilitator needs to keep their Zoom set to Speaker view.
+  + Switching to Gallery view will affect the recording and ASL interpreters will show up as tiny thumbnails, instead of Spotlighted.

--- a/pages/general-information-and-resources/employee-resources-policies/supporting-deaf-hoh-colleagues.md
+++ b/pages/general-information-and-resources/employee-resources-policies/supporting-deaf-hoh-colleagues.md
@@ -24,10 +24,15 @@ When we host a large meeting, we'll often record it so that people can watch aft
 
 We need both the meeting itself and the recording to be fully accessible. That means making sure that ASL interpreters are highlighted in the recording, so that a Deaf or Hard of Hearing person can watch the ASL interpretation along with the recorded meeting.
 
-Here's a guide to faciliating an accessible meeting:
+Here's a short guide to faciliating an accessible meeting -- 
 
-+ Zoom's [Spotlight feature](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0066300) allows the facilitator to spotlight ASL interpreters.
-+ On the day of the meeting, join the Zoom room 10 to 15 minutes early. Chat with the interpreters, captioners, and speakers/preserter to make sure all have what they need.
-+ Make interpreters co-hosts of the meeting. This allows the interpreters to pin Deaf participants during the meeting. It also allows them to Spotlight themselves. 
+### Before the meeting 
++ Consider using [Zoom](/tools/zoom), since Zoom's [Spotlight feature](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0066300) allows the facilitator to spotlight ASL interpreters.
+
+### The day of the meeting
++ Join the Zoom room 10 to 15 minutes early. Chat with the interpreters, captioners, and speakers/preserter to make sure all have what they need.
++ Make interpreters co-hosts of the meeting. This allows the interpreters to pin Deaf participants during the meeting. It also allows them to Spotlight themselves.
+
+### During the meeting
 + During the meeting, the facilitator needs to Spotlight each speaker when they begin presenting, and un-Spotlight each speaker after they are done.
 + During the meeting, the facilitator needs to keep their Zoom set to Speaker view. Switching to Gallery view will affect the recording and ASL interpreters will show up as tiny thumbnails, instead of Spotlighted.

--- a/pages/tools/zoom.md
+++ b/pages/tools/zoom.md
@@ -22,6 +22,9 @@ GSA offers [Zoom for Government](https://zoomgov.com/).
 
 [General instructions.](https://support.zoom.us/hc/en-us/articles/201362613-How-Do-I-Host-A-Video-Meeting-)
 
+To help ensure people can fully participate, see our Handbook page on
+[hosting accessible meetings]({% page "/general-information-and-resources/employee-resources-policies/supporting-deaf-hoh-colleagues/#hosting-accessible-meetings" %}).
+
 ### For meetings longer than 40 minutes
 
 You can check [your Zoom profile](https://gsa.zoomgov.com/profile) to see your


### PR DESCRIPTION
## 👁️ Preview link 👁️ 

https://federalist-cf8341ad-ca07-488c-bd96-0738014c79ca.sites.pages.cloud.gov/preview/18f/handbook/ars/accessible-zoom-meeting/general-information-and-resources/employee-resources-policies/supporting-deaf-hoh-colleagues/#hosting-accessible-meetings

## Changes proposed in this pull request:

Add content on hosting an accessible Zoom meeting, in particular how to spotlight ASL interpreters to make the recorded meeting accessible.

## Security considerations

N/A