### PR TITLE
Add CSP meta header and implements SRI for googletagmanager script

### DIFF
--- a/_data/site.yaml
+++ b/_data/site.yaml
@@ -15,6 +15,7 @@ dap:
 
 ga:
   ua: UA-48605964-19
+  sri: sha384-Mf/zSo9fB7jruHEQ2uzHvxb/nC3QFrIH8Xn5jJYIavYHHAdDVoh3mZNFLXuPvmP
 
 # How long of a word count before showing in page nav
 inpagenavwordcount: 300

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -8,11 +8,24 @@ to modify some of the meta-data for the site, this is the place to do it.
     ================================================== -->
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Content Security Policy -->
+  <meta http-equiv="Content-Security-Policy" 
+        content="default-src 'self';
+                 script-src 'self' 'unsafe-inline' 'unsafe-eval' 
+                            https://dap.digitalgov.gov 
+                            https://www.googletagmanager.com 
+                            https://search.usa.gov;
+                 style-src 'self' 'unsafe-inline';
+                 img-src 'self' data: https:;
+                 connect-src 'self' https://dap.digitalgov.gov https://www.google-analytics.com;
+                 font-src 'self';
+                 frame-src 'none';
+                 object-src 'none';">
   <!-- Mobile Specific Metas
     ================================================== -->
   <meta name="HandheldFriendly" content="True">
   <meta name="MobileOptimized" content="320">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- Title and meta description
     ================================================== -->
   <title>{{title}}</title>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -14,7 +14,7 @@
   <script
     async
     src="https://www.googletagmanager.com/gtag/js?id={{ site.ga.ua }}"
-    integrity="sha384-Mf/zSo9fB7jruHEQ2uzHvxb/nC3QFrIH8Xn5jJYIavYHHAdDVoh3mZNFLXuPvmP"
+    integrity="{{ site.ga.sri }}"
     crossorigin="anonymous"
   ></script>
   <script>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -14,6 +14,8 @@
   <script
     async
     src="https://www.googletagmanager.com/gtag/js?id={{ site.ga.ua }}"
+    integrity="sha384-Mf/zSo9fB7jruHEQ2uzHvxb/nC3QFrIH8Xn5jJYIavYHHAdDVoh3mZNFLXuPvmP"
+    crossorigin="anonymous"
   ></script>
   <script>
     window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
## Changes proposed in this pull request:


## security considerations

Enhancements:
- [x] Implements Sub Resource Integrity (SRI) for googletagmanager
- [x] Implements Content Security Policy (CSP) Header Not Set
