### PR TITLE
TTSC Handbook: Add remainder of Operations, first Engagement page.

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -418,6 +418,11 @@ primary:
                 url: about-us/tts-consulting/about/planning/
               - text: About the TTS Consulting Handbook
                 url: about-us/tts-consulting/about/handbook/
+          - text: Engagements
+            main-file-path: /about-us/tts-consulting/engagements/
+            children:
+              - text: Engagement overview
+                url: about-us/tts-consulting/engagements/
           - text: Operations
             main-file-path: /about-us/tts-consulting/operations/
             children:
@@ -429,12 +434,16 @@ primary:
                 url: about-us/tts-consulting/operations/regulations/
               - text: Terminology and glossaries
                 url: about-us/tts-consulting/operations/glossary/
+              - text: Organization structure and leadership
+                url: about-us/tts-consulting/operations/org-chart/
               - text: Tracking your time and Tock
                 url: about-us/tts-consulting/operations/tock/
               - text: Records management
                 url: about-us/tts-consulting/operations/records/
               - text: Conduct and norms
                 url: about-us/tts-consulting/operations/conduct-and-norms/
+              - text: Internal communications
+                url: about-us/tts-consulting/operations/internal-communications/
               - text: Performance management
                 url: about-us/tts-consulting/operations/performance/
               - text: Organizational financial management
@@ -447,6 +456,10 @@ primary:
                 url: about-us/tts-consulting/operations/delivery-assurance/
               - text: Management oversight of projects
                 url: about-us/tts-consulting/operations/oversight/
+              - text: Supervisor responsibilities
+                url: about-us/tts-consulting/operations/supervisor-responsibilities/
+              - text: Managing public or shared resources
+                url: about-us/tts-consulting/operations/shared-resources/
       - text: 18F
         children:
           - text: About 18F

--- a/pages/about-us/tts-consulting/about/planning.md
+++ b/pages/about-us/tts-consulting/about/planning.md
@@ -33,7 +33,8 @@ Do our deliverables represent our standard operating procedures? Does our work h
 
 How we measure delivery quality:
 
