### PR TITLE
set context to org

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,6 +9,11 @@ terraform {
   }
 }
 
+# Configure the GitHub Provider to use the organization
+provider "github" {
+  owner = var.github_organization
+}
+
 # Variables
 variable "github_organization" {
   description = "GitHub organization name"


### PR DESCRIPTION
change adds a GitHub provider configuration block that explicitly sets the owner parameter to the organization name specified in the github_organization variable.

