### PR TITLE
Add new internal link check and fix broken links

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "npm run test:prefixed-links && npm run test:internal-links && npm run test:html-validation && npm run test:spelling && npm run test:deps",
     "test:html-validation": "html-validate _site/**/*.html",
     "test:internal-links": "node check-links.js",
-    "test:prefixed-links": "! (grep -Erl \"\\]\\(/|href=['\\\"]/\" pages && echo \"ERROR: Internal links must use {% page \"page name\" %} to work correctly with Cloud.gov Pages previews. Fix the above pages.\")",
+    "test:prefixed-links": "! (grep -Erl \"(?:\\]\\()\\s*(?:/|href=['\\\"]\/|https:\/\/handbook\\.tts\\.gsa\\.gov)\" pages && echo \"ERROR: Internal links must use {% page \"page name\" %} to work correctly with Cloud.gov Pages previews. Fix the above pages.\")",
     "test:spelling": "cspell --config ./cSpell.json \"pages/**/*.md\" --no-progress",
     "test:deps": "node check-dependencies.js",
     "podman:build": "podman-compose -f docker-compose.yml build",

--- a/pages/about-us/centers-of-excellence/operations/glossary.md
+++ b/pages/about-us/centers-of-excellence/operations/glossary.md
@@ -7,4 +7,4 @@ Acronyms and lingo abound in both government and technology. Here are some resou
 
 - [TTS's crowd-sourced glossary](https://github.com/GSA-TTS/the-glossary/blob/main/glossary.md) (Tip: Type “@Charlie define” in many Slack channels and a bot will pull the definition from this list.)
 - [CoE glossary](https://docs.google.com/document/d/1Wy0yVoLXlmaNd6oJ0_onS-StoOsP1vgI_4_zWemO2TU/edit?usp=sharing)
-- [TTS glossary](https://handbook.tts.gsa.gov/general-information-and-resources/glossary/) is not as exhaustive, but has links to other programs’ glossaries.
+- [TTS glossary]({% page "/general-information-and-resources/glossary" %}) is not as exhaustive, but has links to other programs’ glossaries.

--- a/pages/general-information-and-resources/tech-policies/gsa-pages.md
+++ b/pages/general-information-and-resources/tech-policies/gsa-pages.md
@@ -92,7 +92,7 @@ The **GSA Website Manager** CAP must be approved by the GSA Pages system owner, 
 ## Incident Response
 **In the event of a security incident:**
 
-Follow [TTS Incident Response Plan](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/security-incidents/)
+Follow [TTS Incident Response Plan]({% page "/general-information-and-resources/tech-policies/security-incidents" %})
 
 ## Contingency Plan
 **In the event of an outage:**

--- a/pages/hiring-staying-or-changing-jobs/hiring.md
+++ b/pages/hiring-staying-or-changing-jobs/hiring.md
@@ -38,7 +38,7 @@ correcting for unconscious bias.
 
 - [TTS Interview Prep Session slides](https://docs.google.com/presentation/d/17ZNmfN40kPOUlF5e6Xix7UlUH02gKQAkY23MhQusPxw/edit#slide=id.p1)
 - [Interviewing for TTS 101](https://docs.google.com/document/d/13MdNbFeWgKWMycdlAhkNSG6Eet3_NAVETnpuIweuMrU/edit#heading=h.arj274vgsryn)
-- [Merit Systems Principles Hiring Practices](https://handbook.tts.gsa.gov/hiring-staying-or-changing-jobs/fair-and-equitable-hiring-practices)
+- [Merit Systems Principles Hiring Practices]({% page "/hiring-staying-or-changing-jobs/fair-and-equitable-hiring-practices" %})
 
 ## Promotions
 

--- a/pages/launching-software/infrastructure.md
+++ b/pages/launching-software/infrastructure.md
@@ -613,7 +613,7 @@ what [infrastructure](#overview) you're using:
   - GSA IT [Service Desk](https://servicedesk.gsa.gov) > Service Catalog >
     Account Services > Internal/External Certificate Request
   - SSLMate through ##acquisition, via an approved
-    [purchase request](https://handbook.tts.gsa.gov/purchase-requests/)
+    [purchase request]({% page "/purchase-requests" %})
   - If in OPP, get a GoDaddy certificate through ##opp-infra
 - If using another agency's infrastructure, consult their IT department.
 

--- a/pages/launching-software/lifecycle.md
+++ b/pages/launching-software/lifecycle.md
@@ -301,7 +301,7 @@ access can be
 
 ## Signing in
 
-1. [Get on the GSA network](https://handbook.tts.gsa.gov/getting-started/how-to-log-in/#connecting-to-gsa-networks)
+1. [Get on the GSA network]({% page "/getting-started/how-to-log-in/#connecting-to-gsa-networks" %})
 1. Visit [archer.gsa.gov](https://archer.gsa.gov)
 1. Sign in with your ENT credentials
 1. Check your email for the one-time password

--- a/pages/launching-software/security.md
+++ b/pages/launching-software/security.md
@@ -153,7 +153,7 @@ recommendations. This page is specifically security-focused.
 | Ruby       | [GitHub][github-alerts]<sup>\*</sup>         | [Code Climate](https://docs.codeclimate.com/v1.0/docs/brakeman) or [Hakiri](https://hakiri.io/) - _Rails only_                                                                                                                                                              |
 
 \* Enabled automatically for repositories in
-[TTS GitHub organizations](https://handbook.tts.gsa.gov/github/#organizations)
+[TTS GitHub organizations]({% page "/github/#organizations" %})
 through [`ghad`](https://github.com/18F/ghad).
 
 ### Dependency analysis

--- a/pages/tools/figma.md
+++ b/pages/tools/figma.md
@@ -10,4 +10,4 @@ You can get started [immediately](https://www.figma.com) with a free account usi
 
 ## Plugins
 
-Figma plugins are okay to use and don’t require approval as long as they don't integrate with other SaaS products (e.g. Google Drive) and are self-contained within the Figma environment. Otherwise, each Figma plugin is treated like a [new software request](https://handbook.tts.gsa.gov/software/), and must undergo review by GSA IT review. If you’re unsure whether a plugin will require approval, reach out in {% slack_channel "figma" %} on Slack with any questions.
+Figma plugins are okay to use and don’t require approval as long as they don't integrate with other SaaS products (e.g. Google Drive) and are self-contained within the Figma environment. Otherwise, each Figma plugin is treated like a [new software request]({% page "/software" %}), and must undergo review by GSA IT review. If you’re unsure whether a plugin will require approval, reach out in {% slack_channel "figma" %} on Slack with any questions.

--- a/pages/travel-and-leave/overtime.md
+++ b/pages/travel-and-leave/overtime.md
@@ -32,7 +32,7 @@ Refer to OPM’s [Overtime Fact Sheet](https://www.opm.gov/policy-data-oversight
 
 Comp time is when you receive hours of leave instead of overtime pay. To determine the maximum number of comp time hours that you can accrue per pay period, please use the [Bi-weekly Comp Time Cap Calculator](https://docs.google.com/spreadsheets/d/1q7wVWPWzBYljj87Wzl-ouVDJux9vplOP_zg3ryxz0iw/edit#gid=0). If you make the maximum salary ($191,900 in 2024), you cannot receive comp time.
 
-You should use your accrued comp time before using Annual Leave. However, if the end of the leave year is approaching, your supervisor can approve your Annual Leave requests first if you are in danger of losing Annual Leave because of “[Use or Lose](https://handbook.tts.gsa.gov/travel-and-leave/leave/#annual-leave).”
+You should use your accrued comp time before using Annual Leave. However, if the end of the leave year is approaching, your supervisor can approve your Annual Leave requests first if you are in danger of losing Annual Leave because of “[Use or Lose]({% page "/travel-and-leave/leave/#annual-leave" %}).”
 
 Comp time expires one year (26 pay periods) after it is earned. When you reach the expiration date, you will forfeit the leave. If you leave GSA, your comp time will be paid out.
 
@@ -40,7 +40,7 @@ Refer to OPM’s [Comp Time Fact Sheet](https://www.opm.gov/policy-data-oversigh
 
 ## Credit hours, in flexible work schedules
 
-Only people on [flexible work schedules](https://handbook.tts.gsa.gov/general-information-and-resources/employee-resources-policies/work-schedules/#flexible-schedule-2) can earn and use credit hours. There is no salary maximum for earning and using credit hours.
+Only people on [flexible work schedules]({% page "/general-information-and-resources/employee-resources-policies/work-schedules/#flexible-schedule" %}) can earn and use credit hours. There is no salary maximum for earning and using credit hours.
 
 You can be approved for credit hours if you want to voluntarily work additional hours to your normal/approved schedule. If you are required to work additional hours, you will receive overtime or comp time.
 
@@ -54,7 +54,7 @@ Refer to OPM’s [Credit Hours Fact Sheet](https://www.opm.gov/policy-data-overs
 
 ### Credit hours example
 
-You are on a [Gliding schedule](https://handbook.tts.gsa.gov/general-information-and-resources/employee-resources-policies/work-schedules/#gliding), and you work 8 hours every day. You are not required to stay late, but if you are in a productive headspace and want to work an extra hour to finish work, you can ask your supervisor about working 1 more hour, therefore receiving 1 credit hour. You will need to request the 1 hour in HR Links, and your supervisor will need to approve it.
+You are on a [Gliding schedule]({% page "/general-information-and-resources/employee-resources-policies/work-schedules/#gliding" %}), and you work 8 hours every day. You are not required to stay late, but if you are in a productive headspace and want to work an extra hour to finish work, you can ask your supervisor about working 1 more hour, therefore receiving 1 credit hour. You will need to request the 1 hour in HR Links, and your supervisor will need to approve it.
 
 ## Religious comp time, for everyone
 

--- a/pages/travel-and-leave/paid-parental-leave.md
+++ b/pages/travel-and-leave/paid-parental-leave.md
@@ -23,7 +23,7 @@ You do not need to take all 12 weeks at once; you can space the leave out for up
 
 #### Other paid leave
 
-You can also use annual, award, and sick leave for parental leave reasons. This includes advanced annual and sick leave, as well as the [Voluntary Leave Transfer Program (VLTP)](https://handbook.tts.gsa.gov/travel-and-leave/voluntary-leave-transfer-program/). We highly recommend you talk with your [Workforce Relations HR Specialist](https://docs.google.com/document/d/15glvq9UakKUN8XTRTa6gRkhBHm2whhQyAGmf8ibTtBs/edit) about recommended ways to combine leave types.
+You can also use annual, award, and sick leave for parental leave reasons. This includes advanced annual and sick leave, as well as the [Voluntary Leave Transfer Program (VLTP)]({% page "/travel-and-leave/voluntary-leave-transfer-program" %}). We highly recommend you talk with your [Workforce Relations HR Specialist](https://docs.google.com/document/d/15glvq9UakKUN8XTRTa6gRkhBHm2whhQyAGmf8ibTtBs/edit) about recommended ways to combine leave types.
 
 #### Unpaid leave
 
@@ -37,7 +37,7 @@ To request PPL, you’ll need to email the following items to your [Workforce Re
 
 1. The [Paid Parental Leave Request and the Paid Parental Leave Service Agreement form PDFs](https://drive.google.com/file/d/1PRdoXhC594Y0OqmDQS7MSMoA7aIDCv-S/view).  
    1. You can use [Docusign templates]({% page "/tools/digital-signatures#use-docusign-templates-to-complete-forms" %}) for Paid Parental Leave to fill out the forms and request the right signatures.
-2. A [timesheet report](https://handbook.tts.gsa.gov/travel-and-leave/leave/#pulling-a-time-sheet-report) for the last 12 months.
+2. A [timesheet report]({% page "/tools/hrlinks/#pulling-a-timesheet-report" %}) for the last 12 months.
 
 Your Workforce Relations HR Specialist reviews your forms and may request more information. 
 

--- a/pages/updating-the-handbook/updating-the-handbook.md
+++ b/pages/updating-the-handbook/updating-the-handbook.md
@@ -24,7 +24,7 @@ Before you make your contribution, there are a few things to remember:
 - This Handbook website and repository are public. Use links to internal Google Docs, Sheets, etc. for
   anything that shouldn't be publicly visible.
 - We're careful about publishing
-  [information collected during research](https://handbook.tts.gsa.gov/research-guidelines/);
+  [information collected during research]({% page "/research-guidelines" %})
   [learn more](https://docs.google.com/document/d/1Xp4LxbW6cx61rXrsnnfIPCz6cglovHzZeEjCcnpIeaM/edit)
   and ask {% slack_channel "g-research" "the research guild" %} for guidance
   first.
@@ -38,7 +38,7 @@ There is also some information that should **not** be included in the Handbook:
 - We receive training on this, but here are a few reminders about things we shouldn't
   include in the Handbook:
 
-  - [Sensitive information](https://handbook.tts.gsa.gov/sensitive-information/)
+  - [Sensitive information]({% page "/sensitive-information" %})
   - Comments that can be easily interpreted as
     [endorsements](https://www.oge.gov/web/oge.nsf/Use%20of%20Government%20Position%20and%20Resources/17593AE8B3A597C685257E96006364E4?opendocument)
     (or other potential ethical issues)


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds another type of prefixed link checking
  - The regular expression is not necessarily intuitive, and JSON doesn't support comments, which makes adding documentation difficult. The regex is checking for Markdown links in the form of:
    - `](/` to find manually constructed relative links
    - `](href="/` to find manually constructed relative links using an href attribute
    - `](https://handbook.tts.gsa.gov` to find absolute links to the TTS handbook. I've added this one.
    - The unescaped form of the regular expression is `(?:\]\()\s*(?:\/|href=['\"]\/|https:\/\/handbook\.tts\.gsa\.gov)`
  - It'd probably be ideal to add testing to ensure we catch the cases we want, but I'm deferring that for now.
    - It should catch and fail the following examples:
      - `This is my relative [link](/my-page)`
      - `This is my other relative [link](href="/my-page")`
      - `This is my other other relative [link](href='/my-page')`
      - `This is my absolute [link](https://handbook.tts.gsa.gov/my-page)`
    - It should allow the following example:
      - `This is the correct example for an internal [link}({% page "/my-page" %})`
- I've fixed the new failures, which included some broken links/anchors.
