### PR TITLE
Updates to Handbook hierarchy and content delegation

### DIFF
--- a/.github/workflows/teams.yml
+++ b/.github/workflows/teams.yml
@@ -1,0 +1,59 @@
+name: "Terraform manages Teams"
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'terraform/**'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'terraform/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write # Required for requesting the JWT
+
+jobs:
+  terraform:
+    name: "Terraform"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./terraform
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_version: 1.0.0
+        
+    - name: Configure GitHub token
+      run: |
+        # Mask the token to prevent it from showing in logs
+        echo "::add-mask::${{ secrets.TF_GITHUB_TOKEN }}"
+        # Set the token as an environment variable for Terraform
+        echo "GITHUB_TOKEN=${{ secrets.TF_GITHUB_TOKEN }}" >> $GITHUB_ENV
+      
+    - name: Terraform Init
+      run: terraform init
+      
+    - name: Terraform Format
+      run: terraform fmt -check
+      
+    - name: Terraform Validate
+      run: terraform validate
+
+    - name: Terraform Plan
+      if: github.event_name == 'pull_request'
+      run: terraform plan
+      
+    # Only apply changes when PR touches terraform and when merged to main
+    - name: Terraform Apply
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      run: terraform apply -auto-approve
+

--- a/.github/workflows/teams.yml
+++ b/.github/workflows/teams.yml
@@ -42,7 +42,10 @@ jobs:
     - name: Terraform Init
       run: terraform init
       
-    - name: Terraform Format
+    - name: Terraform Format Files
+      run: terraform fmt
+      
+    - name: Terraform Format Check
       run: terraform fmt -check
       
     - name: Terraform Validate

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,46 +13,38 @@
 ###########################################################################
 
 # Any changes to ownership should be approved by the Handbook owners.
-CODEOWNERS                                                               
-@gsa-tts/GSA-TTS-Handbook-Owners
+CODEOWNERS                                                               @gsa-tts/GSA-TTS-Handbook-Owners
 
 # Every change that doesn't have a designated code owner should, by default,
 # be reviewed by one of the Handbook owners.
-*                                                                         
-@gsa-tts/GSA-TTS-Handbook-Owners
+*                                                                        @gsa-tts/GSA-TTS-Handbook-Owners
 
 ####################################################################
 # Terraform & Infrastructure
 ####################################################################
