### PR TITLE
Fix links to handbook and GitHub

### DIFF
--- a/pages/general-information-and-resources/san-francisco.md
+++ b/pages/general-information-and-resources/san-francisco.md
@@ -196,7 +196,7 @@ coordinate with [Outreach]({% page "/outreach" %}).
 
 You may host folks from other government agencies. As the host you are
 responsible for access issues and for any requests. You will need to complete
-[50 UNP Auth Form.pdf](https://github.com/18F/handbook/files/433703/50.UNP.Auth.Form.pdf)
+[50 UNP Auth Form.pdf](https://github.com/GSA-TTS/handbook/files/433703/50.UNP.Auth.Form.pdf)
 using your own information and email it to
 <mailto:50UNPBuildingServices@gsa.gov>. Please make sure you do this with
 advance notice, since the building will need time to update the guards’ list of

--- a/pages/launching-software/infrastructure.md
+++ b/pages/launching-software/infrastructure.md
@@ -613,7 +613,7 @@ what [infrastructure](#overview) you're using:
   - GSA IT [Service Desk](https://servicedesk.gsa.gov) > Service Catalog >
     Account Services > Internal/External Certificate Request
   - SSLMate through ##acquisition, via an approved
-    [purchase request](https://handbook.18f.gov/purchase-requests/)
+    [purchase request](https://handbook.tts.gsa.gov/purchase-requests/)
   - If in OPP, get a GoDaddy certificate through ##opp-infra
 - If using another agency's infrastructure, consult their IT department.
 

--- a/pages/launching-software/lifecycle.md
+++ b/pages/launching-software/lifecycle.md
@@ -301,7 +301,7 @@ access can be
 
 ## Signing in
 
-1. [Get on the GSA network](https://handbook.18f.gov/how-to-log-in/#connecting-to-gsa-networks)
+1. [Get on the GSA network](https://handbook.tts.gsa.gov/getting-started/how-to-log-in/#connecting-to-gsa-networks)
 1. Visit [archer.gsa.gov](https://archer.gsa.gov)
 1. Sign in with your ENT credentials
 1. Check your email for the one-time password

--- a/pages/launching-software/security.md
+++ b/pages/launching-software/security.md
@@ -153,7 +153,7 @@ recommendations. This page is specifically security-focused.
 | Ruby       | [GitHub][github-alerts]<sup>\*</sup>         | [Code Climate](https://docs.codeclimate.com/v1.0/docs/brakeman) or [Hakiri](https://hakiri.io/) - _Rails only_                                                                                                                                                              |
 
 \* Enabled automatically for repositories in
-[TTS GitHub organizations](https://handbook.18f.gov/github/#organizations)
+[TTS GitHub organizations](https://handbook.tts.gsa.gov/github/#organizations)
 through [`ghad`](https://github.com/18F/ghad).
 
 ### Dependency analysis

--- a/pages/training-and-development/intro-to-github.md
+++ b/pages/training-and-development/intro-to-github.md
@@ -169,7 +169,7 @@ styles, go back to the file and make sure it ends with the .md file extension.
 ### 5. Practice in GitHub
 
 When you’re ready to start practicing with GitHub, the
-[TTS Handbook repository](https://github.com/18F/handbook) is a good place to
+[TTS Handbook repository](https://github.com/GSA-TTS/handbook) is a good place to
 start. If you see something in the Handbook that is out of date or there is at
 typo that needs to be fixed, you can create a pull request and make the changes.
 At least one review is required for it to be merged into the Handbook, so

--- a/pages/updating-the-handbook/edit-in-github.md
+++ b/pages/updating-the-handbook/edit-in-github.md
@@ -42,7 +42,7 @@ to use a desktop file editor. Doing it directly in GitHub is a bit more
 complicated.
 
 - After editing your first file as described above, navigate to the
-  [list of branches](https://github.com/18F/handbook/branches), find the one you
+  [list of branches](https://github.com/GSA-TTS/handbook/branches), find the one you
   created above, and click it. This will display a list of all files in the
   Handbook, but as they exist on your branch.
 - Browse the file tree to find the ones you want to edit. Click a filename to

--- a/pages/updating-the-handbook/edit-locally.md
+++ b/pages/updating-the-handbook/edit-locally.md
@@ -20,7 +20,7 @@ text editor of your choice. From there, you can make changes as described in the
 [making your updates section]({% page
   "updating-the-handbook/#making-your-updates" %}). When you're satisfied with your
 changes, commit them to a new branch and push that branch to GitHub. Then browse
-to the [Handbook GitHub repo](https://github.com/18F/handbook/pulls) and open a new
+to the [Handbook GitHub repo](https://github.com/GSA-TTS/handbook/pulls) and open a new
 pull request from your branch.
 
 ## Running the Handbook


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix links to handbook.18f.gov since it has been moved to handbook.tts.gsa.gov, these links are currently broken (as I was reminded of [here](https://gsa-tts.slack.com/archives/C028WFKN1/p1746713159313049)). The links should probably be made relative links rather than absolute ones in the long-term.
- Fix links to github.com/18F/handbook as it is now in github.com/GSA-TTS/handbook. It currently redirects, so it is not broken, but it should probably be fixed anyway.