-- **Deliverables are consistent with the standard operating procedures in this handbook.** We’ve been helping modernize government for over ten years and know what approaches are likely to be successful. If your engagement needs to deviate from the SOPs in the handbook, you must be prepared to explain why. {% comment %}  - See: [Engagements](#TODO) {% endcomment %}
+- **Deliverables are consistent with the standard operating procedures in this handbook.** We’ve been helping modernize government for over ten years and know what approaches are likely to be successful. If your engagement needs to deviate from the SOPs in the handbook, you must be prepared to explain why.
+  - See: [Engagements]({% page "about-us/tts-consulting/engagements/" %})
 
 - **Engagement impact assessment.** At every phase of an engagement, we should be assessing its potential for impact on the public or federal employees. Annually, TTSC also reviews overall impact and highlights.
   - See: {% comment %}the [process to evaluate engagement success and impact](#TODO) and {% endcomment %}past impact reports:

--- a/pages/about-us/tts-consulting/engagements/index.md
+++ b/pages/about-us/tts-consulting/engagements/index.md
@@ -1,0 +1,129 @@
+---
+title: Engagement overview
+---
+
+Our work with government partners is the primary way TTSC delivers on our mission. This work is how we help agencies modernize technology systems and build their staff’s capacity.
+
+Historically, 18F has referred to this work as “projects” and CoE has called them “engagements.” As part of our realignment, we are standardizing this language:
+
+- **Projects** are focused around addressing a specific service challenge or problem
+- **Engagements** are generally a broader effort which can contain one or more projects
+
+Both require deep alignment and support of the partner, and can be staffed with 18F people, CoE people, or a combination of the two.
+
+Engagements for both 18F and CoE generally move through the same phases:
+
+- [Set up](#set-up-phase-of-engagements)
+- [Discovery](#discovery-phase-of-engagements)
+- [Implementation](#implementation-phase-of-engagements)
+- [Handover](#handover-phase-of-engagements)
+
+Some notes on engagement phases:
+
+- **All of these phases may or may not occur within the same agreement** with a partner. They may also be spread out over multiple agreements.
+
+- **This is the most common pattern of phases.** However, engagements may need to run activities in a different order, or iterate back and forth between phases.
+
+- **We balance project management, delivery, and capacity building throughout these phases** to meet the partner’s needs and achieve our mission.
+
+- **The Implementation phase frequently includes some kind of acquisition** (either an assisted acquisition operated by TTS Consulting, or acquisition consulting with a partner’s acquisition folks). The sequence and duration of acquisition work depends on the needs of the partner. CoE tends to do the acquisition work right at the beginning of Implementation, while 18F typically does any acquisition work in parallel with the Implementation activities conducted by our fed team.
+
+- **Depending on the phase and scope of your project, there are various standards for delivery and compliance** that your team needs to adhere to. When relevant to common activities, laws, regulations, standards, and/or best practices are highlighted.
+
+## Set up {#set-up-phase-of-engagements}
+
+In the set up phase, our goals are to:
+
+- Understand the scope of problem (identify the organizational problem or need) and pitch how TTS Consulting can help
+- Set expectations on the level of effort, team composition, and cost to our partners
+- Establish a legal agreement to provide funding for a team
+- Onboard the team and bring them up to speed on expectations set
+
+To achieve these goals, we typically:
+
+- Identify and qualify new engagements in business and partnership development {% comment %}TODO link to Partnerships and business development{% endcomment %}
+- Establish productive relationships and partnerships {% comment %}TODO link to Managing the partner relationship{% endcomment %}
+- Process agreements and SOWs {% comment %}TODO link to Agreements{% endcomment %}
+- Prepare our partners to work with us {% comment %}TODO link to Preparing our partners to work with us{% endcomment %}
+- Start tracking finances {% comment %}TODO link to Managing engagement finances{% endcomment %}
+- Staff people to the engagement {% comment %}TODO link to Staffing engagements{% endcomment %}
+- Kick off the engagement team {% comment %}TODO link to Kickoffs{% endcomment %}
+  - Clarify roles and responsibilities in the team {% comment %}TODO link to Roles and responsibilities{% endcomment %}
+  - Define the tools the team will use to work together {% comment %}TODO link to Tools for collaboration{% endcomment %}
+- Start internal reporting{% comment %}TODO link to Project Management {% endcomment %}
+
+We know we have been successful when:
+
+- TTSC has the authority, funding, and staff to conduct an engagement
+- The team can bill against inter-agency agreement (IAA)
+- Partner and engagement team know the scope that was agreed upon
+
+## Discovery {#discovery-phase-of-engagements}
+
+In the discovery phase, our goals are to:
+
+- Validate the problem or need with end users to reduce risk of failure in future phases
+- Recommend a path forward for the partner to deliver on their problem
+
+To achieve these goals, we frequently:
+
+- Conduct desk and user research {% comment %}TODO link to Conducting research and synthesizing findings{% endcomment %}
+- Synthesize findings and recommendations {% comment %}TODO link to Conducting research and synthesizing findings, Making recommendations{% endcomment %}
+- Track progress and risks {% comment %}TODO link to Tracking progress and risks{% endcomment %}
+- Create demos, presentations, and reports {% comment %}TODO link to Creating demos, preseations, and reports{% endcomment %}
+- Manage blockers, escalations, and scope adjustments {% comment %}TODO link to Managing blockers, escalations, and adjustments{% endcomment %}
+- Get and manage contractor support {% comment %}TODO link to Managing contractors{% endcomment %}
+
+We know we have been successful when:
+
+- Research validates the core problem or need (or the problem or need is shifted to match the research), and the partner understands and trusts the research performed
+- The first slice of implementation is identified and validated, and the partner is aligned on this path
+- An assessment of the organization’s maturity is conducted and the first slice of capacity building is identified
+- Recommend who will deliver first slice of implementation — 18F team, industry partner, or other
+
+## Implementation {#implementation-phase-of-engagements}
+
+In the implementation phase, our goals are to:
+
+- Build trust in the path forward by delivering on the first slice of work
+- Continuously validate and correct the delivery path to de-risk overall effort
+- Enable partner to continue the work after TTS Consulting departs
+
+To achieve these goals, we frequently:
+
+- Run an acquisition {% comment %}TODO link to Acqusitions{% endcomment %}
+- Teach our partners skills to manage digital services {% comment %}TODO link to Teaching our partners{% endcomment %}
+- Evaluate engagement impact {% comment %}TODO link to Evaluating engagement impact{% endcomment %}
+- Develop and begin executing a transition plan {% comment %}TODO link to Planning for transition{% endcomment %}
+- Build a website or software {% comment %}TODO link to Building products, websites, and software{% endcomment %}
+- Launch a website or software {% comment %}TODO link to Launching products, websites, and software{% endcomment %}
+- Advance larger modernization efforts {% comment %}TODO link to Advancing larger modernization efforts{% endcomment %}
+
+We know we have been successful when:
+
+- Functioning software, feature, or product is delivered to partner and end users
+- Research validates what is delivered with end users
+- Implemented software, feature, or product is released, deprecating previous system if applicable
+- Partner capacity and capabilities increased through training, hiring, or other means
+- The transition plan is clear and feasible
+
+## Handover {#handover-phase-of-engagements}
+
+In the handover phase, our goals are to:
+
+- Reduce dependency on TTSC so partner can continue digital modernization work
+- Prepare TTSC and partner to speak to the outcomes achieved
+- Document and share what we have learned together
+
+To achieve these goals, we:
+
+- Develop talking points and share our work {% comment %}TODO link to Sharing our work{% endcomment %}
+- Complete the transition to partner {% comment %}TODO link to Planning for transition{% endcomment %}
+- Complete closeout tasks for the engagement {% comment %}TODO link to Closing an engagement or project{% endcomment %}
+
+We know we have been successful when:
+
+- Partner is fully operating product without TTSC support and tools
+- Case studies, blog posts, or talking points are prepared for both TTSC and the partner to describe the outcomes achieved
+- TTSC practices are updated based on lessons learned if applicable
+- Engagement is administratively closed

--- a/pages/about-us/tts-consulting/operations/conduct-and-norms.md
+++ b/pages/about-us/tts-consulting/operations/conduct-and-norms.md
@@ -81,7 +81,7 @@ In discussion-based meetings, pay attention to whose voices dominate. If you not
 - Silent writing time in a shared document (such as a Google Doc or Mural), provides a way for participants to contribute without speaking out loud.
 - Explicitly inviting input from specific individuals — either in the meeting (“Herbert, what do you think? I know you have expertise in this area”) or privately (by DMing them to say that you would value their opinion) — can encourage quieter team members to share their ideas.
 
-{% comment %}For information about meeting platforms, see [internal communications](#TODO).{% endcomment %}
+For information about meeting platforms, see [internal communications]({% page "about-us/tts-consulting/operations/internal-communications/" %}).
 
 ### Getting to know people
 

--- a/pages/about-us/tts-consulting/operations/internal-communications.md
+++ b/pages/about-us/tts-consulting/operations/internal-communications.md
@@ -1,0 +1,132 @@
+---
+title: Internal communications
+---
+
+TTSC uses several practices and tools to support clear and frequent internal communication.
+
+## Calendars
+
+- [Google Calendar]({% page "tools/google-calendar" %}) is the primary way we indicate our availability and reserved time blocks.
+- [The TTSC Calendar](https://airtable.com/appN6llr7h1vUry6P/pag1kYDFRwB6qUilp?cmpsj=allRecords) in Airtable includes both 18F and CoE events.
+  - You can subscribe to a [feed](https://airtable.com/appN6llr7h1vUry6P/pag0aA4Lrc6QZta3Q) that brings these into your Google Calendar.
+- [The Federal holidays calendar](https://airtable.com/appN6llr7h1vUry6P/pag0aA4Lrc6QZta3Q) from OPM is handy too.
+
+## Google Groups
+
+[Google Groups]({% page "tools/google-groups/" %}) are used as email aliases for groups such as chapters.
+
+TTSC-specific groups of note:
+
+- [All TTSC staff](https://groups.google.com/a/gsa.gov/g/TTS-Consulting-Team)
+- [TTSC leadership](https://groups.google.com/a/gsa.gov/g/TTS-Consulting-Leadership)
+- [All 18F staff](https://groups.google.com/a/gsa.gov/g/18f-team)
+- [All CoE staff](https://groups.google.com/a/gsa.gov/g/coe-leads)
+- [18F-dev@gsa.gov](https://groups.google.com/a/gsa.gov/forum/#!forum/18fdev)
+  - All new engineering chapter members should be added by their supervisor. If for some reason you didn't get automatically added, give a shout in {% slack_channel "#dev" %} and someone there will get you set up.
+- [18f-eng-leadership@gsa.gov](https://groups.google.com/a/gsa.gov/forum/#!forum/18f-eng-leadership)
+  - This is a good way to write to the entire engineering leadership team at once.
+
+## Slack
+
+Slack is a primary communication space across TTS.
+
+### Conduct and norms
+
+- [TTS guidance]({% page "tools/slack/" %})
+- [TTSC Slack Code of Conduct]({% page "about-us/tts-consulting/operations/conduct-and-norms/#interacting-on-slack" %})
+
+### Channels especially relevant to TTSC
+
+- For everyone
+  - {% slack_channel "#the-shipping-news" %} where teams publish their weekly project overviews (called “ships”)
+- TTSC Leadership
+  - {% slack_channel "#tts-consulting" %} for all TTSC staff
+  - {% slack_channel "tts-consulting-leadership-chat" %} 🔒
+- Account Management
+  - {% slack_channel "18f-account-management" %}
+- Acquisition
+  - {% slack_channel "acquisition" %} (TTS-wide)
+- Design
+  - {% slack_channel "#18f-design" %} — Home base for 18F Design Chapter conversation and news
+  - {% slack_channel "#design" %} (TTS-wide)
+  - {% slack_channel "#service-design" %}
+  - {% slack_channel "#ux" %}
+  - {% slack_channel "#product-design" %}
+  - {% slack_channel "#g-content" %}
+  - {% slack_channel "#g-research" %}
+  - {% slack_channel "#18f-help-wanted" %}
+  - {% slack_channel "#dev-frontend" %}
+  - {% slack_channel "#18f-methods" %}
+- Engineering
+  - {% slack_channel "18f-engineering" %} — Home base for 18F Engineering Chapter conversation and news
+  - {% slack_channel "18f-eng-leadership" %} — channel for supervisors and principal engineers to discuss chapter initiatives and best practices
+  - {% slack_channel "#dev" %}  (TTS-wide)
+  - {% slack_channel "#dev-frontend" %}
+  - {% slack_channel "javascript" %}
+  - {% slack_channel "python" %}
+  - {% slack_channel "ruby" %}
+  - {% slack_channel "#infrastructure" %}
+  - {% slack_channel "18fers-working-toward-atos" %}
+  - {% slack_channel "g-accessibility" %}
+  - {% slack_channel "g-security-compliance" %}
+- Product Management
+  - {% slack_channel "18f-product" %}
+  - {% slack_channel "product" %} (TTS-wide)
+
+### Fun stuff
+
+- [Non-project Slack channels list](https://docs.google.com/document/d/1HAcC0qU756AzeZ38iZOlosN98Xeppr2sJ9LXLOx0UbM/edit#heading=h.k48c7a84vrza)
+- [Request a custom emoji]({% page "tools/slack/emoji/#custom-emoji" %})
+
+
+## Meetings
+
+### Conduct and norms
+
+See the handbook section on [interacting in meetings]({% page "about-us/tts-consulting/operations/conduct-and-norms/#interacting-in-meetings" %}).
+
+### Scheduling meetings
+
+When scheduling a meeting, include an agenda and a descriptive title. If an invitee’s attendance is optional, indicate this.
+
+Aim to schedule meetings during the block of working hours shared across continental U.S. time zones. That block of time is:
+
+- Eastern: 1 p.m–5 p.m.
+- Central: 12 p.m.–4 p.m.
+- Mountain: 11 a.m.–3 p.m
+- Pacific: 10 a.m.–2 p.m.
+
+### Meeting platforms
+
+TTSC’s primary meeting platforms are [Google Meet]({% page "tools/google-meet/" %}) and [Zoom]({% page "tools/zoom/" %}) (generally for larger meetings). Engagement partners may use other platforms, such as Microsoft Teams: see [using partners’ tools]({% page "general-information-and-resources/collaboration-tools/#using-partners-tools" %}).
+
+### Recurring meetings
+
+If you schedule recurring meetings for your engagement or other work, revisit them regularly and adjust their cadence and purpose as needed.
+
+Several recurring meetings share information especially relevant to TTSC staff:
+
+| Meeting  | Attendees | Timing |
+|----------|-----------|--------|
+| **TTSC All Hands**<br> To share updates with all staff. Chat happens in the meeting chat and {% slack_channel "#townhall" %}. [Archive of past recordings, slide decks, and question docs](https://docs.google.com/spreadsheets/d/1KK1aU5fN0wiOtcHbVWm-FX4-ITFrY3Qohvny_Tazrl0/edit?gid=0#gid=0). | For all TTSC staff  | 60 minutes every other month |
+| **TTSC Project Snapshot**<br> To brief TTSC leadership on current project work. [Past 18F decks](https://drive.google.com/drive/folders/1KPLs6gNkRjHS-eFzHUvmP6wu8GyVJgoO?usp=sharing) | 18F or CoE leadership, TTSC leadership | 60 minutes for each 18F/CoE monthly |
+| **TTS Monthly Program Review for Consulting**<br> For TTSC leadership to share with TTS leadership | TTSC leadership, TTS front officer, TTS Ops representative | 60 minutes monthly |
+
+#### CoE-focused meetings
+
+| Meeting  | Attendees | Timing |
+|----------|-----------|--------|
+| **CoE weekly Management Update \[Internal\]**<br> Update on changes to CoE approach, strategy, upcoming plans, etc. | CoE PMO and supervisors | 2 hours every 2-3 months |
+| **CoE All Hands**<br> CoE-wide meeting on announcements, administrative updates, team events, and deadlines | All CoE Team Members  | 90 minutes every 4-6 weeks |
+| **Center Check-in**<br> Touch base in each CoE on announcements, strategy, and timely risks as well as sharing challenges and experiences | Center members with the supervisor  | 30 minutes weekly |
+| **State of Center**<br> Review each centers, location, utilization in staff needs to make sure the central lead is well equipped to act on them | Center lead and PMO | 30 minutes fortnightly |
+
+#### 18F-focused meetings
+
+| Meeting  | Attendees | Timing |
+|----------|-----------|--------|
+| **18F Team Coffee**<br> Various updates, trainings, reports.  Chat happens in the meeting chat and {% slack_channel "#townhall" %} [Agendas and recordings of past meetings](https://docs.google.com/spreadsheets/d/1jWg2ei1EyiDyf7j0kKALXy2lcG53_1thIUyx09oTSzM/edit?gid=0#gid=0) | All 18F staff,  and open to TTS guests | 75 minutes fortnightly on Fridays |
+| **18F Leadership Team meetings**<br> Support people of 18F, projects of 18F, plan for the future, and clear blockers | 18F Directors, Chief of Staff, Chief of Delivery | 45 minutes Mondays, 30 minutes Thursdays |
+| **18F GMT**<br> To share updates and work through management issues. [Agenda and notes](https://docs.google.com/document/d/1HNdH_MI8UMcylkQvG22Zw1dvMkvgPRl2Tj2Cu_Gzy0w/edit) | Supervisors, directors, and representatives from Account Management and Acquisitions  | 30 minutes on Thursdays |
+| **18F Pipeline meeting**<br> To track and communicate incoming work, balance capacity and risk, and align chapter directors. [Agenda and notes](https://docs.google.com/document/d/1uw691U2T_l7_6zHhayt70L-g17uV-FuFZiiObvjUeGE/edit?tab=t.0#heading=h.ufshoiz2aed0) | 18F Leadership Team, specific account managers as needed | 30-60 minutes on Tuesdays |
+| **18F Chapter meetings**<br> To discuss chapter practices and administrative news. | Individual contributors, supervisors, and directors | Various |

--- a/pages/about-us/tts-consulting/operations/onboarding.md
+++ b/pages/about-us/tts-consulting/operations/onboarding.md
@@ -95,7 +95,7 @@ The outline below suggests topics to cover with new employees in their first two
 
 - Explain the different layers of the organization: GSA > FAS > TTS > TTSC > 18F or CoE.
   - Suggest correspondence codes as a way to place individuals within the reporting structure.
-- Review the org charts and project roles. Explain: {% comment %}TODO: Link "org charts" and "project roles" to relevant sections in the handbook {% endcomment %}
+- Review the [org charts]({% page "about-us/tts-consulting/operations/org-chart/" %}) and project roles. Explain: {% comment %}TODO: Link "project roles" to relevant sections in the handbook {% endcomment %}
   - What different chapters or centers do
   - What teams can look like at 18F or CoE
   - That we are a matrixed organization (“You’ll report to me, your functional manager. You’ll also have a project or engagement lead who will oversee day to day work.”)
@@ -105,7 +105,7 @@ The outline below suggests topics to cover with new employees in their first two
 #### Schedules and hours
 
 - Emphasize that the new employee should not work more than 40 hours per week.
-- Discuss TTSC norms around scheduling.{% comment %} TODO: Link to internal comms section, Scheduling Meetings header {% endcomment %}
+- Discuss TTSC [norms around scheduling]({% page "about-us/tts-consulting/operations/internal-communications/#scheduling-meetings" %}).
 
 #### Payroll and tracking time in Tock
 
@@ -132,7 +132,7 @@ The outline below suggests topics to cover with new employees in their first two
 
 #### Project expectations
 
-- Review the project delivery section of this handbook. {% comment %}TODO: Link to engagements section when it exists{% endcomment %}
+- Review the [project delivery section]({% page "about-us/tts-consulting/engagements/" %}) of this handbook.
 
 #### Organizational context
 

--- a/pages/about-us/tts-consulting/operations/org-chart.md
+++ b/pages/about-us/tts-consulting/operations/org-chart.md
@@ -1,0 +1,32 @@
+---
+title: Organization structure and leadership
+---
+
+TTS Consulting is in the process of aligning roles and structures across 18F and CoE. This content is likely to be updated in the coming months.
+
+## Org charts
+
+- [TTS Visual Chart](https://docs.google.com/presentation/d/1jmhj1prrok6VafISfWvcY3Y9sm8z_i3JzqduARLj5ew/edit#slide=id.g2293711ba17_0_0)
+- [18F Org Chart](https://docs.google.com/presentation/d/189TanLPSFF9MWvNr6VdfUvhBAWBSXeoCSGD2ZXRDm3s/edit#slide=id.g54b7f7db38_18_0)
+  - 18F is organized into five chapters: Design, Engineering, Product Management, Acquisitions, and Account Management.
+  - The larger chapters – Engineering, Design, and Product Management – have multiple supervisors.
+- [CoE Org Chart](https://docs.google.com/presentation/d/1mr8jXZqTkdUQ_EBP8yuHiAYqWt0nPTx7QPPIKA5XVSQ/edit#slide=id.g2e5da8eafc1_0_0)
+  - CoE is organized into six centers: Data Analytics, Artificial Intelligence, Cloud Adoption, Infrastructure Optimization, Customer Experience, and Contact Centers.
+  - There are also three supporting practice areas: Innovation Adoption, Acquisition, Client Services.
+- TTSC combined org chart, TK
+
+## 18F resources
+
+- [18F Leadership Handbook](https://docs.google.com/document/d/1b9bsJn0fF2muBQhWH4wHghd_IdvgFwg8VzUrGbrw9f8/edit#heading=h.bq00h4kp4evc)
+- Connecting with 18F Leadership Team
+  - [18F LT weekly ship archive](https://docs.google.com/document/d/1-wHVNxCKB2ML6ZtYtx7lbKZLxCofwFJMVbor2JRmEgk/edit#heading=h.fwqg4mlo3edj) is a running document of updates from 18F LT posted to {% slack_channel "18f-news" %}
+  - Questions for the Leadership Team should typically go through your supervisor and/or director.
+  - [18F leadership feedback form](https://forms.gle/BgUfv5pW3vWyt37S6) can be used to ask questions of the whole LT. Form submissions go to an 18F leadership shared folder, and email notification goes to one leadership member, who shares submissions with the group. If a name is submitted with the form, leadership will reach out to the person who submitted the form.
+
+## Additional reading
+
+{% comment %}
+- [Engagement roles and responsibilities](#TODO)
+- [Managing blockers, escalations, and adjustments](#TODO)
+{% endcomment %}
+- [Supervisor responsibilities]({% page "about-us/tts-consulting/operations/supervisor-responsibilities/" %})

--- a/pages/about-us/tts-consulting/operations/shared-resources.md
+++ b/pages/about-us/tts-consulting/operations/shared-resources.md
@@ -1,0 +1,15 @@
+---
+title: Managing public or shared resources
+---
+
+Over the years 18F and CoE have both developed resources or products that others rely on. Some of these are publicly available websites and others are tools used by teams across TTS.
+
+| Resource | Where we manage and maintain it | Point of contact |
+|----------|---------------------------------|------------------|
+| [**TTS Consulting Handbook**](https://handbook.tts.gsa.gov/)<br> Documentation of standard operating procedures for TTS Consulting staff | [GitHub: 18F/handbook](https://github.com/18F/handbook)<br> [Cloud.gov Pages config](https://pages.cloud.gov/sites/21)  | TTSC Chief of Staff |
+| [**TTSC Resources Library**](https://airtable.com/appkBrEBVTMd9M5VC/pagyCKyWNdrBCgvP1)<br>  An AirTable  | [Airtable base](https://airtable.com/appkBrEBVTMd9M5VC/pagyCKyWNdrBCgvP1)  | Currently, 18F Director of Product |
+| **[CoE website](https://coe.gsa.gov/)**<br>  Our public-facing site | [GitHub: gsa/centers-of-excellence](https://github.com/gsa/centers-of-excellence)<br> [Cloud.gov Pages config](https://pages.cloud.gov/sites/449)  | CoE Communications Lead |
+| [**18F website**](https://18f.gsa.gov/)<br>  Our public-facing site | [GitHub: 18F/18f.gsa.gov](https://github.com/18F/18f.gsa.gov)<br> [Cloud.gov Pages config](https://pages.cloud.gov/sites/3)  | 18F Outreach Lead |
+| [**18F blog**](https://18f.gsa.gov/blog/)<br>  Our blog is part of the public site but blog post draft are managed in a different repo. | [GitHub: 18F/blog-drafts](https://github.com/18F/blog-drafts) | 18F Outreach Lead |
+| [**18F Guides**](https://18f.gsa.gov/guides/)<br>  Public-facing resources including Derisking Guide, UX Guide, Product Guide, Content Guide, Engineering Guide, and more | [GitHub: 18F/guides](https://github.com/18F/guides)<br> [Cloud.gov Pages config](https://pages.cloud.gov/sites/1372)  | 18F Chief of Delivery  |
+| [**Tock**](https://tock.18f.gov/)<br>  18F maintains this time tracking tool used by a couple different offices | [GitHub: 18F/tock](https://github.com/18F/tock/)  | 18F Director of Engineering |

--- a/pages/about-us/tts-consulting/operations/supervisor-responsibilities.md
+++ b/pages/about-us/tts-consulting/operations/supervisor-responsibilities.md
@@ -1,0 +1,49 @@
+---
+title: Supervisor responsibilities
+---
+
+Supervisor responsibilities are generally outlined in the [TTS New Supervisor Playbook]({% page "supervisor-resources/new-supervisor-playbook/" %}) and the [TTS Supervisors Guide](https://docs.google.com/document/d/14bSqkCzfxvf5lI7k_LwSK8MLDnImqjrQFTXrtTcwcEY/edit#heading=h.5m4e2v6ntbj1). [Performance plans]({% page "about-us/tts-consulting/operations/performance/" %}) also lay out specific expectations for TTSC supervisors.
+
+At a high-level, TTSC supervisors are expected to provide their direct reports with:
+
+- Being a thought partner and reviewer for engagement work, ensuring the deliverables meet quality standards *and* advance the engagement goals
+- Help completing administrative tasks
+- Providing context on our organization and ways of working
+- Collecting peer feedback and conducting performance reviews
+- Supporting professional development
+
+Supervisors are also expected to contribute to organizational initiatives and fulfill duties as assigned such as:
+
+- Leading or supporting hiring activities
+- Serving as a SME for business development and partnership calls and proposal development
+- Facilitating the Delivery Assurance team (aka TLC Crew) and ensuring individual contributors not assigned to partner work are contributing to organizational initiatives productively
+- Leading necessary working groups
+
+TTSC supervisors are also responsible for regularly conducting the following administrative tasks:
+
+## Weekly
+
+- Check that your direct reports are [Tocking correctly]({% page "about-us/tts-consulting/operations/tock/#supervisor-review" %}).
+- 18F: Fill out the [data check form](https://airtable.com/app1anoO5i5d3RJRA/pagYbQmUcGgPS4lEt/form). Report any Airtable discrepancies, and follow up with your direct report on any necessary Tock changes.
+- 18F: Read {% slack_channel "#the-shipping-news" %} for your direct reports’ projects
+- 18F: Review [project health reports](https://airtable.com/appsLLLryeqBK2V9d/paguMwC2PYWUhaokc) for your direct reports’ projects
+- 18F: Attend GMT meetings.
+- CoE: Attend “CoE Management Weekly” meetings
+
+## Fortnightly
+
+- Meet each with direct report 1:1 and review the project deliverables they have been working on. If appropriate, Tock to the project for this time.
+
+## Quarterly/semi-annually
+
+- Collect peer observations on your direct report’s work, synthesize, and share with them.
+- Talk to your direct reports about their progress towards performance goals.
+
+## Rolling basis
+
+- Help match direct reports to incoming work
+- When one of your direct report starts on a new engagement, reach out to the AM and PL/EL to introduce yourself and offer to help as needed
+- Onboarding new team members
+- Offboard departing staff and conduct exit interviews
+- Update employee’s performance plans if their role changes or they are going on detail for 120 days or more
+- Highlight direct report’s accomplishments with kudos or [award nominations](https://docs.google.com/spreadsheets/d/1ZEPf0SrbRMEdRpQTFyONoKqs6w_I1pZmzol1JgG4__U/edit?gid=1337778906#gid=1337778906) as appropriate

--- a/pages/about-us/tts-consulting/operations/welcome.md
+++ b/pages/about-us/tts-consulting/operations/welcome.md
@@ -9,8 +9,10 @@ As you work through the onboarding checklist provided to you by TTS People Ops, 
 - [About this handbook]({% page "about-us/tts-consulting/about/handbook/" %})
 - [About the TTS Office of Consulting]({% page "about-us/tts-consulting/about/mission/" %})
 - [Compliance with laws and regulations]({% page "about-us/tts-consulting/operations/regulations/" %})
-- [Conduct and norms]({% page "about-us/tts-consulting/operations/conduct-and-norms/" %}) {% comment %}- [Internal communications](#TODO) {% endcomment %}
-- [Organizational financial management]({% page "about-us/tts-consulting/operations/finance/" %}) {% comment %}- [Engagement overview](#TODO){% endcomment %}
+- [Conduct and norms]({% page "about-us/tts-consulting/operations/conduct-and-norms/" %})
+- [Internal communications]({% page "about-us/tts-consulting/operations/internal-communications/" %})
+- [Organizational financial management]({% page "about-us/tts-consulting/operations/finance/" %})
+- [Engagement overview]({% page "about-us/tts-consulting/engagements/" %})
 
 Other important things to know as a new employee:
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds the remainder of the Operations (section C) content, as well as the Engagement overview page.
- Links into these sections from existing pages where TODO links were previously flagged.

## Security considerations

None, content changes only. 
