### PR TITLE
Add 'data:' font sources to the CSP, because the stylesheet uses them

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -10,16 +10,16 @@ to modify some of the meta-data for the site, this is the place to do it.
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- Content Security Policy -->
-  <meta http-equiv="Content-Security-Policy" 
+  <meta http-equiv="Content-Security-Policy"
         content="default-src 'self';
-                 script-src 'self' 'unsafe-inline' 'unsafe-eval' 
-                            https://dap.digitalgov.gov 
-                            https://www.googletagmanager.com 
+                 script-src 'self' 'unsafe-inline' 'unsafe-eval'
+                            https://dap.digitalgov.gov
+                            https://www.googletagmanager.com
                             https://search.usa.gov;
                  style-src 'self' 'unsafe-inline';
                  img-src 'self' data: https:;
                  connect-src 'self' https://dap.digitalgov.gov https://www.google-analytics.com;
-                 font-src 'self';
+                 font-src 'self' data:;
                  frame-src 'none';
                  object-src 'none';">
   <!-- Mobile Specific Metas


### PR DESCRIPTION
## Changes proposed in this pull request:

Add `data:` to the allowed `font-src`s in the Content Security Policy. 
``
The CSS includes fonts by `data:` URLs, which are currently blocked. I think some OSs handle the missing fonts better than others, but I am running Linux now and here's what I see on the live site: 

![image](https://github.com/user-attachments/assets/cd6be813-3839-408b-a1e5-105d5f9b60ae)

With the `data:` font source allowed, I see this: 

![Screenshot from 2025-06-18 17-10-08](https://github.com/user-attachments/assets/a6ff6ff5-8589-455c-861b-ae7248c199df)

## security considerations

I suppose allowing another font source is less secure, but we are providing these fonts in our stylesheet, so they should be safe. 