-/terraform/*                                                              
-@gsa-tts/GSA-TTS-Handbook-Owners
-.github/workflows/**                                         
-/@gsa-tts/GSA-TTS-Handbook-Owners
+/terraform/*                                                             @gsa-tts/GSA-TTS-Handbook-Owners
+.github/workflows/*                                                      @gsa-tts/GSA-TTS-Handbook-Owners
 
 ##################################################################
 # TTS Offices
 ################################################################
 ## Office of Operations
-pages/office-of-operations/*                                           
-@gsa-tts/Outreach-and-Marketing-Division
+pages/office-of-operations/*                                             @gsa-tts/Outreach-and-Marketing-Division
 
 ## Office of Acquisition
 pages/office-of-acquisition/*                                            @gsa-tts/Acquisition-Division
 
-## Solutions
-pages/office-of-solutions/*                                              @gsa-tts/Outreach-and-Marketing-Division
+## Office of Solutions
+pages/office-of-solutions/*                                              @gsa-tts/Office-of-Solutions
 
 ## Centers of Excellence (CoE)
 pages/centers-of-excellence/*                                            @gsa-tts/Centers-of-Excellence-Division
 
-## Technology Services
-pages/tools/*                                            
-@gsa-tts/Technology-Operations-Division
+## Tools
+pages/tools/*                                                            @gsa-tts/Technology-Operations-Division
 
 # Training
-pages/training-and-development/*
-@gsa-tts/Business-Operations-Division
+pages/training-and-development/*                                         @gsa-tts/Business-Operations-Division
 
 # Travel and Leave
-pages/travel-and-leave/* 
-@gsa-tts/Business-Operations-Division
+pages/travel-and-leave/*                                                 @gsa-tts/Business-Operations-Division

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,69 +13,46 @@
 ###########################################################################
 
 # Any changes to ownership should be approved by the Handbook owners.
-CODEOWNERS                                                                @gsa-tts/handbook-owners
+CODEOWNERS                                                               
+@gsa-tts/GSA-TTS-Handbook-Owners
 
 # Every change that doesn't have a designated code owner should, by default,
 # be reviewed by one of the Handbook owners.
-*                                                                         @gsa-tts/handbook-owners
+*                                                                         
+@gsa-tts/GSA-TTS-Handbook-Owners
 
-###########################################################################
+####################################################################
+# Terraform & Infrastructure
+####################################################################
+/terraform/*                                                              
+@gsa-tts/GSA-TTS-Handbook-Owners
+.github/workflows/**                                         
+/@gsa-tts/GSA-TTS-Handbook-Owners
+
+##################################################################
 # TTS Offices
-###########################################################################
+################################################################
 ## Office of Operations
-pages/office-of-operations/outreach.md                                   @gsa-tts/outreach
-pages/office-of-operations/blogging.md                                   @gsa-tts/outreach
-pages/office-of-operations/talent.md                                     @gsa-tts/team-talent
-_data/jobs.json                                                          @gsa-tts/team-talent
+pages/office-of-operations/*                                           
+@gsa-tts/Outreach-and-Marketing-Division
 
 ## Office of Acquisition
-pages/office-of-acquisition/*                                            @gsa-tts/tts-office-of-acqusition
-
-## gsa-tts
-pages/gsa-tts/*                                                              @gsa-tts/gsa-tts-handbook-owners
+pages/office-of-acquisition/*                                            @gsa-tts/Acquisition-Division
 
 ## Solutions
-pages/office-of-solutions/*                                              @gsa-tts/solutions-handbook-owners
+pages/office-of-solutions/*                                              @gsa-tts/Outreach-and-Marketing-Division
 
 ## Centers of Excellence (CoE)
-pages/centers-of-excellence/*                                            @gsa-tts/coes
+pages/centers-of-excellence/*                                            @gsa-tts/Centers-of-Excellence-Division
 
-###########################################################################
-# Guilds, working groups, and councils
-###########################################################################
-pages/about-us/digital-council.md                                        @gsa-tts/digital-council
+## Technology Services
+pages/tools/*                                            
+@gsa-tts/Technology-Operations-Division
 
-###########################################################################
-# Classes
-###########################################################################
-pages/getting-started/classes/accessibility.md                           @gsa-tts/guild-accessibility
-pages/getting-started/classes/intro-to-TTS-Tech-Operations.md            @gsa-tts/tts-tech-operations
-pages/getting-started/classes/meetings-and-meeting-tools.md              @gsa-tts/tts-tech-operations
-pages/getting-started/classes/gsa-internal-tools.md                      @gsa-tts/tts-tech-operations
-pages/getting-started/classes/travel-101.md                              @gsa-tts/people-ops
-pages/getting-started/classes/benefits.md                                @gsa-tts/people-ops
-pages/getting-started/classes/writing-lab.md                             @gsa-tts/guild-content
+# Training
+pages/training-and-development/*
+@gsa-tts/Business-Operations-Division
 
-###########################################################################
-# People Ops
-###########################################################################
-pages/performance-management/*                                           @gsa-tts/people-ops
-pages/getting-started/*                                                  @gsa-tts/people-ops
-pages/travel-and-leave/*                                                 @gsa-tts/people-ops
-pages/hiring-staying-or-changing-jobs/*                                  @gsa-tts/team-talent
-pages/training-and-development/*                                         @gsa-tts/people-ops
-
-###########################################################################
-# General information and policies
-###########################################################################
-pages/about-us/*                                                         @gsa-tts/handbook-owners
-pages/general-information-and-resources/employee-resources-policies      @gsa-tts/people-ops
-pages/general-information-and-resources/tech-policies                    @gsa-tts/tts-tech-operations
-pages/general-information-and-resources/*                                @gsa-tts/handbook-owners
-
-###########################################################################
-# Tech Operations
-###########################################################################
-pages/launching-software/*                                               @gsa-tts/tts-tech-operations
-pages/tools/*                                                            @gsa-tts/tts-tech-operations
-pages/training-and-development/intro-to-github.md                        @gsa-tts/tts-tech-operations
+# Travel and Leave
+pages/travel-and-leave/* 
+@gsa-tts/Business-Operations-Division

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -40,6 +40,13 @@ resource "github_team" "q2a0a" {
   parent_team_id = github_team.q2.id
 }
 
+# Define the parent handbook_owners team
+resource "github_team" "handbook_owners" {
+  name        = "handbook-owners"
+  description = "Handbook owners with elevated permissions"
+  privacy     = "closed"
+}
+
 # others in TTS are periodically added to this team to collaboratively manage the Handbook reviews
 resource "github_team" "gsa_tts_handbook_owners" {
   name        = "GSA-TTS-Handbook-Owners"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,384 @@
+# Terraform expects GITHUB_TOKEN set as a secret in actions with admin:org permissions to manage teams
+# main.tf
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# Variables
+variable "github_organization" {
+  description = "GitHub organization name"
+  type        = string
+  default     = "GSA-TTS"
+}
+
+variable "parent_team_id" {
+  description = "ID of the parent team (if creating as nested teams)"
+  type        = string
+  default     = null
+}
+
+# Main TTS Office
+# This team is granted write access to the Handbook - all teams inherit Write as children of this team
+resource "github_team" "q2" {
+  name        = "Technology-Transformation-Services"
+  description = "Office of the Deputy Commissioner/Director, Technology Transformation Services (Q2)"
+  privacy     = "closed"
+  parent_team_id = var.parent_team_id
+}
+
+# Technology Operations Division
+# Handbook Website Manager and Tech Lead are members of this office
+resource "github_team" "q2a0a" {
+  name        = "Technology-Operations-Division"
+  description = "Technology Operations Division (Q2A0A)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2.id
+}
+
+# others in TTS are periodically added to this team to collaboratively manage the Handbook reviews
+resource "github_team" "gsa_tts_handbook_owners" {
+  name        = "GSA-TTS-Handbook-Owners"
+  description = "Team responsible for GSA-TTS specific handbook content"
+  privacy     = "closed"
+  parent_team_id = github_team.handbook_owners.id
+}
+
+# Main offices under TTS
+# These offices are used to update CODEOWNERS.md file for review of specific sections of the Handbook
+resource "github_team" "q2a" {
+  name        = "TTS-Delivery"
+  description = "Office of TTS Delivery - TTS Deputy Director (Q2A)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2.id
+}
+
+resource "github_team" "q2b" {
+  name        = "TTS-Operations"
+  description = "Office of TTS Operations (Q2B)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2.id
+}
+
+resource "github_team" "q2c" {
+  name        = "TTS-Fellowship-Office"
+  description = "TTS Fellowship Office (Q2C)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2.id
+}
+
+# Office of TTS Delivery Subdivisions
+resource "github_team" "q2aa" {
+  name        = "Office-of-Solutions"
+  description = "Office of Solutions (Q2AA)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2a.id
+}
+
+resource "github_team" "q2ab" {
+  name        = "Office-of-Regulatory-and-Oversight-Systems"
+  description = "Office of Regulatory & Oversight Systems (Q2AB)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2a.id
+}
+
+resource "github_team" "q2ac" {
+  name        = "Office-of-Integrated-Award-Environment"
+  description = "Office of Integrated Award Environment (Q2AC)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2a.id
+}
+
+# Office of TTS Operations Subdivisions
+resource "github_team" "q2ba" {
+  name        = "Acquisition-Division"
+  description = "Acquisition Division (Q2BA)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2b.id
+}
+
+resource "github_team" "q2bb" {
+  name        = "Business-Operations-Division"
+  description = "Business Operations Division (Q2BB)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2b.id
+}
+
+resource "github_team" "q2bc" {
+  name        = "Market-Development-and-Partnerships-Division"
+  description = "Market Development & Partnerships Division (Q2BC)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2b.id
+}
+
+resource "github_team" "q2bd" {
+  name        = "Outreach-and-Marketing-Division"
+  description = "Outreach & Marketing Division (Q2BD)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2b.id
+}
+
+# Office of Solutions Teams (Q2AA)
+resource "github_team" "q2aaa" {
+  name        = "Cloud-gov-Division"
+  description = "Cloud.gov Division (Q2AAA)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aa.id
+}
+
+resource "github_team" "q2aab" {
+  name        = "Login-gov-Division"
+  description = "Login.gov Division (Q2AAB)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aa.id
+}
+
+resource "github_team" "q2aac" {
+  name        = "Platforms-and-Services-Division"
+  description = "Platforms & Services Division (Q2AAC)"                                                                                             
+  privacy     = "closed"
+  parent_team_id = github_team.q2aa.id
+}
+
+resource "github_team" "q2aad" {
+  name        = "Public-Experience-Division"
+  description = "Public Experience Division (Q2AAD)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aa.id
+}
+
+resource "github_team" "q2aae" {
+  name        = "FedRAMP-Division"
+  description = "FedRAMP Division (Q2AAE)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aa.id
+}
+
+resource "github_team" "q2aaf" {
+  name        = "Accelerators-Division"
+  description = "Accelerators Division (Q2AAF)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aa.id
+}
+
+# Cloud.gov branches
+resource "github_team" "q2aaaa" {
+  name        = "Cloud-gov-Engineering-Branch"
+  description = "Engineering Branch (Q2AAAA)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aaa.id
+}
+
+# Login.gov branches
+resource "github_team" "q2aaba" {
+  name        = "Login-gov-Operations-Branch"
+  description = "Login.gov Operations Branch (Q2AABA)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aab.id
+}
+
+resource "github_team" "q2aabb" {
+  name        = "Login-gov-Engineering-Branch"
+  description = "Login.gov Engineering Branch (Q2AABB)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aab.id
+}
+
+resource "github_team" "q2aabc" {
+  name        = "Login-gov-Security-UX-Branch"
+  description = "Login.gov Security UX Branch (Q2AABC)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aab.id
+}
+
+resource "github_team" "q2aabd" {
+  name        = "Login-gov-Product-Branch"
+  description = "Login.gov Product Branch (Q2AABD)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aab.id
+}
+
+resource "github_team" "q2aabe" {
+  name        = "Login-gov-Platform-Branch"
+  description = "Login.gov Platform Branch (Q2AABE)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aab.id
+}
+
+resource "github_team" "q2aabf" {
+  name        = "Login-gov-Security-Branch"
+  description = "Login.gov Security Branch (Q2AABF)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aab.id
+}
+
+resource "github_team" "q2aabg" {
+  name        = "Login-gov-Partnerships-Growth-Branch"
+  description = "Login.gov Partnerships & Growth Branch (Q2AABG)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aab.id
+}
+
+resource "github_team" "q2aabh" {
+  name        = "Login-gov-Engineering-Partnerships-Branch"
+  description = "Login.gov Engineering Partnerships Branch (Q2AABH)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aab.id
+}
+
+# Platforms & Services branches
+resource "github_team" "q2aaca" {
+  name        = "Communities-and-Collaboration-Branch"
+  description = "Communities & Collaboration Branch (Q2AACA)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aac.id
+}
+
+resource "github_team" "q2aacb" {
+  name        = "Web-Tools-Branch"
+  description = "Web Tools Branch (Q2AACB)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aac.id
+}
+
+resource "github_team" "q2aacc" {
+  name        = "Open-Data-and-Participatory-Science-Branch"
+  description = "Open Data & Participatory Science Branch (Q2AACC)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aac.id
+}
+
+# Public Experience Division branches
+resource "github_team" "q2aada" {
+  name        = "Content-and-Outreach-Branch"
+  description = "Content & Outreach Branch (Q2AADA)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aad.id
+}
+
+resource "github_team" "q2aadb" {
+  name        = "Customer-Product-Experience-Branch"
+  description = "Customer & Product Experience Branch (Q2AADB)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aad.id
+}
+
+resource "github_team" "q2aadc" {
+  name        = "Contact-Center-Operations-Branch"
+  description = "Contact Center Operations Branch (Q2AADC)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aad.id
+}
+
+resource "github_team" "q2aadd" {
+  name        = "Infrastructure-and-Technology-Branch"
+  description = "Infrastructure & Technology Branch (Q2AADD)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aad.id
+}
+
+# FedRAMP Division branches
+resource "github_team" "q2aaea" {
+  name        = "FedRAMP-Branch-A"
+  description = "FedRAMP Branch A (Q2AAEA)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aae.id
+}
+
+resource "github_team" "q2aaeb" {
+  name        = "FedRAMP-Branch-B"
+  description = "FedRAMP Branch B (Q2AAEB)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aae.id
+}
+
+# Accelerators Division branches
+resource "github_team" "q2aafa" {
+  name        = "ARP-Delivery-Branch-A"
+  description = "ARP Delivery Branch A (Q2AAFA)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aaf.id
+}
+
+resource "github_team" "q2aafb" {
+  name        = "ARP-Delivery-Branch-B"
+  description = "ARP Delivery Branch B (Q2AAFB)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aaf.id
+}
+
+resource "github_team" "q2aafc" {
+  name        = "10x-Branch"
+  description = "10x Branch (Q2AAFC)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aaf.id
+}
+
+resource "github_team" "q2aafd" {
+  name        = "Benefits-Studio-Branch"
+  description = "Benefits Studio Branch (Q2AAFD)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2aaf.id
+}
+
+# Office of Regulatory & Oversight Systems (Q2AB)
+resource "github_team" "q2aba" {
+  name        = "Modernized-Rulemaking-Division"
+  description = "Modernized Rulemaking Division (Q2ABA)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2ab.id
+}
+
+resource "github_team" "q2abb" {
+  name        = "Grants-and-Acquisition-Division"
+  description = "Grants & Acquisition Division (Q2ABB)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2ab.id
+}
+
+resource "github_team" "q2abc" {
+  name        = "Systems-Design-Division"
+  description = "Systems Design Division (Q2ABC)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2ab.id
+}
+
+resource "github_team" "q2abd" {
+  name        = "Experience-Design-Division"
+  description = "Experience Design Division (Q2ABD)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2ab.id
+}
+
+# Office of Integrated Award Environment (Q2AC)
+resource "github_team" "q2aca" {
+  name        = "Management-and-Program-Support-Division"
+  description = "Management & Program Support Division (Q2ACA)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2ac.id
+}
+
+resource "github_team" "q2acb" {
+  name        = "Business-Applications-Operations-Division"
+  description = "Business Applications Operations Division (Q2ACB)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2ac.id
+}
+
+resource "github_team" "q2acc" {
+  name        = "Outreach-and-Stakeholder-Engagement-Division"
+  description = "Outreach & Stakeholder Engagement Division (Q2ACC)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2ac.id
+}
+
+resource "github_team" "q2adb" {
+  name        = "Centers-of-Excellence-Division"
+  description = "Centers of Excellence Division (Q2ADB)"
+  privacy     = "closed"
+  parent_team_id = github_team.q2.id
+}

--- a/terraform/teams-structure.md
+++ b/terraform/teams-structure.md
@@ -1,0 +1,106 @@
+# TTS Teams Structure
+
+```mermaid
+graph TD
+    classDef topLevel fill:#f96,stroke:#333,stroke-width:2px
+    classDef secondLevel fill:#9cf,stroke:#333,stroke-width:1px
+    classDef thirdLevel fill:#cfc,stroke:#333,stroke-width:1px
+    classDef fourthLevel fill:#fcf,stroke:#333,stroke-width:1px
+    classDef specialTeam fill:#fc9,stroke:#333,stroke-width:2px,stroke-dasharray: 5 5
+
+    %% Top Level Organization
+    q2["Technology-Transformation-Services (Q2)"]
+    
+    %% Handbook Teams
+    handbook["Handbook-Owners"]
+    gsa_handbook["GSA-TTS-Handbook-Owners"]
+    operations_handbook["Operations-Handbook-Owners"]
+    solutions_handbook["Solutions-Handbook-Owners"]
+    
+    %% Main Divisions
+    q2a["TTS-Delivery (Q2A)"]
+    q2b["TTS-Operations (Q2B)"]
+    q2c["TTS-Fellowship-Office (Q2C)"]
+    q2a0a["Technology-Operations-Division (Q2A0A)"]
+    q2adb["Centers-of-Excellence-Division (Q2ADB)"]
+
+    %% Office of TTS Delivery Subdivisions
+    q2aa["Office-of-Solutions (Q2AA)"]
+    q2ab["Office-of-Regulatory-and-Oversight-Systems (Q2AB)"]
+    q2ac["Office-of-Integrated-Award-Environment (Q2AC)"]
+
+    %% Office of TTS Operations Subdivisions
+    q2ba["Acquisition-Division (Q2BA)"]
+    q2bb["Business-Operations-Division (Q2BB)"]
+    q2bc["Market-Development-and-Partnerships-Division (Q2BC)"]
+    q2bd["Outreach-and-Marketing-Division (Q2BD)"]
+
+    %% Office of Solutions Teams
+    q2aaa["Cloud-gov-Division (Q2AAA)"]
+    q2aab["Login-gov-Division (Q2AAB)"]
+    q2aac["Platforms-and-Services-Division (Q2AAC)"]
+    q2aad["Public-Experience-Division (Q2AAD)"]
+    q2aae["FedRAMP-Division (Q2AAE)"]
+    q2aaf["Accelerators-Division (Q2AAF)"]
+
+    %% Parent-Child Relationships - Top Level
+    q2 --> q2a
+    q2 --> q2b
+    q2 --> q2c
+    q2 --> q2a0a
+    q2 --> q2adb
+
+    %% Parent-Child Relationships - Handbook Teams
+    q2b --> handbook
+    handbook --> gsa_handbook
+    handbook --> operations_handbook
+    handbook --> solutions_handbook
+
+    %% Parent-Child Relationships - Office of TTS Delivery
+    q2a --> q2aa
+    q2a --> q2ab
+    q2a --> q2ac
+
+    %% Parent-Child Relationships - Office of TTS Operations
+    q2b --> q2ba
+    q2b --> q2bb
+    q2b --> q2bc
+    q2b --> q2bd
+
+    %% Parent-Child Relationships - Office of Solutions
+    q2aa --> q2aaa
+    q2aa --> q2aab
+    q2aa --> q2aac
+    q2aa --> q2aad
+    q2aa --> q2aae
+    q2aa --> q2aaf
+
+    %% Style Applications
+    class q2 topLevel
+    class q2a,q2b,q2c,q2a0a,q2adb secondLevel
+    class q2aa,q2ab,q2ac,q2ba,q2bb,q2bc,q2bd thirdLevel
+    class q2aaa,q2aab,q2aac,q2aad,q2aae,q2aaf fourthLevel
+    class handbook,gsa_handbook,operations_handbook,solutions_handbook specialTeam
+```
+
+## Team Ownership
+
+Teams inherit permissions from their parent teams. 
+
+### Key Teams for Handbook Management
+
+- **Technology-Transformation-Services (Q2)**: Top-level organization
+- **Handbook-Owners**: Team responsible for overall handbook management
+- **GSA-TTS-Handbook-Owners**: Team responsible for GSA-TTS specific content
+- **Technology-Operations-Division (Q2A0A)**: Technical management of the handbook platform
+
+### Content Ownership
+
+Teams own specific sections of the handbook content as defined in the CODEOWNERS file:
+
+- **Outreach-and-Marketing-Division**: Office of Operations content
+- **Acquisition-Division**: Office of Acquisition content
+- **Office-of-Solutions**: Office of Solutions content
+- **Centers-of-Excellence-Division**: CoE content
+- **Technology-Operations-Division**: Tools content
+- **Business-Operations-Division**: Training, Travel and Leave content


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds Terraform to create `Teams` to assign Handbook sections in CODEOWNERS
- Adds Github action to run terraform apply only when a change to terraform directory is detected and merged to main
- Adds c4 mermaid diagram explain the terraform hierarchy
- Updates CODEOWNERS to use new Team names
